### PR TITLE
Add top level logging

### DIFF
--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -58,10 +58,10 @@ def dump_file(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
 
     with open(fname_out, "wb") as f:
         f.write(file_data)
-    logger.debug(f'Wrote {fname_out}, {len(file_data)/1024:0.1f} kB')
+    logger.debug(f'Wrote {fname_out}, {len(file_data)/(1<<20):0.1f} MiB')
 
     phone.dumpsuccess(fname)
-    logger.debug(f'Sent @DUMPSUCCESS for {fname}.')
+    logger.debug(f'Sent @DUMPSUCCESS for {fname}')
 
 
 if __name__ == "__main__":

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -5,14 +5,30 @@ import os
 import os.path as op
 import datetime
 import logging
+from typing import Optional
 from neurobooth_os.logging import make_iphone_dump_logger
+import argparse
 
 
-def neurobooth_dump():
+class TimeoutException(Exception):
+    pass
+
+
+def neurobooth_dump(args: argparse.Namespace) -> None:
+    """
+    Retrieve a list of files stored in the iPhone and attempt to extract and save them to the session folder specified
+    by their file names.
+
+    Parameters
+    ----------
+    args
+        Command line arguments.
+    """
     session_root = cfg.paths["data_out"]
     logger = logging.getLogger('iphone_dump')
     logger.debug(f'Session Root: {session_root}')
 
+    # Connect to the iPhone
     logger.debug('Connecting to iPhone')
     phone = iphone.IPhone("dump_iphone")
     handshake_success = phone.prepare()
@@ -20,61 +36,134 @@ def neurobooth_dump():
         logger.error(f'Unable to connect to iPhone [state={phone._state}]!')
         return
 
+    # Get a list of stored files
     flist = phone.dumpall_getfilelist(log_files=False)
     if flist is None:
         logger.error(f'Unable to retrieve file list [state={phone._state}]!')
         phone.disconnect()
         return
-
     logger.debug(f'{len(flist)} files to transfer: {str(flist)}')
+
+    # Try to extract and save each file
     for fname in flist:
+        # Parse the session folder out of the file name
         sess_name = re.findall("[0-9]*_[0-9]{4}-[0-9]{2}-[0-9]{2}", fname)
         if len(sess_name) == 0 or sess_name is None:
             logger.error(f'Invalid session name: file={fname}; name={sess_name}.')
             continue
 
+        # Make the session folder if it does not exist
         sess_folder = op.join(session_root, sess_name[0])
         if not op.exists(sess_folder):
             logger.debug(f'Creating directory: {sess_folder}')
             os.mkdir(sess_folder)
 
-        dump_file(phone, fname, op.join(sess_folder, fname), 30)
+        try:
+            dump_file(
+                phone, fname, op.join(sess_folder, fname),
+                timeout_sec=args.timeout,
+                delete_zero_byte=args.delete_zero_byte,
+            )
+        except TimeoutException:
+            logger.warning('Discontinuing file transfer to prevent out-of-order files.')
+            break
 
     logger.debug('Disconnecting iPhone')
     phone.disconnect()
 
 
-def dump_file(phone: iphone.IPhone, fname: str, fname_out: str, timeout_sec: float) -> None:
+def dump_file(
+        phone: iphone.IPhone,
+        fname: str,
+        fname_out: str,
+        timeout_sec: Optional[float] = None,
+        delete_zero_byte: bool = False,
+) -> None:
+    """
+    Extract a single file from the iPhone, save it in the specified location, and tell the iPhone to delete the file.
+
+    Parameters
+    ----------
+    phone
+        The iPhone object to interface with.
+    fname
+        The name of the file on the iPhone (returned by dumpall_getfilelist).
+    fname_out
+        The path to save the retrieved file to.
+    timeout_sec
+        If not None, log an error and return if the file transfer exceeds the timeout.
+    delete_zero_byte
+        If true, delete files from the iPhone if no data is observed.
+    """
     logger = logging.getLogger('iphone_dump')
-    if op.exists(fname_out):
+    if op.exists(fname_out):  # Do not overwrite a file that already exists
         logger.error(f'Cannot write {fname_out} as it already exists!')
         return
 
+    # Attempt to retrieve the file from the iPhone
     logger.info(f'Dump {fname} -> {fname_out}')
     success, file_data = phone.dump(fname, timeout_sec=timeout_sec)
     if not success:
-        logger.error(f'Unable to retrieve {fname}! (Error in _sendpacket or timeout on wait)')
-        return
+        logger.error(f'Unable to retrieve {fname}! (Either the wait timed out or _sendpacket failed.)')
+        raise TimeoutException
 
-    if len(file_data) == 0:
+    if len(file_data) == 0:  # Handle 0-byte files
         logger.error(f'{fname} returned a zero-byte file!')
-        # Get rid of the 0-byte file
-        phone.dumpsuccess(fname)
-        logger.debug(f'Sent @DUMPSUCCESS for {fname}')
+        if delete_zero_byte:
+            phone.dumpsuccess(fname)  # Delete file from iPhone
+            logger.debug(f'Sent @DUMPSUCCESS for {fname}')
         return
 
-    with open(fname_out, "wb") as f:
-        f.write(file_data)
-    logger.debug(f'Wrote {fname_out}, {len(file_data)/(1<<20):0.1f} MiB')
-    phone.dumpsuccess(fname)
-    logger.debug(f'Sent @DUMPSUCCESS for {fname}')
+    try:  # Save the file and delete from the iphone
+        with open(fname_out, "wb") as f:
+            f.write(file_data)
+        logger.debug(f'Wrote {fname_out}, {len(file_data)/(1<<20):0.1f} MiB')
+
+        phone.dumpsuccess(fname)  # Delete file from iPhone
+        logger.debug(f'Sent @DUMPSUCCESS for {fname}')
+    except Exception as e:
+        logger.error(f'Unable to write file {fname_out}; error={e}')
+
+
+def parse_arguments() -> argparse.Namespace:
+    logger = logging.getLogger('iphone_dump')
+    parser = argparse.ArgumentParser(description='Download and save all files on the iPhone (both .json and .MOV).')
+    parser.add_argument(
+        '--delete-zero-byte',
+        action='store_true',
+        help='If set, suspected zero-byte files will be deleted from the iPhone. WARNING: MAY DELETE DATA.'
+    )
+    parser.add_argument(
+        '--timeout',
+        default=None,
+        type=int,
+        help='Specify a timeout (in seconds) for each file retrieval. No timeout if not specified.'
+    )
+    args = parser.parse_args()
+
+    if args.delete_zero_byte:
+        logger.warning('USE CAUTION: the --delete-zero-byte argument could potentially lead to data deletion.')
+
+    if args.timeout is not None:
+        if args.timeout <= 0:
+            logger.error(f'Invalid timeout specified ({args.timeout} sec).')
+            parser.error(f'Invalid timeout specified ({args.timeout} sec).')
+        if args.timeout < 15:
+            logger.warning(f'Short timeout ({args.timeout} sec) specified. Not all files may be transferred.')
+
+    return args
+
+
+def main():
+    logger = make_iphone_dump_logger()
+    iphone.DEBUG_IPHONE = 'verbatim_no_lsl'  # Get debug prints from the iPhone
+
+    args = parse_arguments()
+    t0 = datetime.datetime.now()
+    logger.info('Running Dump')
+    neurobooth_dump(args)
+    logger.info(f"Dump Complete; Total Time: {datetime.datetime.now() - t0}")
 
 
 if __name__ == "__main__":
-    logger = make_iphone_dump_logger()
-    iphone.DEBUG_IPHONE = 'verbatim_no_lsl'
-
-    t0 = datetime.datetime.now()
-    logger.info('Running Dump')
-    neurobooth_dump()
-    logger.info(f"Dump Complete; Total Time: {datetime.datetime.now() - t0}")
+    main()

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -48,13 +48,13 @@ def dump_video(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
         return
 
     logger.info(f'Dump {fname} -> {fname_out}')
-    video = phone.dump(fname)
-    if len(video) == 0:
+    file_data = phone.dump(fname)
+    if len(file_data) == 0:
         logger.error(f'{fname} returned a zero-byte file!')
         return
 
     with open(fname_out, "wb") as f:
-        f.write(video)
+        f.write(file_data)
     logger.debug(f'Wrote {fname_out}')
 
     phone.dumpsuccess(fname)

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -26,7 +26,7 @@ def neurobooth_dump():
         phone.disconnect()
         return
 
-    logger.debug(f'Files to transfer: {str(flist)}')
+    logger.debug(f'{len(flist)} files to transfer: {str(flist)}')
     for fname in flist:
         sess_name = re.findall("[0-9]*_[0-9]{4}-[0-9]{2}-[0-9]{2}", fname)
         if len(sess_name) == 0 or sess_name is None:

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -1,39 +1,71 @@
-from neurobooth_os.iout.iphone import IPhone
+import neurobooth_os.iout.iphone as iphone
 import neurobooth_os.config as cfg
 import re
 import os
 import os.path as op
+import datetime
+import logging
+from neurobooth_os.logging import make_iphone_dump_logger
 
 
 def neurobooth_dump():
+    session_root = cfg.paths["data_out"]
+    logger = logging.getLogger('iphone_dump')
+    logger.debug(f'Session Root: {session_root}')
 
-    iphone = IPhone("dump_iphone")
-    iphone.prepare()
-    flist = iphone.dumpall_getfilelist()
+    logger.debug('Connecting to iPhone')
+    phone = iphone.IPhone("dump_iphone")
+    phone.prepare()
+    flist = phone.dumpall_getfilelist()
 
-    if flist is not None:
-        for fname in flist:
-            sess_name = re.findall("[0-9]*_[0-9]{4}-[0-9]{2}-[0-9]{2}", fname)
-            sess_folder = cfg.paths["data_out"]
+    if flist is None:
+        logger.error('Unable to retrieve file list!')
+        phone.disconnect()
+        return
 
-            if len(sess_name):
-                sess_folder = op.join(cfg.paths["data_out"], sess_name[0])
-                if not op.exists(sess_folder):
-                    os.mkdir(sess_folder)
+    logger.debug(f'Files to transfer: {str(flist)}')
+    for fname in flist:
+        sess_name = re.findall("[0-9]*_[0-9]{4}-[0-9]{2}-[0-9]{2}", fname)
+        if len(sess_name) == 0 or sess_name is None:
+            logger.error(f'Invalid session name: file={fname}; name={sess_name}.')
+            continue
 
-            video = iphone.dump(fname)
-            fname_out = op.join(sess_folder, fname)
-            f = open(fname_out, "wb")
-            f.write(video)
-            f.close()
-            iphone.dumpsuccess(fname)
+        sess_folder = op.join(session_root, sess_name[0])
+        if not op.exists(sess_folder):
+            logger.debug(f'Creating directory: {sess_folder}')
+            os.mkdir(sess_folder)
 
-    iphone.disconnect()
+        dump_video(phone, fname, op.join(sess_folder, fname))
+
+    logger.debug('Disconnecting iPhone')
+    phone.disconnect()
+
+
+def dump_video(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
+    logger = logging.getLogger('iphone_dump')
+    if op.exists(fname_out):
+        logger.error(f'Cannot write {fname_out} as it already exists!')
+        return
+
+    logger.info(f'Dump {fname} -> {fname_out}')
+    video = phone.dump(fname)
+    if len(video) == 0:
+        logger.error(f'{fname} returned a zero-byte file!')
+        return
+
+    with open(fname_out, "wb") as f:
+        f.write(video)
+    logger.debug(f'Wrote {fname_out}')
+
+    phone.dumpsuccess(fname)
+    logger.debug(f'Sent @DUMPSUCCESS for {fname}.')
 
 
 if __name__ == "__main__":
-    import datetime
+    logger = make_iphone_dump_logger()
+    iphone.DEBUG_IPHONE = 'verbatim_no_lsl'
 
     t0 = datetime.datetime.now()
+    logger.info('Running Dump')
     neurobooth_dump()
-    print(f"total time: {datetime.datetime.now() - t0}")
+    logger.info(f"Dump Complete; Total Time: {datetime.datetime.now() - t0}")

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -54,12 +54,14 @@ def dump_file(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
     file_data = phone.dump(fname)
     if len(file_data) == 0:
         logger.error(f'{fname} returned a zero-byte file!')
+        # Get rid of the 0-byte file
+        phone.dumpsuccess(fname)
+        logger.debug(f'Sent @DUMPSUCCESS for {fname}')
         return
 
     with open(fname_out, "wb") as f:
         f.write(file_data)
     logger.debug(f'Wrote {fname_out}, {len(file_data)/(1<<20):0.1f} MiB')
-
     phone.dumpsuccess(fname)
     logger.debug(f'Sent @DUMPSUCCESS for {fname}')
 

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -164,4 +164,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        logger = logging.getLogger('iphone_dump')
+        logger.exception(e)

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -58,7 +58,7 @@ def dump_file(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
 
     with open(fname_out, "wb") as f:
         f.write(file_data)
-    logger.debug(f'Wrote {fname_out}')
+    logger.debug(f'Wrote {fname_out}, {len(file_data)/1024:0.1f} kB')
 
     phone.dumpsuccess(fname)
     logger.debug(f'Sent @DUMPSUCCESS for {fname}.')

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -35,13 +35,13 @@ def neurobooth_dump():
             logger.debug(f'Creating directory: {sess_folder}')
             os.mkdir(sess_folder)
 
-        dump_video(phone, fname, op.join(sess_folder, fname))
+        dump_file(phone, fname, op.join(sess_folder, fname))
 
     logger.debug('Disconnecting iPhone')
     phone.disconnect()
 
 
-def dump_video(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
+def dump_file(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
     logger = logging.getLogger('iphone_dump')
     if op.exists(fname_out):
         logger.error(f'Cannot write {fname_out} as it already exists!')

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -6,7 +6,7 @@ import os.path as op
 import datetime
 import logging
 from typing import Optional
-from neurobooth_os.logging import make_iphone_dump_logger
+from neurobooth_os.logging import make_default_logger
 import argparse
 
 
@@ -153,7 +153,7 @@ def parse_arguments() -> argparse.Namespace:
 
 
 def main():
-    logger = make_iphone_dump_logger()
+    logger = make_default_logger()
     iphone.DISABLE_LSL = True
 
     args = parse_arguments()

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -15,9 +15,12 @@ def neurobooth_dump():
 
     logger.debug('Connecting to iPhone')
     phone = iphone.IPhone("dump_iphone")
-    phone.prepare()
-    flist = phone.dumpall_getfilelist()
+    handshake_success = phone.prepare()
+    if not handshake_success:
+        logger.error('Unable to connect to iPhone!')
+        return
 
+    flist = phone.dumpall_getfilelist()
     if flist is None:
         logger.error('Unable to retrieve file list!')
         phone.disconnect()

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -38,20 +38,24 @@ def neurobooth_dump():
             logger.debug(f'Creating directory: {sess_folder}')
             os.mkdir(sess_folder)
 
-        dump_file(phone, fname, op.join(sess_folder, fname))
+        dump_file(phone, fname, op.join(sess_folder, fname), 30)
 
     logger.debug('Disconnecting iPhone')
     phone.disconnect()
 
 
-def dump_file(phone: iphone.IPhone, fname: str, fname_out: str) -> None:
+def dump_file(phone: iphone.IPhone, fname: str, fname_out: str, timeout_sec: float) -> None:
     logger = logging.getLogger('iphone_dump')
     if op.exists(fname_out):
         logger.error(f'Cannot write {fname_out} as it already exists!')
         return
 
     logger.info(f'Dump {fname} -> {fname_out}')
-    file_data = phone.dump(fname)
+    success, file_data = phone.dump(fname, timeout_sec=timeout_sec)
+    if not success:
+        logger.error(f'Unable to retrieve {fname}! (Error in _sendpacket or timeout on wait)')
+        return
+
     if len(file_data) == 0:
         logger.error(f'{fname} returned a zero-byte file!')
         # Get rid of the 0-byte file

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -20,7 +20,7 @@ def neurobooth_dump():
         logger.error(f'Unable to connect to iPhone [state={phone._state}]!')
         return
 
-    flist = phone.dumpall_getfilelist()
+    flist = phone.dumpall_getfilelist(log_files=False)
     if flist is None:
         logger.error(f'Unable to retrieve file list [state={phone._state}]!')
         phone.disconnect()

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -17,12 +17,12 @@ def neurobooth_dump():
     phone = iphone.IPhone("dump_iphone")
     handshake_success = phone.prepare()
     if not handshake_success:
-        logger.error('Unable to connect to iPhone!')
+        logger.error(f'Unable to connect to iPhone [state={phone._state}]!')
         return
 
     flist = phone.dumpall_getfilelist()
     if flist is None:
-        logger.error('Unable to retrieve file list!')
+        logger.error(f'Unable to retrieve file list [state={phone._state}]!')
         phone.disconnect()
         return
 

--- a/extras/serv_acq_upload - neurobooth_OS.bat
+++ b/extras/serv_acq_upload - neurobooth_OS.bat
@@ -1,4 +1,4 @@
 call C:\Users\ACQ\anaconda3\Scripts\activate.bat C:\Users\ACQ\anaconda3\envs\neurobooth-staging
-call start /W ipython C:\neurobooth-os\dump_iphone_video.py
+call start /W ipython C:\neurobooth-os\extras\dump_iphone_video.py
 robocopy  /MOVE  D:\neurobooth\neurobooth_data Z:\data /e
 mkdir D:\neurobooth\neurobooth_data

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -29,23 +29,20 @@ from neurobooth_os.netcomm import (
     socket_message,
 )
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes
+from neurobooth_os.logging import make_default_logger
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.iout.split_xdf import split_sens_files, get_xdf_name
 from neurobooth_os.iout import marker_stream
 import neurobooth_os.config as cfg
 
-def setup_log(name, sg_handler = None):
-    logger = logging.getLogger(name)
+
+def setup_log(sg_handler = None):
+    logger = make_default_logger()
     logger.setLevel(logging.DEBUG)
-    log_format = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-    #filename = f"./{name}.log"
-    #log_handler = logging.FileHandler(filename)
-    #log_handler.setLevel(logging.DEBUG)
-    #log_handler.setFormatter(log_format)
-    #logger.addHandler(log_handler)
     if sg_handler:
         logger.addHandler(sg_handler)
     return logger
+
 
 class Handler(logging.StreamHandler):
 
@@ -57,11 +54,10 @@ class Handler(logging.StreamHandler):
         buffer = f'{BUFFER}\n{str(record)}'.strip()
         window['log'].update(value=buffer)
 
+
 BUFFER = ''
 
-logger = setup_log(__name__, sg_handler = Handler().setLevel(logging.DEBUG))
-
-
+logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
 
 
 def _process_received_data(serv_data, window):
@@ -650,7 +646,12 @@ def main():
         help="Specify which database to connect",
     )
     (options, args) = parser.parse_args()
-    gui(remote=options.remote, database=options.database)
+    try:
+        gui(remote=options.remote, database=options.database)
+    except Exception as e:
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise
 
 
 if __name__ == "__main__":

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -45,7 +45,7 @@ def setup_log(sg_handler = None):
 
 
 class Handler(logging.StreamHandler):
-
+    """LogHandler that emits entries to the GUI"""
     def __init__(self):
         logging.StreamHandler.__init__(self)
 

--- a/neurobooth_os/iout/camera_intel.py
+++ b/neurobooth_os/iout/camera_intel.py
@@ -85,6 +85,7 @@ class VidRec_Intel:
 
         self.prepare(name)
         self.recording.set()
+        self.record_stopped_flag.clear()
         self.video_thread = threading.Thread(target=self.record)
         self.logger.debug(f'RealSense [{self.device_index}]: Beginning Recording')
         self.video_thread.start()
@@ -127,8 +128,14 @@ class VidRec_Intel:
 
     def record(self):
         self.frame_counter = 1
-        self.logger.debug(f'RealSense [{self.device_index}]: Starting Pipeline')
-        self.pipeline.start(self.config)
+        
+        try:
+            self.logger.debug(f'RealSense [{self.device_index}]: Starting Pipeline')
+            self.pipeline.start(self.config)
+        except Exception as e:
+            self.logger.error(f'RealSense [{self.device_index}]: Unable to start pipeline: {e}')
+            self.record_stopped_flag.set()
+            return
 
         # Avoid autoexposure frame drops
         dev = self.pipeline.get_active_profile().get_device()
@@ -162,7 +169,6 @@ class VidRec_Intel:
 
     def stop(self):
         self.logger.debug(f'RealSense [{self.device_index}]: Setting Record Stop Flag')
-        self.record_stopped_flag.clear()
         self.recording.clear()
 
     def close(self):

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -579,10 +579,11 @@ class IPhone:
     def dumpall_getfilelist(self, log_files: bool = True):
         self._sendpacket("@DUMPALL", cond=self._wait_for_reply_cond)
         filelist = self._msg_latest["Message"]
-        if log_files:
-            self.logger.debug(f"iPhone [state={self._state}]: File List = {filelist}")
         if self._state == "#ERROR":
+            self.logger.error(f'iPhone [state={self._state}]: @DUMPALL Error; message="{filelist}"')
             return None
+        if log_files:
+            self.logger.debug(f"iPhone [state={self._state}]: File List (N={len(filelist)}) = {filelist}")
         return filelist
 
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -447,21 +447,21 @@ class IPhone:
                 {"message": msg, "ctr_timestamp": str(datetime.now()), "tag": tag})
             
 
-        if msg["MessageType"] in [
-            "@STARTTIMESTAMP",
-            "@INPROGRESSTIMESTAMP",
-            "@STOPTIMESTAMP",
-        ]:
-            finfo = eval(msg["TimeStamp"])
-            self.fcount = int(finfo["FrameNumber"])
-            debug_print([self.fcount, float(finfo["Timestamp"]), time.time()])
-            self.lsl_push_sample([self.fcount, float(finfo["Timestamp"]), time.time()])
-            if msg["MessageType"]=="@INPROGRESSTIMESTAMP":
-                if self._state == "#RECORDING":
+            if msg["MessageType"] in [
+                "@STARTTIMESTAMP",
+                "@INPROGRESSTIMESTAMP",
+                "@STOPTIMESTAMP",
+            ]:
+                finfo = eval(msg["TimeStamp"])
+                self.fcount = int(finfo["FrameNumber"])
+                debug_print([self.fcount, float(finfo["Timestamp"]), time.time()])
+                self.lsl_push_sample([self.fcount, float(finfo["Timestamp"]), time.time()])
+                if msg["MessageType"]=="@INPROGRESSTIMESTAMP":
+                    if self._state == "#RECORDING":
+                        self._wait_for_reply_cond.notify()
+                else:
                     self._wait_for_reply_cond.notify()
-            else:
-                self._wait_for_reply_cond.notify()
-        self._wait_for_reply_cond.release()
+            self._wait_for_reply_cond.release()
 
     @debug_lsl
     def createOutlet(self):
@@ -556,6 +556,7 @@ class IPhone:
     def dump(self, filename):
         self._dump_video_data = b""
         msg_filename = {"Message": filename}
+        print(f'DUMPING: {filename}')
         self._sendpacket("@DUMP", msg_filename, cond=self._dump_video_cond)
         return self._dump_video_data
 
@@ -584,6 +585,7 @@ class IPhone:
     def dumpall_getfilelist(self):
         self._sendpacket("@DUMPALL", cond=self._wait_for_reply_cond)
         filelist = self._msg_latest["Message"]
+        print(f'FILELIST: {filelist}')
         if self._state == "#ERROR":
             return None
         return filelist

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -644,6 +644,10 @@ class IPhone:
                 self._raise_timeout("@DUMPALL")
                 return None
 
+            if self._state == '#ERROR':  # Usually occurs when no files present
+                self.logger.error(f'iPhone [state={self._state}]: {self._latest_message["Message"]}')
+                return None
+
             filelist = self._latest_message["Message"]
             if DEBUG_LOGGING:
                 self.logger.debug(f"iPhone [state={self._state}]: File List (N={len(filelist)}) = {filelist}")

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -55,6 +55,19 @@ class IPhonePanic(Exception):
 # --------------------------------------------------------------------------------
 # Hardware Interface Code
 # --------------------------------------------------------------------------------
+def _handle_panic(func):
+    """Decorator to wrap a function call in a try/except to detect panic and generically handle panic exceptions."""
+    @functools.wraps(func)
+    def wrapper_panic(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except IPhonePanic as e:
+            _iphone: IPhone = args[0]
+            _iphone.panic(e)
+            return None
+    return wrapper_panic
+
+
 class IPhone:
     """
     Handles interactions with an iPhone device running the Neurobooth app.
@@ -192,19 +205,6 @@ class IPhone:
 
         if disconnect:
             self.disconnect()
-
-    @staticmethod
-    def _handle_panic(func):
-        """Decorator to wrap a function call in a try/except to detect panic and generically handle panic exceptions."""
-        @functools.wraps(func)
-        def wrapper_panic(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except IPhonePanic as e:
-                _iphone: IPhone = args[0]
-                _iphone.panic(e)
-                return None
-        return wrapper_panic
 
     def _update_state(self, msg_type: str) -> None:
         """

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -626,7 +626,13 @@ if __name__ == "__main__":
         '--recording-folder',
         default='',
         type=str,
-        help='The folder the LSL stream should record to.'
+        help='The folder the LSL stream should record to.',
+    )
+    parser.add_argument(
+        '--no-plots',
+        dest='show_plots',
+        action='store_false',
+        help='Disable plotting of results.',
     )
     args = parser.parse_args()
 
@@ -657,7 +663,7 @@ if __name__ == "__main__":
 
     streamargs = {"name": "IPhoneFrameIndex"}
     date = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
-    task_id = f'{args.subject_id}_{date}_task_obs_1_IPhone'
+    task_id = f'{args.subject_id}_{date}_task_obs_1'
 
     # Start LSL
     session = liesl_sesion_create(
@@ -688,26 +694,26 @@ if __name__ == "__main__":
 
     df_pc = np.diff(ts_pc)
     df_ip = np.diff(ts_ip)
+    print(f"mean diff diff: {np.mean(np.abs(df_pc[1:] - df_ip[1:]))}")
 
-    import matplotlib.pyplot as plt
+    if args.show_plots:
+        import matplotlib.pyplot as plt
 
-    plt.figure()
-    plt.plot(df_pc)
-    plt.plot(df_ip)
-    plt.show()
+        plt.figure()
+        plt.plot(df_pc)
+        plt.plot(df_ip)
+        plt.show()
 
-    plt.figure()
-    plt.scatter(df_pc, df_ip)
+        plt.figure()
+        plt.scatter(df_pc, df_ip)
 
-    plt.show()
+        plt.show()
 
-    plt.figure()
-    plt.hist(np.diff(ts_pc[1:]) - np.diff(ts_ip[1:]), 20)
+        plt.figure()
+        plt.hist(np.diff(ts_pc[1:]) - np.diff(ts_ip[1:]), 20)
 
-    print("mean diff diff ", np.mean(np.abs(np.diff(ts_pc[1:]) - np.diff(ts_ip[1:]))))
+        tstmp = data[0]["time_stamps"]
+        plt.hist(np.diff(tstmp[1:]) - np.diff(ts_ip[1:]))
 
-    tstmp = data[0]["time_stamps"]
-    plt.hist(np.diff(tstmp[1:]) - np.diff(ts_ip[1:]))
-
-    plt.figure()
-    plt.hist(df_ip, 50)
+        plt.figure()
+        plt.hist(df_ip, 50)

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -1,4 +1,5 @@
 import os.path as op
+import sys
 from logging import raiseExceptions
 from multiprocessing import Condition, Event, RLock
 import functools
@@ -868,7 +869,22 @@ if __name__ == "__main__":
         action='store_false',
         help='Disable plotting of results.',
     )
+    parser.add_argument(
+        '--log-console',
+        action='store_true',
+        help='Print session logs to the console.'
+    )
+    parser.add_argument(
+        '--log-file',
+        default=None,
+        type=str,
+        help='Write session logs to the specified file.',
+    )
     args = parser.parse_args()
+
+    if args.log_console or args.log_file is not None:
+        from neurobooth_os.logging import make_session_logger_debug
+        make_session_logger_debug(file=args.log_file, console=args.log_console)
 
 
     # Creating and starting mock streams:

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -737,7 +737,7 @@ class IPhone:
         except IPhonePanic as e:
             self.logger.error(f'iPhone: PANIC while sending @DISCONNECT: {e}')
 
-        time.sleep(1)  # Give things some time to happen; was 4 before rewrite...
+        time.sleep(4)  # Give things some time to happen; was here before rewrite, but why?
 
         # Try to stop the listener thread
         self._listen_thread.stop()

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -574,7 +574,7 @@ class IPhone:
             ),
             device_id=self.device_id,
             sensor_ids=self.sensor_ids,
-            data_version=DataVersion(1, 0),
+            data_version=DataVersion(1, 1),
             columns=['FrameNum', 'Time_iPhone', 'Time_ACQ'],
             column_desc={
                 'FrameNum': 'App-tracked frame number',

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -12,6 +12,7 @@ import select
 import uuid
 import logging
 import time
+from typing import Dict, List, Tuple, Any, Optional, Union, ByteString
 
 from neurobooth_os.iout.usbmux import USBMux
 
@@ -22,6 +23,13 @@ if DEBUG_IPHONE in ["default", "verbatim"]:
     from pylsl import StreamInfo, StreamOutlet
     import liesl
     from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
+
+
+# Type aliases
+MESSAGE = Dict[str, Any]
+PACKET_PAYLOAD = Union[MESSAGE, ByteString]
+PACKET_CONTENTS = Tuple[PACKET_PAYLOAD, int, int, int]
+CONFIG = Dict[str, Any]
 
 
 # decorator for debug printing
@@ -53,7 +61,7 @@ def debug_print(arg):
     print(arg)
 
 
-def safe_socket_operation(func):
+def safe_socket_operation(func):  # This decorator detects errors and sends the IPhone object into an #ERROR state
     @functools.wraps(func)
     def wrapper_safe_socket(*args, **kwargs):
         try:
@@ -78,8 +86,12 @@ class IPhoneError(Exception):
 
 
 class IPhoneListeningThread(threading.Thread):
+    """
+    A thread that listens for messages sent by the iPhone and processes them (e.g., updates state, notifies conditions.)
+    """
+
     def __init__(self, *args):
-        self._iphone = args[0]
+        self._iphone: IPhone = args[0]
         self._running = True
         self.logger = logging.getLogger('session')
         threading.Thread.__init__(self)
@@ -88,10 +100,11 @@ class IPhoneListeningThread(threading.Thread):
         self.logger.debug('iPhone: Entering Listening Loop')
         while self._running:
             try:
-                msg, version, type, resp_tag = self._iphone._getpacket()
-                self._iphone._process_received_message(msg, resp_tag)
+                payload, _, _, resp_tag = self._iphone._getpacket()
+                self._iphone._process_received_message(payload, resp_tag)
+
                 if resp_tag == 0:
-                    debug_print(f"Listener received: {msg}")
+                    debug_print(f"Listener received: {payload}")
                 else:
                     debug_print(f"Listener received: Tag {resp_tag}")
             except OSError as e:  # Will occur when the socket is closed during shutdown
@@ -106,8 +119,17 @@ class IPhoneListeningThread(threading.Thread):
 
 
 class IPhone:
+    """
+    Handles interactions with an iPhone device running the Neurobooth app.
+    """
+
+    # Constants for interfacing with the app
     TYPE_MESSAGE = 101
     VERSION = 1
+
+    # State transition directed graph. States start with # and messages start with @.
+    # The nested (key->value) structure is (#CURRENT_STATE->(@MESSAGE->#NEXT_STATE)), where if @MESSAGE is received in
+    # #CURRENT_STATE, then the state machine should transition to #NEXT_STATE.
     STATE_TRANSITIONS = {
         "#DISCONNECTED": {"@HANDSHAKE": "#CONNECTED", "@ERROR": "#ERROR"},
         "#CONNECTED": {
@@ -168,17 +190,13 @@ class IPhone:
     for elem in STATE_TRANSITIONS:
         MESSAGE_TYPES += STATE_TRANSITIONS[elem].keys()
     MESSAGE_TYPES = set(MESSAGE_TYPES)
-    #    print(MESSAGE_TYPES)
-    #    MESSAGE_TYPES=set(['@START','@STOP','@STANDBY','@READY','@PREVIEW','@DUMP','@STARTTIMESTAMP','@INPROGRESSTIMESTAMP','@STOPTIMESTAMP','@DUMPALL','@DISCONNECT','@FILESTODUMP'])
     MESSAGE_KEYS = {"MessageType", "SessionID", "TimeStamp", "Message"}
 
-    # decorator for socket_send
-
-    @safe_socket_operation
+    @safe_socket_operation  # safe_socket decorator for self.sock.send
     def _socket_send(self, packet):
         return self.sock.send(packet)
 
-    @safe_socket_operation
+    @safe_socket_operation  # safe_socket decorator for self.sock.recv
     def _socket_recv(self, nbytes):
         return self.sock.recv(nbytes)
 
@@ -190,36 +208,63 @@ class IPhone:
         self.mock = mock
         self.device_id = device_id
         self.sensor_ids = sensor_ids
-        self._state = "#DISCONNECTED"
-        self._frame_preview_data = b""
-        self._frame_preview_cond = Condition()
-        self._dump_video_data = b""
-        self._dump_video_cond = Condition()
-        self._allmessages = []
-        self._message_lock = RLock()
-        self._state_lock = RLock()
-        self._latest_message = {}
-        self._latest_message_type = ''
-        self._wait_for_reply_cond = Condition()
-        self._timeout_cond = 5
-        self.ready_event = Event()  # Used to check if we have re-entered the ready state by ensure_stopped()
         self.streaming = False
         self.streamName = "IPhoneFrameIndex"
         self.outlet_id = str(uuid.uuid4())
         self.logger = logging.getLogger('session')
+
+        # --------------------------------------------------------------------------------
+        # Lock-based threading objects and their associated protected data
+        # --------------------------------------------------------------------------------
+        self._timeout_cond = 5  # Default threading timeout
+
+        self._frame_preview_data = b""
+        self._frame_preview_cond = Condition()
+
+        self._dump_video_data = b""
+        self._dump_video_cond = Condition()
+
+        self._allmessages = []
+        self._message_lock = RLock()
+
+        self._state = "#DISCONNECTED"  # Entry point of state machine
+        self._state_lock = RLock()
+
+        self._latest_message = {}
+        self._latest_message_type = ''
+        self._wait_for_reply_cond = Condition()
+
+        self.ready_event = Event()  # Used to check if we have re-entered the ready state by ensure_stopped()
+        # --------------------------------------------------------------------------------
+
         self.logger.debug('iPhone: Created Object')
 
-    def _validate_message(self, message, tag):
+    def _validate_message(self, message: MESSAGE, tag: int) -> bool:
+        """
+        Validate the structure of a message and update the state machine if validated.
+
+        Parameters
+        ----------
+        message
+            The message to validate
+        tag
+            The associated message tag
+
+        Returns
+        -------
+        success
+            Whether the function call was successful.
+        """
         if tag == 1:  # TAG==1 corresponds to PREVIEW file receiving
             msg_type = "@PREVIEWRECEIVE"
-        elif tag == 2:
+        elif tag == 2:  # TAG==2 corresponds to DUMP file receiving
             msg_type = "@DUMPRECEIVE"
-        elif tag != 0:
+        elif tag != 0:  # Incorrect / unexpected tag
             print(f"Incorrect tag received from IPhone. Tag={tag}")
             self.logger.error(f'iPhone: Incorrect tag ({tag}) received.')
             self.disconnect()
             return False
-        else:
+        else:  # Tag==0; all other messages
             if len(message) != len(self.MESSAGE_KEYS):
                 print(f"Message has incorrect length: {message}")
                 self.logger.error(f'iPhone: Message has incorrect length: {message}')
@@ -235,51 +280,100 @@ class IPhone:
         debug_print(f"Message: {msg_type}")
         return self._update_state(msg_type)
 
-    def _update_state(self, msg_type):
+    def _update_state(self, msg_type: str) -> bool:
+        """
+        Update the state machine based on the given message type.
+
+        Parameters
+        ----------
+        msg_type
+            The message type string (e.g., @START) used to update the state machine.
+
+        Returns
+        -------
+        success
+            Whether the state update was successful. False if an invalid transition was requested.
+
+        """
         with self._state_lock:
             debug_print(f"Initial State: {self._state}")
             allowed_trans = self.STATE_TRANSITIONS[self._state]
-            if msg_type in allowed_trans:
-                prev_state = self._state
-                self._state = allowed_trans[msg_type]
-                if self._state == '#ERROR':
-                    self.logger.error(f'iPhone: Entered #ERROR state from {prev_state} via {msg_type}!')
-                elif self._state == '#READY':
-                    self.ready_event.set()
-            else:
+            if msg_type not in allowed_trans:
                 print(f"Message {msg_type} is not valid in the state {self._state}.")
                 self.logger.error(f"iPhone: Message {msg_type} is not valid in the state {self._state}.")
                 self.disconnect()
                 return False
+
+            prev_state = self._state
+            self._state = allowed_trans[msg_type]
+            if self._state == '#ERROR':
+                self.logger.error(f'iPhone: Entered #ERROR state from {prev_state} via {msg_type}!')
+            elif self._state == '#READY':
+                self.ready_event.set()
             debug_print(f"Outcome State:{self._state}")
         return True
 
-    def _message(self, msg_type, ts="", msg=""):
+    def _message(self, msg_type: str, timestamp: str = "", msg: str = "") -> MESSAGE:
+        """
+        Create a message given a subset of its contents (defaulting the rest).
+
+        Parameters
+        ----------
+        msg_type
+            The message type string (e.g., @START)
+        timestamp
+            The message timestamp
+        msg
+            The message contents
+
+        Returns
+        -------
+        message
+            A populated message dictionary.
+        """
         if msg_type not in self.MESSAGE_TYPES:
             self.logger.error(f'iPhone [state={self._state}]: "{msg_type}" is not an allowed message')
             raise IPhoneError(f'Message type "{msg_type}" not in allowed message type list')
         return {
             "MessageType": msg_type,
             "SessionID": self.iphone_sessionID,
-            "TimeStamp": ts,
+            "TimeStamp": timestamp,
             "Message": msg,
         }
 
-    def _json_wrap(self, message):
-        json_msg = json.dumps(message)
-        json_msg = "####" + json_msg  # add 4 bytes
-        return json_msg
+    @staticmethod
+    def _json_wrap(message: MESSAGE) -> str:
+        """Convert a message dictionary into a JSON string for transmission."""
+        return "####" + json.dumps(message)
 
-    def _json_unwrap(self, payload):
-        message = json.loads(payload[4:])
-        return message
+    @staticmethod
+    def _json_unwrap(payload: Union[str, bytes]) -> MESSAGE:
+        """Convert a transmitted JSON string into a message dictionary."""
+        return json.loads(payload[4:])
 
-    def _sendpacket(self, msg_type, msg_contents=None):
-        msg = self._message(msg_type)
-        if msg_contents is not None:
-            # replace contents of msg with information from provided dict
-            for key in msg_contents:
-                msg[key] = msg_contents[key]
+    def _update_message_log(self, msg: MESSAGE, tag: int) -> None:
+        """Safely update the log of messages sent and received."""
+        with self._message_lock:
+            self._allmessages.append({"message": msg, "ctr_timestamp": str(datetime.now()), "tag": tag})
+
+    def _sendpacket(self, msg_type: str, msg_contents: Optional[MESSAGE] = None) -> bool:
+        """
+        Validate a message, update the state machine, and send the message to the iPhone.
+
+        Parameters
+        ----------
+        msg_type
+            The message type string (e.g., @START)
+        msg_contents
+            Any non-default message entries/contents
+        Returns
+        -------
+        success
+            Whether the message was successfully validated and sent.
+        """
+        msg = self._message(msg_type)  # Default message contents
+        if msg_contents is not None:  # Replace default contents with information from provided dict
+            msg.update(msg_contents)
 
         if not self._validate_message(msg, 0):  # State transition is side effect of validate_message
             print(f"Message {msg} did not pass validation. Exiting _sendpacket.")
@@ -288,7 +382,7 @@ class IPhone:
             return False
 
         self._update_message_log(msg, self.tag)
-        payload = self._json_wrap(msg).encode("utf-8")
+        payload = IPhone._json_wrap(msg).encode("utf-8")
         payload_size = len(payload)
         packet = (
             struct.pack("!IIII", self.VERSION, self.TYPE_MESSAGE, self.tag, payload_size) + payload
@@ -296,7 +390,32 @@ class IPhone:
         self._socket_send(packet)
         return True
 
-    def _send_and_wait_for_response(self, msg_type, msg_contents=None, wait_on=None):
+    def _send_and_wait_for_response(
+            self,
+            msg_type: str,
+            msg_contents: Optional[MESSAGE] = None,
+            wait_on: Optional[List[str]] = None,
+    ) -> bool:
+        """
+        A convenience wrapper for _sendpacket that waits for a response (with tag==0) from the iPhone.
+        The data of the response is NOT returned. If safe access to the message itself is required, then the calling
+        function should instead do its own handling of an appropriate condition variable.
+
+        Parameters
+        ----------
+        msg_type
+            The message type string (e.g., @START) to be passed to _sendpacket
+        msg_contents
+            Any non-default message entries/contents to be passed to _sendpacket
+        wait_on
+            If None, wait for any response from the iPhone.
+            If a list of message types is provided, wait for any of the specified message types.
+
+        Returns
+        -------
+        success
+            Whether the message was successfully validated and sent. A False value may also indicate a wait timeout.
+        """
         with self._wait_for_reply_cond:
             if not self._sendpacket(msg_type, msg_contents=msg_contents):
                 self.logger.error(f'iPhone [state={self._state}]: Failed to send {msg_type} packet!')
@@ -315,114 +434,88 @@ class IPhone:
 
             return success
 
-    def recvall(self, sock, n):
-        # Helper function to recv n bytes or return None if EOF is hit
+    @staticmethod
+    def recvall(sock: socket.socket, n: int) -> ByteString:
+        """
+        Helper function to receive large packets.
+
+        Parameters
+        ----------
+        sock
+            The socket to pull from.
+        n
+            The number of bytes to retrieve.
+
+        Returns
+        -------
+        data
+            The data pulled from the socket.
+        """
+        MAX_RECV = (1 << 17) - 80  # Largest chunk of data to pull from the socket in any one call.
+
         fragments = []
-        BUFF_SIZE = 16384
-        MAX_RECV = 130992
-        buff_recv = 0
+        bytes_received = 0
         while True:
-            bytes_to_pull = n
-            if (n - buff_recv) < MAX_RECV:
-                bytes_to_pull = n - buff_recv
+            bytes_to_pull = n - bytes_received
+            if bytes_to_pull > MAX_RECV:
+                bytes_to_pull = MAX_RECV
+
             packet = sock.recv(bytes_to_pull)
-            # packet = self._socket_recv(bytes_to_pull)
-
-            buff_recv += len(packet)
+            bytes_received += len(packet)
             fragments.append(packet)
-            if buff_recv >= n:
-                break
-        data = b"".join(fragments)
-        return data
 
-    def _getpacket(self, timeout_in_seconds=20):
-        ready, _, _ = select.select([self.sock], [], [], timeout_in_seconds)
+            if bytes_received >= n:
+                break
+
+        return b"".join(fragments)
+
+    def _getpacket(self, timeout_sec: int = 20) -> PACKET_CONTENTS:
+        """
+        Retrieve a packet of data from the iPhone. This method will block until timed out.
+
+        Parameters
+        ----------
+        timeout_sec
+            How long to block before timing out
+
+        Returns
+        -------
+        package_contents
+            (payload, version, type, tag): Payload is either a message dictionary (tag == 0) or byte string
+            (tag == 1 or tag == 2).
+        """
+        ready, _, _ = select.select([self.sock], [], [], timeout_sec)
         if not ready:
             self.logger.error(f"iPhone [state={self._state}]: Exceeded timeout for packet receipt")
             raise IPhoneError(
-                f"Timeout for packet receive exceeded ({timeout_in_seconds} sec)"
+                f"Timeout for packet receive exceeded ({timeout_sec} sec)"
             )
 
         first_frame = self.sock.recv(16)
-        version, type, tag, payload_size = struct.unpack("!IIII", first_frame)
+        version, type_, tag, payload_size = struct.unpack("!IIII", first_frame)
 
         if tag == 1 or tag == 2:
             self._validate_message({}, tag)
-            payload = self.recvall(self.sock, payload_size)
-            return payload, version, type, tag
+            payload = IPhone.recvall(self.sock, payload_size)
+            return payload, version, type_, tag
 
         payload = self.sock.recv(payload_size)
-        msg = self._json_unwrap(payload)
+        msg = IPhone._json_unwrap(payload)
         self._validate_message(msg, tag)
-        return msg, version, type, tag
+        return msg, version, type_, tag
 
-    def handshake(self, config):
-        if self._state != "#DISCONNECTED":
-            print("Handshake is only available when disconnected")
-            return False
+    def _process_received_message(self, msg: PACKET_PAYLOAD, tag: int) -> None:
+        """
+        Notify appropriate conditions of message arrival.
+        Also push data to LSL for appropriate messages.
 
-        self.usbmux = USBMux()
-        if not self.usbmux.devices:
-            self.usbmux.process(0.1)
-        if len(self.usbmux.devices) != 1:
-            return False
-
-        self.device = self.usbmux.devices[0]
-        try:
-            self.sock = self.usbmux.connect(self.device, IPHONE_PORT)
-        except:
-            return False
-        self._state = "#CONNECTED"
-
-        # as soon as we're connected - start parallel listening thread.
-        self._listen_thread = IPhoneListeningThread(self)
-        self._listen_thread.start()
-        # self.sock.setblocking(0)
-        self.connected = True
-        #            self.notifyonframe=1
-        # Create config
-
-        msg_camera_config = {"Message": json.dumps(config)}
-        print(msg_camera_config)
-        return self._send_and_wait_for_response(
-            "@STANDBY",
-            msg_contents=msg_camera_config,
-            wait_on=self.STATE_TRANSITIONS['#STANDBY'].keys(),
-        )
-
-    def _mock_handshake(self):
-        tag = self.tag
-        self._sendpacket("@STANDBY")
-        msg, version, type, resp_tag = self._getpacket()
-        self._validate_message(msg)
-        if msg["MessageType"] != "@READY":
-            self.sock.close()  # close the socket on our side to avoid hanging sockets
-            self.logger.error(f"iPhone [state={self._state}]: Cannot establish STANDBY->READY connection")
-            raise IPhoneError("Cannot establish STANDBY->READY connection with Iphone")
-        return 0
-
-    def start_recording(self, filename):
-        msg_filename = {"Message": filename}
-        self.logger.debug(f'iPhone [state={self._state}]: Sending @START Message')
-        self._send_and_wait_for_response(
-            "@START",
-            msg_contents=msg_filename,
-            wait_on=self.STATE_TRANSITIONS['#START'].keys(),
-        )
-
-    def stop_recording(self):
-        self.logger.debug(f'iPhone [state={self._state}]: Sending @STOP Message')
-        self.ready_event.clear()  # Clear this event so that ensure_stopped() can wait on it
-        self._send_and_wait_for_response(
-            "@STOP",
-            wait_on=["@STOPTIMESTAMP", "@DISCONNECT", "@ERROR"],
-        )
-
-    def _update_message_log(self, msg, tag):
-        with self._message_lock:
-            self._allmessages.append({"message": msg, "ctr_timestamp": str(datetime.now()), "tag": tag})
-
-    def _process_received_message(self, msg, tag):
+        Parameters
+        ----------
+        msg
+            The payload received from the iPhone. (Either a message or raw data depending on the tag.)
+        tag
+            The message tag that indicates how to handle the payload.
+        """
         if tag == 1:
             with self._frame_preview_cond:
                 self._frame_preview_data = msg
@@ -437,21 +530,128 @@ class IPhone:
             with self._wait_for_reply_cond:
                 self._latest_message = msg
                 self._latest_message_type = message_type
+
+                # Push data to LSL in an appropriate message was received
+                if message_type in [
+                    "@STARTTIMESTAMP",
+                    "@INPROGRESSTIMESTAMP",
+                    "@STOPTIMESTAMP",
+                ]:
+                    finfo = eval(msg["TimeStamp"])
+                    self.fcount = int(finfo["FrameNumber"])
+                    lsl_sample = [self.fcount, float(finfo["Timestamp"]), time.time()]
+                    self.lsl_push_sample(lsl_sample)
+                    debug_print(lsl_sample)
+
                 self._wait_for_reply_cond.notify()
 
-            if message_type in [
-                "@STARTTIMESTAMP",
-                "@INPROGRESSTIMESTAMP",
-                "@STOPTIMESTAMP",
-            ]:
-                finfo = eval(msg["TimeStamp"])
-                self.fcount = int(finfo["FrameNumber"])
-                lsl_sample = [self.fcount, float(finfo["Timestamp"]), time.time()]
-                self.lsl_push_sample(lsl_sample)
-                debug_print(lsl_sample)
+    @debug_lsl
+    def lsl_push_sample(self, *args):
+        self.outlet.push_sample(*args)
 
     @debug_lsl
-    def createOutlet(self):
+    def lsl_print(self, *args):
+        print(*args)
+
+    def prepare(self, mock: bool = False, config: Optional[CONFIG] = None) -> bool:
+        """
+        Connect to the iPhone and open an LSL outlet.
+
+        Parameters
+        ----------
+        mock
+            Whether to use a mock iPhone
+        config
+            iPhone configuation options
+
+        Returns
+        -------
+        success
+            Whether the connection was successful
+        """
+        if mock:
+            HOST = "127.0.0.1"  # Symbolic name meaning the local host
+            PORT = 50009  # Arbitrary non-privileged port
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.sock.connect((HOST, PORT))
+            self._mock_handshake()
+            self.connected = True
+            return self.connected
+
+        if config is None:
+            config = {
+                "NOTIFYONFRAME": "1",
+                "VIDEOQUALITY": "1920x1080",
+                "USECAMERAFACING": "BACK",
+                "FPS": "240",
+                "BRIGHTNESS": "50",
+                "LENSPOS": "0.7",
+            }
+        self.notifyonframe = int(config["NOTIFYONFRAME"])
+        success = self.handshake(config)
+        if success:
+            self.outlet = self.create_outlet()
+            self.streaming = True
+        return success and self.connected
+
+    def handshake(self, config: CONFIG) -> bool:
+        """
+        Establish a connection with the iPhone; helper for prepare.
+
+        Parameters
+        ----------
+        config
+            iPhone configuation options
+
+        Returns
+        -------
+        success
+            Whether the connection was successful
+        """
+        if self._state != "#DISCONNECTED":
+            print("Handshake is only available when disconnected")
+            self.logger.error(f'iPhone [state={self._state}]: Attempted handshake in inappropriate state.')
+            return False
+
+        self.usbmux = USBMux()
+        if not self.usbmux.devices:
+            self.usbmux.process(0.1)
+        if len(self.usbmux.devices) != 1:
+            self.logger.error(
+                f'iPhone [state={self._state}]: Incorrect number of usbmux devices (N={len(self.usbmux.devices)}).'
+            )
+            return False
+
+        self.device = self.usbmux.devices[0]
+        try:
+            self.sock = self.usbmux.connect(self.device, IPHONE_PORT)
+        except Exception as e:
+            self.logger.error(f'iPhone [state={self._state}]: Unable to connect; error={e}')
+            return False
+        self._state = "#CONNECTED"
+
+        # As soon as we're connected, start the parallel listening thread.
+        self._listen_thread = IPhoneListeningThread(self)
+        self._listen_thread.start()
+        # self.sock.setblocking(0)
+        self.connected = True
+
+        msg_camera_config = {"Message": json.dumps(config)}
+        print(msg_camera_config)
+        return self._send_and_wait_for_response(
+            "@STANDBY",
+            msg_contents=msg_camera_config,
+            wait_on=list(self.STATE_TRANSITIONS['#STANDBY'].keys()),
+        )
+
+    def _mock_handshake(self) -> bool:
+        self._validate_message(self._message('@STANDBY'), 0)
+        self._validate_message(self._message('@READY'), 0)
+        return True
+
+    @debug_lsl
+    def create_outlet(self) -> StreamOutlet:
+        """Create an LSL outlet; helper for prepare."""
         info = set_stream_description(
             stream_info=StreamInfo(
                 name=self.streamName,
@@ -473,15 +673,27 @@ class IPhone:
         print(f"-OUTLETID-:{self.streamName}:{self.outlet_id}")
         return StreamOutlet(info)
 
-    @debug_lsl
-    def lsl_push_sample(self, *args):
-        self.outlet.push_sample(*args)
+    def start_recording(self, filename: str) -> None:
+        """Signal the iPhone to start recording using the given filename"""
+        msg_filename = {"Message": filename}
+        self.logger.debug(f'iPhone [state={self._state}]: Sending @START Message')
+        self._send_and_wait_for_response(
+            "@START",
+            msg_contents=msg_filename,
+            wait_on=list(self.STATE_TRANSITIONS['#START'].keys()),
+        )
 
-    @debug_lsl
-    def lsl_print(self, *args):
-        print(*args)
+    def stop_recording(self) -> None:
+        """Signal the iPhone to stop recording."""
+        self.logger.debug(f'iPhone [state={self._state}]: Sending @STOP Message')
+        self.ready_event.clear()  # Clear this event so that ensure_stopped() can wait on it
+        self._send_and_wait_for_response(
+            "@STOP",
+            wait_on=["@STOPTIMESTAMP", "@DISCONNECT", "@ERROR"],
+        )
 
-    def frame_preview(self):
+    def frame_preview(self) -> ByteString:
+        """Retrieve a frame preview from the iPhone,"""
         self.logger.debug(f'iPhone [state={self._state}]: Sending @PREVIEW Message')
         with self._frame_preview_cond:
             self._frame_preview_data = b""
@@ -489,7 +701,85 @@ class IPhone:
                 self._frame_preview_cond.wait(timeout=self._timeout_cond)
             return self._frame_preview_data
 
-    def start(self, filename):
+    def dumpall_getfilelist(self, log_files: bool = True) -> Optional[List[str]]:
+        """
+        Get a list of files saved on the iPhone.
+
+        Parameters
+        ----------
+        log_files
+            Whether to log the list of retrieved files using the session logger.
+
+        Returns
+        -------
+        file_names
+            The list of files saved on the iPhone.
+        """
+        self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMPALL Message')
+        with self._wait_for_reply_cond:
+            if not self._sendpacket("@DUMPALL"):
+                return None
+
+            if not self._wait_for_reply_cond.wait_for(
+                lambda: self._latest_message_type in self.STATE_TRANSITIONS['#DUMPALL'].keys(),
+                timeout=self._timeout_cond,
+            ):
+                self.logger.error('Timeout when waiting for @FILESTODUMP.')
+                return None
+
+            filelist = self._latest_message["Message"]
+            if self._state == "#ERROR":
+                self.logger.error(f'iPhone [state={self._state}]: @DUMPALL Error; message="{filelist}"')
+                return None
+
+            if log_files:
+                self.logger.debug(f"iPhone [state={self._state}]: File List (N={len(filelist)}) = {filelist}")
+
+            return filelist
+
+    def dump(self, filename: str, timeout_sec=None) -> (bool, ByteString):
+        """
+        Retrieve a file from the iPhone.
+
+        Parameters
+        ----------
+        filename
+            The file (from the list returned by dumpall_getfilelist) to retrieve.
+        timeout_sec
+            Wait the specified amount of time for the file transfer to complete.
+
+        Returns
+        -------
+        success
+            False if a timeout occurred or the request could not be sent; a zero-byte file will be returned.
+        """
+        success = False
+        self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMP Message')
+        with self._dump_video_cond:
+            self._dump_video_data = b""
+            if self._sendpacket("@DUMP", msg_contents={"Message": filename}):
+                success = self._dump_video_cond.wait(timeout=timeout_sec)
+            return success, self._dump_video_data
+
+    def dumpsuccess(self, filename: str) -> bool:
+        """
+        Notify the iPhone that it may delete the specified file.
+
+        Parameters
+        ----------
+        filename
+            The file (from the list returned by dumpall_getfilelist) to delete.
+
+        Returns
+        -------
+        success
+            Whether the @DUMPSUCCESS message was successfully sent.
+        """
+        self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMPSUCCESS Message')
+        return self._sendpacket("@DUMPSUCCESS", msg_contents={"Message": filename})
+
+    def start(self, filename: str) -> None:
+        """Start data capture."""
         self.streaming = True
         filename += "_IPhone"
         filename = op.split(filename)[-1]
@@ -498,12 +788,10 @@ class IPhone:
         self.lsl_print(f"-new_filename-:{self.streamName}:{filename}.json")
         self.start_recording(filename)
 
-    def stop(self):
+    def stop(self) -> None:
+        """Stop data capture."""
         self.stop_recording()
         self.streaming = False
-
-    def close(self):
-        self.disconnect()
 
     def ensure_stopped(self, timeout_seconds: float) -> None:
         """Check to make sure that we have transitioned from the #STOP state back to the #READY state."""
@@ -516,50 +804,12 @@ class IPhone:
 
         self.logger.debug(f'iPhone [state={self._state}]: Transition to #READY Detected')
 
-    def prepare(self, mock=False, config=None):
-        if mock:
-            HOST = "127.0.0.1"  # Symbolic name meaning the local host
-            PORT = 50009  # Arbitrary non-privileged port
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((HOST, PORT))
-            self.sock = s
-            self._mock_handshake()
-            self.connected = True
-        else:
-            if config is None:
-                self.notifyonframe = 1
-                config = {
-                    "NOTIFYONFRAME": str(self.notifyonframe),
-                    "VIDEOQUALITY": "1920x1080",
-                    "USECAMERAFACING": "BACK",
-                    "FPS": "240",
-                    "BRIGHTNESS": "50",
-                    "LENSPOS": "0.7",
-                }
-            self.notifyonframe = int(config["NOTIFYONFRAME"])
-            connected = self.handshake(config)
-            if connected:
-                self.outlet = self.createOutlet()
-                self.streaming = True
-            return connected
+    def close(self) -> None:
+        """Close the stream and disconnect the iPhone"""
+        self.disconnect()
 
-    def dump(self, filename, timeout_sec=None):
-        if timeout_sec is None:
-            timeout_sec = self._timeout_cond
-        success = False
-
-        self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMP Message')
-        with self._dump_video_cond:
-            self._dump_video_data = b""
-            if self._sendpacket("@DUMP", msg_contents={"Message": filename}):
-                success = self._dump_video_cond.wait(timeout=timeout_sec)
-            return success, self._dump_video_data
-
-    def dumpsuccess(self, filename):
-        self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMPSUCCESS Message')
-        return self._sendpacket("@DUMPSUCCESS", msg_contents={"Message": filename})
-
-    def disconnect(self):
+    def disconnect(self) -> bool:
+        """Disconnect the iPhone"""
         if self._state == "#DISCONNECTED":
             print("IPhone device is already disconnected")
             return False
@@ -576,31 +826,9 @@ class IPhone:
         self.streaming = False
         return True
 
-    def dumpall_getfilelist(self, log_files: bool = True):
-        self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMPALL Message')
-        with self._wait_for_reply_cond:
-            if not self._sendpacket("@DUMPALL"):
-                return None
-
-            if not self._wait_for_reply_cond.wait_for(
-                lambda: self._latest_message_type in self.STATE_TRANSITIONS['#DUMPALL'].keys(),
-                timeout=self._timeout_cond,
-            ):
-                self.logger.error('Timeout when waiting for @@FILESTODUMP.')
-                return None
-
-            filelist = self._latest_message["Message"]
-            if self._state == "#ERROR":
-                self.logger.error(f'iPhone [state={self._state}]: @DUMPALL Error; message="{filelist}"')
-                return None
-
-            if log_files:
-                self.logger.debug(f"iPhone [state={self._state}]: File List (N={len(filelist)}) = {filelist}")
-
-            return filelist
-
 
 if __name__ == "__main__":
+    import argparse
 
     @debug_lsl
     def liesl_sesion_create(**kwargs):
@@ -614,9 +842,6 @@ if __name__ == "__main__":
     @debug_lsl
     def liesl_sesion_stop(session):
         session.stop_recording()
-
-    import time
-    import argparse
 
     parser = argparse.ArgumentParser(description='Run a standalone capture using the iPhone.')
     parser.add_argument(
@@ -656,7 +881,7 @@ if __name__ == "__main__":
     #                        'VIDEOQUALITY':'1920x1080',
     #                        'USECAMERAFACING':'BACK','FPS':'120 or 240'}
     iphone = IPhone("iphone")
-    config = {
+    default_config: CONFIG = {
         "NOTIFYONFRAME": "1",
         "VIDEOQUALITY": "1920x1080",
         "USECAMERAFACING": "BACK",
@@ -665,7 +890,7 @@ if __name__ == "__main__":
         "LENSPOS": "0.7",
     }
 
-    if not iphone.prepare(config=config):
+    if not iphone.prepare(config=default_config):
         print("Could not connect to iphone")
 
     frame = iphone.frame_preview()

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -543,13 +543,17 @@ class IPhone:
                 self.streaming = True
             return connected
 
-    def dump(self, filename):
+    def dump(self, filename, timeout_sec=None):
+        if timeout_sec is None:
+            timeout_sec = self._timeout_cond
+        success = False
+
         self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMP Message')
         with self._dump_video_cond:
             self._dump_video_data = b""
             if self._sendpacket("@DUMP", msg_contents={"Message": filename}):
-                self._dump_video_cond.wait(timeout=self._timeout_cond)
-            return self._dump_video_data
+                success = self._dump_video_cond.wait(timeout=timeout_sec)
+            return success, self._dump_video_data
 
     def dumpsuccess(self, filename):
         self.logger.debug(f'iPhone [state={self._state}]: Sending @DUMPSUCCESS Message')

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -559,9 +559,9 @@ class IPhone:
         self.logger.debug(f'iPhone [state={self._state}]: Disconnecting')
         self._sendpacket("@DISCONNECT")
         time.sleep(4)
-        self.sock.close()
         self._listen_thread.stop()
         self._listen_thread.join(timeout=3)
+        self.sock.close()
         if self._listen_thread.is_alive():
             self.logger.error(f'iPhone [state={self._state}]: Could not stop listening thread.')
             raise IPhoneError("Cannot stop the recording thread")

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -520,11 +520,6 @@ class IPhone:
 
         self.logger.debug(f'iPhone [state={self._state}]: Transition to #READY Detected')
 
-    def log_files(self) -> None:
-        """Add the files currently in the iPhone's memory to the log"""
-        files = self.dumpall_getfilelist(print_files=False)
-        self.logger.debug(f"iPhone [state={self._state}]: File List = {str(files)}")
-
     def prepare(self, mock=False, config=None):
         if mock:
             HOST = "127.0.0.1"  # Symbolic name meaning the local host
@@ -581,11 +576,11 @@ class IPhone:
         self.streaming = False
         return True
 
-    def dumpall_getfilelist(self, print_files: bool = True):
+    def dumpall_getfilelist(self, log_files: bool = True):
         self._sendpacket("@DUMPALL", cond=self._wait_for_reply_cond)
         filelist = self._msg_latest["Message"]
-        if print_files:
-            print(f'FILELIST: {filelist}')
+        if log_files:
+            self.logger.debug(f"iPhone [state={self._state}]: File List = {filelist}")
         if self._state == "#ERROR":
             return None
         return filelist

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -609,6 +609,29 @@ if __name__ == "__main__":
         session.stop_recording()
 
     import time
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Run a standalone capture using the iPhone.')
+    parser.add_argument(
+        '--duration',
+        default=1,
+        type=int,
+        help='Duration of video capture'
+    )
+    parser.add_argument(
+        '--subject-id',
+        default='007',
+        type=str,
+        help='The subject ID to use',
+    )
+    parser.add_argument(
+        '--recording-folder',
+        default='',
+        type=str,
+        help='The folder the LSL stream should record to.'
+    )
+    args = parser.parse_args()
+
 
     # Creating and starting mock streams:
 
@@ -635,29 +658,30 @@ if __name__ == "__main__":
     frame = iphone.frame_preview()
 
     streamargs = {"name": "IPhoneFrameIndex"}
-    recording_folder = ""
-    subject = "007"
+    date = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
+    task_id = f'{args.subject_id}_{date}_task_obs_1_IPhone'
 
+    # Start LSL
     session = liesl_sesion_create(
-        prefix=subject, streamargs=[streamargs], mainfolder=recording_folder
+        prefix=args.subject_id, streamargs=[streamargs], mainfolder=args.recording_folder
     )
     liesl_sesion_start(session)
-    # iphone.start('mov120_1')
-    iphone.start(subject + f"_task_obs_1_{time.time()}")
 
-    time.sleep(1)
-
+    # Data capture
+    iphone.start(task_id)
+    time.sleep(args.duration)
     iphone.stop()
+
+    # Stop LSL
     liesl_sesion_stop(session)
+    
     iphone.disconnect()
 
     import pyxdf
     import glob
     import numpy as np
 
-    subject = "007"
-    path = r"C:\neurobooth-eel\007"
-    fname = glob.glob(f"{subject}/recording_R0*.xdf")[-1]
+    fname = glob.glob(f"{args.subject_id}/recording_R0*.xdf")[-1]
     data, header = pyxdf.load_xdf(fname)
 
     ts = data[0]["time_series"]

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import select
 import uuid
 import logging
+import time
 
 from neurobooth_os.iout.usbmux import USBMux
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -594,10 +594,8 @@ class IPhone:
 if __name__ == "__main__":
 
     @debug_lsl
-    def liesl_sesion_create(**args):
-        session = liesl.Session(
-            prefix=subject, streamargs=[streamargs], mainfolder=recording_folder
-        )
+    def liesl_sesion_create(**kwargs):
+        session = liesl.Session(**kwargs)
         return session
 
     @debug_lsl
@@ -674,7 +672,7 @@ if __name__ == "__main__":
 
     # Stop LSL
     liesl_sesion_stop(session)
-    
+
     iphone.disconnect()
 
     import pyxdf

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -18,11 +18,17 @@ def make_session_logger(session_folder: str, machine_name: str, log_level=loggin
     return logger
 
 
-def make_iphone_dump_logger(log_level=logging.DEBUG) -> logging.Logger:
+def make_iphone_dump_logger(
+        log_path: str = 'D:/neurobooth/neurobooth_logs',
+        log_level=logging.DEBUG
+) -> logging.Logger:
+    if not os.path.exists(log_path):
+        os.mkdir(log_path)
+
     logger = logging.getLogger('iphone_dump')
     time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
 
-    file_handler = logging.FileHandler(f'D:/neurobooth_logs/iphone_dump_{time_str}.log')
+    file_handler = logging.FileHandler(os.path.join(log_path, f'iphone_dump_{time_str}.log'))
     file_handler.setLevel(log_level)
     file_handler.setFormatter(LOG_FORMAT)
     logger.addHandler(file_handler)

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -4,8 +4,9 @@ import sys
 from datetime import datetime
 from typing import Optional
 
-
 LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
+
+DEFAULT_LOG_PATH = r"D:\neurobooth\neurobooth_logs"
 
 
 def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
@@ -42,16 +43,16 @@ def make_session_logger_debug(
     return logger
 
 
-def make_iphone_dump_logger(
-        log_path: str = 'D:/neurobooth/neurobooth_logs',
+def make_default_logger(
+        log_path=DEFAULT_LOG_PATH,
         log_level=logging.DEBUG,
 ) -> logging.Logger:
     if not os.path.exists(log_path):
-        os.mkdir(log_path)
+        os.makedirs(log_path)
 
-    logger = logging.getLogger('iphone_dump')
+    logger = logging.getLogger('default')
     time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
-    file = os.path.join(log_path, f'iphone_dump_{time_str}.log')
+    file = os.path.join(log_path, f'default_{time_str}.log')
 
     file_handler = logging.FileHandler(file)
     file_handler.setLevel(log_level)

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -20,7 +20,7 @@ def make_session_logger(session_folder: str, machine_name: str, log_level=loggin
 
 def make_iphone_dump_logger(
         log_path: str = 'D:/neurobooth/neurobooth_logs',
-        log_level=logging.DEBUG
+        log_level=logging.DEBUG,
 ) -> logging.Logger:
     if not os.path.exists(log_path):
         os.mkdir(log_path)

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -1,17 +1,36 @@
 import os
 import logging
+import sys
 from datetime import datetime
 
 
-def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
-    formatter = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
+LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
 
+
+def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
     logger = logging.getLogger('session')
     time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
     file_handler = logging.FileHandler(os.path.join(session_folder, f'{machine_name}_session_{time_str}.log'))
     file_handler.setLevel(log_level)
-    file_handler.setFormatter(formatter)
+    file_handler.setFormatter(LOG_FORMAT)
     logger.addHandler(file_handler)
     logger.setLevel(log_level)
+    return logger
 
+
+def make_iphone_dump_logger(log_level=logging.DEBUG) -> logging.Logger:
+    logger = logging.getLogger('iphone_dump')
+    time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
+
+    file_handler = logging.FileHandler(f'D:/neurobooth_logs/iphone_dump_{time_str}.log')
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(LOG_FORMAT)
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(log_level)
+    console_handler.setFormatter(LOG_FORMAT)
+    logger.addHandler(console_handler)
+
+    logger.setLevel(log_level)
     return logger

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -2,6 +2,7 @@ import os
 import logging
 import sys
 from datetime import datetime
+from typing import Optional
 
 
 LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
@@ -14,6 +15,29 @@ def make_session_logger(session_folder: str, machine_name: str, log_level=loggin
     file_handler.setLevel(log_level)
     file_handler.setFormatter(LOG_FORMAT)
     logger.addHandler(file_handler)
+    logger.setLevel(log_level)
+    return logger
+
+
+def make_session_logger_debug(
+        file: Optional[str] = None,
+        console: bool = True,
+        log_level=logging.DEBUG
+) -> logging.Logger:
+    logger = logging.getLogger('session')
+
+    if file is not None:
+        file_handler = logging.FileHandler(file)
+        file_handler.setLevel(log_level)
+        file_handler.setFormatter(LOG_FORMAT)
+        logger.addHandler(file_handler)
+
+    if console:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setLevel(log_level)
+        console_handler.setFormatter(LOG_FORMAT)
+        logger.addHandler(console_handler)
+
     logger.setLevel(log_level)
     return logger
 

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -21,7 +21,7 @@ def make_session_logger(session_folder: str, machine_name: str, log_level=loggin
 
 def make_session_logger_debug(
         file: Optional[str] = None,
-        console: bool = True,
+        console: bool = False,
         log_level=logging.DEBUG
 ) -> logging.Logger:
     logger = logging.getLogger('session')
@@ -51,8 +51,9 @@ def make_iphone_dump_logger(
 
     logger = logging.getLogger('iphone_dump')
     time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
+    file = os.path.join(log_path, f'iphone_dump_{time_str}.log')
 
-    file_handler = logging.FileHandler(os.path.join(log_path, f'iphone_dump_{time_str}.log'))
+    file_handler = logging.FileHandler(file)
     file_handler.setLevel(log_level)
     file_handler.setFormatter(LOG_FORMAT)
     logger.addHandler(file_handler)
@@ -61,6 +62,8 @@ def make_iphone_dump_logger(
     console_handler.setLevel(log_level)
     console_handler.setFormatter(LOG_FORMAT)
     logger.addHandler(console_handler)
+
+    make_session_logger_debug(file=file)
 
     logger.setLevel(log_level)
     return logger

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -157,7 +157,10 @@ def Main():
             for k in streams.keys():  # Log the list of files present on the iPhone
                 if k.split("_")[0] == "IPhone":
                     iphone_files = streams[k].dumpall_getfilelist()
-                    logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
+                    if iphone_files is not None:
+                        logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
+                    else:
+                        logger.warning(f'iPhone did not return a list of files to dump.')
 
             streams = close_streams(streams)
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -156,7 +156,8 @@ def Main():
             # TODO: It would be nice to generically register logging handlers at each stage of a stream's lifecycle.
             for k in streams.keys():  # Log the list of files present on the iPhone
                 if k.split("_")[0] == "IPhone":
-                    streams[k].dumpall_getfilelist()
+                    iphone_files = streams[k].dumpall_getfilelist()
+                    logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
 
             streams = close_streams(streams)
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -141,10 +141,6 @@ def Main():
                     if task_devs_kw[task].get(k):
                         streams[k].ensure_stopped(10)
 
-            for k in streams.keys():  # Run logging handler for iphone; TODO: make this more device generic
-                if k.split("_")[0] == "IPhone" and task_devs_kw[task].get(k):
-                    streams[k].log_files()
-
             elapsed_time = time() - t0
             print(f"Device stop took {elapsed_time:.2f}")
             logger.info(f'Device stop took {elapsed_time:.2f}')
@@ -156,6 +152,11 @@ def Main():
             if "shutdown" in data:
                 sys.stdout = sys.stdout.terminal
                 s1.close()
+
+            # TODO: It would be nice to generically register logging handlers at each stage of a stream's lifecycle.
+            for k in streams.keys():  # Log the list of files present on the iPhone
+                if k.split("_")[0] == "IPhone":
+                    streams[k].dumpall_getfilelist()
 
             streams = close_streams(streams)
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -131,15 +131,19 @@ def Main():
 
         elif "record_stop" in data:
             t0 = time()
-            for k in streams.keys():
+            for k in streams.keys():  # Call stop on streams with that method
                 if k.split("_")[0] in ["hiFeed", "FLIR", "Intel", "IPhone"]:
                     if task_devs_kw[task].get(k):
                         streams[k].stop()
 
-            for k in streams.keys():
+            for k in streams.keys():  # Ensure the streams are stopped
                 if k.split("_")[0] in ["FLIR", "Intel", "IPhone"]:
                     if task_devs_kw[task].get(k):
                         streams[k].ensure_stopped(10)
+
+            for k in streams.keys():  # Run logging handler for iphone; TODO: make this more device generic
+                if k.split("_")[0] == "IPhone" and task_devs_kw[task].get(k):
+                    streams[k].log_files()
 
             elapsed_time = time() - t0
             print(f"Device stop took {elapsed_time:.2f}")

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -10,6 +10,7 @@ import logging
 
 import neurobooth_os
 from neurobooth_os import config
+from neurobooth_os.logging import make_default_logger
 from neurobooth_os.netcomm import NewStdout, get_client_messages
 from neurobooth_os.iout.camera_brio import VidRec_Brio
 from neurobooth_os.iout.lsl_streamer import (
@@ -36,10 +37,17 @@ def Main():
     sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)
     s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    # Initialize logging to nothing, will get overwritten during session preparation
-    logger = logging.getLogger('null')
-    logger.addHandler(logging.NullHandler())
+    # Initialize default logger
+    logger = make_default_logger()
+    try:
+        run_acq(logger)
+    except Exception as e:
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise
 
+
+def run_acq(logger):
     streams = {}
     lowFeed_running = False
     recording = False

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -1,11 +1,9 @@
 import socket
 import sys
 import os
-from time import time, sleep
-from collections import OrderedDict
+from time import time
 from datetime import datetime
 import copy
-import logging
 
 from psychopy import prefs
 
@@ -33,18 +31,26 @@ from neurobooth_os.netcomm import (
 from neurobooth_os.tasks.wellcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
 from neurobooth_os.tasks.task_importer import get_task_funcs
-from neurobooth_os.logging import make_session_logger
+from neurobooth_os.logging import make_session_logger, make_default_logger
 
 
 def Main():
     os.chdir(neurobooth_os.__path__[0])
-
     sys.stdout = NewStdout("STM", target_node="control", terminal_print=True)
-    s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    # Initialize logging to nothing, will get overwritten during session preparation
-    logger = logging.getLogger('null')
-    logger.addHandler(logging.NullHandler())
+    # Initialize logging to default
+    logger = make_default_logger()
+
+    try:
+        run_stm(logger)
+    except Exception as e:
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise
+
+
+def run_stm(logger):
+    s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     if os.getenv("NB_FULLSCREEN") == "false":
         win = utl.make_win(full_screen=False)

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+import unittest
+
+from neurobooth_os.logging import make_default_logger
+
+
+class TestLogging(unittest.TestCase):
+
+    def test_default_logging(self):
+
+        def do_something():
+            raise ValueError(":(")
+
+        log_path = r"C:\neurobooth\neurobooth_logs"
+        print(log_path)
+        make_default_logger(log_path)
+        logger = logging.getLogger("default")
+        try:
+            do_something()
+        except Exception as e:
+            logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+            logger.critical(e, exc_info=sys.exc_info())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds logging to the top levels of the three servers in an attempt to ensure that all errors are logged (and no crashes occur without leaving a trail).

Each server writes to a log on its local drive by default.
The GUI server log should also emit to the GUI by virtue of a specialized handler.

Limitations: 

1. While this code should catch errors currently escaping through the main loops for each server, it will not catch exceptions that blow-up individual threads created in those loops. Additional logic may be required.  
2. No changes have been made to the logging of any other script, except for the iPhone dump script, as this code is based on the logging that was added there. 