### PR TITLE
added extra strip() call to handle double-quotes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ version = None
 with open(os.path.join('neurobooth_os', '__init__.py'), 'r') as fid:
     for line in (line.strip() for line in fid):
         if line.startswith('__version__'):
-            version = line.split('=')[1].strip().strip('\'')
+            version = line.split('=')[1].strip().strip('\'').strip('"')
             break
 if version is None:
     raise RuntimeError('Could not determine version')


### PR DESCRIPTION
The project version number was being wrapped in a second set of quotes, causing it to fail the PEP 440 version number check on installation.