### PR TITLE
Top level logging

### DIFF
--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -167,5 +167,7 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger = logging.getLogger('iphone_dump')
-        logger.exception(e)
+        logger = logging.getLogger("default")
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -6,7 +6,7 @@ import os.path as op
 import datetime
 import logging
 from typing import Optional
-from neurobooth_os.logging import make_iphone_dump_logger
+from neurobooth_os.logging import make_default_logger
 import argparse
 
 
@@ -153,7 +153,7 @@ def parse_arguments() -> argparse.Namespace:
 
 
 def main():
-    logger = make_iphone_dump_logger()
+    logger = make_default_logger()
     iphone.DISABLE_LSL = True
 
     args = parse_arguments()

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -50,12 +50,10 @@ class Handler(logging.StreamHandler):
         logging.StreamHandler.__init__(self)
 
     def emit(self, record):
-        global BUFFER
-        buffer = f'{BUFFER}\n{str(record)}'.strip()
+        spacer = ''
+        buffer = f'{spacer}\n{str(record)}'.strip()
         window['log'].update(value=buffer)
 
-
-BUFFER = ''
 
 logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -29,23 +29,20 @@ from neurobooth_os.netcomm import (
     socket_message,
 )
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes
+from neurobooth_os.logging import make_default_logger
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.iout.split_xdf import split_sens_files, get_xdf_name
 from neurobooth_os.iout import marker_stream
 import neurobooth_os.config as cfg
 
-def setup_log(name, sg_handler = None):
-    logger = logging.getLogger(name)
+
+def setup_log(sg_handler = None):
+    logger = make_default_logger()
     logger.setLevel(logging.DEBUG)
-    log_format = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-    #filename = f"./{name}.log"
-    #log_handler = logging.FileHandler(filename)
-    #log_handler.setLevel(logging.DEBUG)
-    #log_handler.setFormatter(log_format)
-    #logger.addHandler(log_handler)
     if sg_handler:
         logger.addHandler(sg_handler)
     return logger
+
 
 class Handler(logging.StreamHandler):
 
@@ -57,11 +54,10 @@ class Handler(logging.StreamHandler):
         buffer = f'{BUFFER}\n{str(record)}'.strip()
         window['log'].update(value=buffer)
 
+
 BUFFER = ''
 
-logger = setup_log(__name__, sg_handler = Handler().setLevel(logging.DEBUG))
-
-
+logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
 
 
 def _process_received_data(serv_data, window):
@@ -650,7 +646,12 @@ def main():
         help="Specify which database to connect",
     )
     (options, args) = parser.parse_args()
-    gui(remote=options.remote, database=options.database)
+    try:
+        gui(remote=options.remote, database=options.database)
+    except Exception as e:
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise
 
 
 if __name__ == "__main__":

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -50,8 +50,7 @@ class Handler(logging.StreamHandler):
         logging.StreamHandler.__init__(self)
 
     def emit(self, record):
-        spacer = ''
-        buffer = f'{spacer}\n{str(record)}'.strip()
+        buffer = str(record).strip()
         window['log'].update(value=buffer)
 
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -45,7 +45,7 @@ def setup_log(sg_handler = None):
 
 
 class Handler(logging.StreamHandler):
-
+    """LogHandler that emits entries to the GUI"""
     def __init__(self):
         logging.StreamHandler.__init__(self)
 

--- a/neurobooth_os/logging.py
+++ b/neurobooth_os/logging.py
@@ -4,8 +4,9 @@ import sys
 from datetime import datetime
 from typing import Optional
 
-
 LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
+
+DEFAULT_LOG_PATH = r"D:\neurobooth\neurobooth_logs"
 
 
 def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
@@ -42,16 +43,16 @@ def make_session_logger_debug(
     return logger
 
 
-def make_iphone_dump_logger(
-        log_path: str = 'D:/neurobooth/neurobooth_logs',
+def make_default_logger(
+        log_path=DEFAULT_LOG_PATH,
         log_level=logging.DEBUG,
 ) -> logging.Logger:
     if not os.path.exists(log_path):
-        os.mkdir(log_path)
+        os.makedirs(log_path)
 
-    logger = logging.getLogger('iphone_dump')
+    logger = logging.getLogger('default')
     time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
-    file = os.path.join(log_path, f'iphone_dump_{time_str}.log')
+    file = os.path.join(log_path, f'default_{time_str}.log')
 
     file_handler = logging.FileHandler(file)
     file_handler.setLevel(log_level)

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -33,9 +33,7 @@ def countdown(period):
 
 def Main():
     os.chdir(neurobooth_os.__path__[0])
-
     sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)
-    s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     # Initialize default logger
     logger = make_default_logger()
@@ -48,6 +46,8 @@ def Main():
 
 
 def run_acq(logger):
+    s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
     streams = {}
     lowFeed_running = False
     recording = False

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -10,6 +10,7 @@ import logging
 
 import neurobooth_os
 from neurobooth_os import config
+from neurobooth_os.logging import make_default_logger
 from neurobooth_os.netcomm import NewStdout, get_client_messages
 from neurobooth_os.iout.camera_brio import VidRec_Brio
 from neurobooth_os.iout.lsl_streamer import (
@@ -36,10 +37,17 @@ def Main():
     sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)
     s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    # Initialize logging to nothing, will get overwritten during session preparation
-    logger = logging.getLogger('null')
-    logger.addHandler(logging.NullHandler())
+    # Initialize default logger
+    logger = make_default_logger()
+    try:
+        run_acq(logger)
+    except Exception as e:
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise
 
+
+def run_acq(logger):
     streams = {}
     lowFeed_running = False
     recording = False

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -1,11 +1,9 @@
 import socket
 import sys
 import os
-from time import time, sleep
-from collections import OrderedDict
+from time import time
 from datetime import datetime
 import copy
-import logging
 
 from psychopy import prefs
 
@@ -33,18 +31,26 @@ from neurobooth_os.netcomm import (
 from neurobooth_os.tasks.wellcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
 from neurobooth_os.tasks.task_importer import get_task_funcs
-from neurobooth_os.logging import make_session_logger
+from neurobooth_os.logging import make_session_logger, make_default_logger
 
 
 def Main():
     os.chdir(neurobooth_os.__path__[0])
-
     sys.stdout = NewStdout("STM", target_node="control", terminal_print=True)
-    s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    # Initialize logging to nothing, will get overwritten during session preparation
-    logger = logging.getLogger('null')
-    logger.addHandler(logging.NullHandler())
+    # Initialize logging to default
+    logger = make_default_logger()
+
+    try:
+        run_stm(logger)
+    except Exception as e:
+        logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+        logger.critical(e, exc_info=sys.exc_info())
+        raise
+
+
+def run_stm(logger):
+    s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     if os.getenv("NB_FULLSCREEN") == "false":
         win = utl.make_win(full_screen=False)

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -1,26 +1,50 @@
 import logging
+import os
+import shutil
 import sys
 import unittest
 
 from neurobooth_os.logging import make_default_logger
 
+log_path = r"C:\neurobooth\test_data\test_logs"
+logger = make_default_logger(log_path)
+
 
 class TestLogging(unittest.TestCase):
+
+    def tearDown(self):
+
+        handlers = logger.handlers[:]
+        for handler in handlers:
+            logger.removeHandler(handler)
+            handler.close()
+        logging.shutdown()
+
+        if os.path.exists(log_path):
+            files = os.listdir(log_path)
+            for file in files:
+                filename = os.path.join(log_path, file)
+                os.remove(filename)
+            shutil.rmtree(log_path)
 
     def test_default_logging(self):
 
         def do_something():
             raise ValueError(":(")
 
-        log_path = r"C:\neurobooth\neurobooth_logs"
-        print(log_path)
-        make_default_logger(log_path)
-        logger = logging.getLogger("default")
         try:
             do_something()
         except Exception as e:
             logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
             logger.critical(e, exc_info=sys.exc_info())
+
+        filename = os.path.join(log_path, os.listdir(log_path)[0])
+
+        with open(filename, 'r') as file:
+            data = file.read()
+
+        self.assertTrue("Exiting" in data)
+        self.assertTrue("Traceback" in data)
 
 
 if __name__ == '__main__':

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+import unittest
+
+from neurobooth_os.logging import make_default_logger
+
+
+class TestLogging(unittest.TestCase):
+
+    def test_default_logging(self):
+
+        def do_something():
+            raise ValueError(":(")
+
+        log_path = r"C:\neurobooth\neurobooth_logs"
+        print(log_path)
+        make_default_logger(log_path)
+        logger = logging.getLogger("default")
+        try:
+            do_something()
+        except Exception as e:
+            logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
+            logger.critical(e, exc_info=sys.exc_info())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds logging to the top levels of the three servers in an attempt to ensure that all errors are logged (and no crashes occur without leaving a trail).

Each server writes to a log on its local drive by default.
The GUI server log should also emit to the GUI by virtue of a specialized handler.

Limitations:

- While this code should catch errors currently escaping through the main loops for each server, it will not catch exceptions that blow-up individual threads created in those loops. Additional logic may be required.
- No changes have been made to the logging of any other script, except for the iPhone dump script, as this code is based on the logging that was added there.