### PR TITLE
Release process documentation

### DIFF
--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -12,7 +12,7 @@ Specifically, the `__init__.py` module in the neurobooth-os folder holds the att
 
 Keeping the version name in the code in sync with the release is a key part of the process:
 - When release 0.0.4 is in development, `__version__ = "v0.0.4-dev"`
-- When we're ready to make the release, the '-dev' part is removed and `__version__ = "v0.0.4"`. This version gets packaged into the release.
+- When we're ready to release, the '-dev' part is removed and `__version__ = "v0.0.4"`. This version gets packaged into the release.
 - When the release has been created, `__version__` is incremented, and the '-dev' suffix is restored so that `__version__ = "0.0.5-dev"`.
 
 (At some point all this version name shuffling can be automated.)
@@ -25,19 +25,21 @@ Development is performed on feature branches as usual. When complete, feature br
 
 1. Update the `__version__` in neurobooth_os to match the planned release name, by removing the '-dev' suffix as described above.
 3. The modified `__init__.py` is committed and pushed to master
-4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release" 
-5. Increment the version in `__init__.py` and append the string '-dev' 
-9. Commit the new version of `__init__.py`
-6. Deploy the candidate release into staging and complete testing in that environment 
+4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release". This tags the code in the release to the current state in the git history.
+5. Increment the version in `__init__.py`, append the string '-dev', and commit the changes.
+6. Deploy the candidate release into staging and complete testing 
 6. Publish the release in GitHub 
-7. Deploy the published release into production environments. 
+7. Deploy the published release into production environment(s). 
  
-Deploying releases: 
+Checking out and deploying releases: 
 
 The examples below show how to checkout released code install it using pip. Release v0.0.1 is used for demonstration. 
 
-To install a release using pip: 
-	pip install git+https://github.com/neurobooth/neurobooth-os@v0.0.1
+To checkout a release without installing specify the tag and branch (master):
+	`git checkout tags/<tag> -b <branch>`
 
-To checkout a release:
-	git checkout
+To install a release using pip: 
+	`pip install git+https://github.com/neurobooth/neurobooth-os@v0.0.1`
+
+If desired, the release can be installed in a particular location using the -target flag
+

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -1,0 +1,43 @@
+
+This document describes the Neurobooth release process.
+
+The goals for this process are:
+1. To ensure consistency in the Neurobooth deployment process such that every deployed environment is associated with a known release version. 
+2. To ensure the code tested in staging is identical to the code deployed to production.
+3. To make it easy to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
+
+For simplicity, this process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same, except that the 'V' indicating version is lowercase in the tag name and uppercase in the release name.  For example: Release V.0.0.1 should have tag v.0.0.1.
+
+The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. Keeping the version name in the code in sync with the release is a key part of the process. 
+
+When release n is in development, `__version__` should say 'Vn-dev' (e.g. V0.0.2-dev)
+When we're ready to make the release, the '-dev' part is stripped to provide the true version name (e.g. V0.0.2)
+When the release has been created, `__version__` is incremented, and the '-dev' suffix is re-added.
+
+(At some point this version name shuffling can be automated.)
+
+A release that isn't ready for production deployment should be flagged as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
+The process: 
+
+make a release (the new title should match the version in __init__.py, but more importantly, should be the next logical number from the last title used). Note that the release title starts with a capital V and the release tag starts with a lower-case v.
+
+Development is performed on feature branches as usual. When complete, feature branches are merged into master.
+
+1. To start the release process, update the version in neurobooth_os to match the planned release name. Usually, this just involves stripping the '-dev' string from the current value
+3. The modified `__init__.py` is committed and pushed to master
+4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release" 
+5. Deploy the candidate release into staging and complete testing in that environment 
+6. Publish the release in GitHub 
+7. Deploy the published release into production environments. 
+8. Increment the version in `__init__.py` and append the string '-dev' 
+9. Commit the new version
+ 
+Deploying releases: 
+
+The examples below show how to checkout released code install it using pip. Release V0.0.1 is used for demonstration. 
+
+To install a release using pip: 
+	pip install git+https://github.com/neurobooth/neurobooth-os@v0.0.1
+
+To checkout a release:
+	git checkout

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -6,7 +6,7 @@ The goals for this process are:
 2. To ensure the code tested in staging is identical to the code deployed to production.
 3. To make it easier to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
 
-For simplicity, this process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
+This process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
 The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. In code, the name is stored in a `__version__` attribute in a way that is consistent with Python package naming standards. 
 
 Keeping the version name in the code in sync with the release is a key part of the process:

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -2,9 +2,9 @@
 This document describes the Neurobooth release process.
 
 The goals for this process are:
-1. To ensure consistency in the Neurobooth deployment process such that every deployed environment is associated with a known release version. 
+1. To ensure consistency in Neurobooth deployments such that every environment is associated with a known release version. 
 2. To ensure the code tested in staging is identical to the code deployed to production.
-3. To make it easy to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
+3. To make it easier to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
 
 For simplicity, this process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
 

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -7,14 +7,14 @@ The goals for this process are:
 3. To make it easier to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
 
 For simplicity, this process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
+The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. In code, the name is stored in a `__version__` attribute in a way that is consistent with Python package naming standards. 
 
-The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. Keeping the version name in the code in sync with the release is a key part of the process. 
+Keeping the version name in the code in sync with the release is a key part of the process:
+- When release 0.0.4 is in development, `__version__ = "v0.0.4-dev"`
+- When we're ready to make the release, the '-dev' part is removed and `__version__ = "v0.0.4"`. This version gets packaged into the release.
+- When the release has been created, `__version__` is incremented, and the '-dev' suffix is restored so that `__version__ = "0.0.5-dev"`.
 
-When release N is in development, `__version__` should say 'vN-dev' (e.g. v0.0.2-dev)
-When we're ready to make the release, the '-dev' part is stripped to provide the true version name (e.g. v0.0.2)
-When the release has been created, `__version__` is incremented, and the '-dev' suffix is re-added. The value of `__version__` should now be 'v0.0.3-dev'.
-
-(At some point this version name shuffling can be automated.)
+(At some point all this version name shuffling can be automated.)
 
 A release that isn't ready for production deployment should be flagged as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
 

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -6,31 +6,30 @@ The goals for this process are:
 2. To ensure the code tested in staging is identical to the code deployed to production.
 3. To make it easy to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
 
-For simplicity, this process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same, except that the 'V' indicating version is lowercase in the tag name and uppercase in the release name.  For example: Release V.0.0.1 should have tag v.0.0.1.
+For simplicity, this process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
 
 The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. Keeping the version name in the code in sync with the release is a key part of the process. 
 
 When release N is in development, `__version__` should say 'vN-dev' (e.g. v0.0.2-dev)
 When we're ready to make the release, the '-dev' part is stripped to provide the true version name (e.g. v0.0.2)
-When the release has been created, `__version__` is incremented, and the '-dev' suffix is re-added.
+When the release has been created, `__version__` is incremented, and the '-dev' suffix is re-added. The value of `__version__` should now be 'v0.0.3-dev'.
 
 (At some point this version name shuffling can be automated.)
 
 A release that isn't ready for production deployment should be flagged as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
-The process: 
 
-make a release (the new title should match the version in __init__.py, but more importantly, should be the next logical number from the last title used).
+The process: 
 
 Development is performed on feature branches as usual. When complete, feature branches are merged into master.
 
 1. To start the release process, update the version in neurobooth_os to match the planned release name. Usually, this just involves stripping the '-dev' string from the current value
 3. The modified `__init__.py` is committed and pushed to master
 4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release" 
-5. Deploy the candidate release into staging and complete testing in that environment 
+5. Increment the version in `__init__.py` and append the string '-dev' 
+9. Commit the new version of `__init__.py`
+6. Deploy the candidate release into staging and complete testing in that environment 
 6. Publish the release in GitHub 
 7. Deploy the published release into production environments. 
-8. Increment the version in `__init__.py` and append the string '-dev' 
-9. Commit the new version
  
 Deploying releases: 
 

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -10,8 +10,8 @@ For simplicity, this process uses GitHub's release support. In this model, a rel
 
 The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. Keeping the version name in the code in sync with the release is a key part of the process. 
 
-When release n is in development, `__version__` should say 'Vn-dev' (e.g. V0.0.2-dev)
-When we're ready to make the release, the '-dev' part is stripped to provide the true version name (e.g. V0.0.2)
+When release N is in development, `__version__` should say 'vN-dev' (e.g. v0.0.2-dev)
+When we're ready to make the release, the '-dev' part is stripped to provide the true version name (e.g. v0.0.2)
 When the release has been created, `__version__` is incremented, and the '-dev' suffix is re-added.
 
 (At some point this version name shuffling can be automated.)
@@ -19,7 +19,7 @@ When the release has been created, `__version__` is incremented, and the '-dev' 
 A release that isn't ready for production deployment should be flagged as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
 The process: 
 
-make a release (the new title should match the version in __init__.py, but more importantly, should be the next logical number from the last title used). Note that the release title starts with a capital V and the release tag starts with a lower-case v.
+make a release (the new title should match the version in __init__.py, but more importantly, should be the next logical number from the last title used).
 
 Development is performed on feature branches as usual. When complete, feature branches are merged into master.
 
@@ -34,7 +34,7 @@ Development is performed on feature branches as usual. When complete, feature br
  
 Deploying releases: 
 
-The examples below show how to checkout released code install it using pip. Release V0.0.1 is used for demonstration. 
+The examples below show how to checkout released code install it using pip. Release v0.0.1 is used for demonstration. 
 
 To install a release using pip: 
 	pip install git+https://github.com/neurobooth/neurobooth-os@v0.0.1

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -20,7 +20,7 @@ A release that isn't ready for production deployment should be flagged as "pre-r
 
 The process: 
 
-Development is performed on feature branches as usual. When complete, feature branches are merged into master.
+Development is performed on feature branches as usual. When complete, feature branches are merged into master. Frequent merges of small branches simplifies coordination between developers and makes it easier to review code. 
 
 1. To start the release process, update the version in neurobooth_os to match the planned release name. Usually, this just involves stripping the '-dev' string from the current value
 3. The modified `__init__.py` is committed and pushed to master

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -8,6 +8,7 @@ The goals for this process are:
 
 This process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
 The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. In code, the name is stored in a `__version__` attribute in a way that is consistent with Python package naming standards. 
+Specifically, the `__init__.py` module in the neurobooth-os folder holds the attribute.  
 
 Keeping the version name in the code in sync with the release is a key part of the process:
 - When release 0.0.4 is in development, `__version__ = "v0.0.4-dev"`
@@ -20,9 +21,9 @@ A release that isn't ready for production deployment should be flagged as "pre-r
 
 The process: 
 
-Development is performed on feature branches as usual. When complete, feature branches are merged into master. Frequent merges of small branches simplifies coordination between developers and makes it easier to review code. 
+Development is performed on feature branches as usual. When complete, feature branches are merged into master. Frequent merges of small branches simplifies coordination between developers and makes it easier to review code. The rest of the process is as follows:
 
-1. To start the release process, update the version in neurobooth_os to match the planned release name. Usually, this just involves stripping the '-dev' string from the current value
+1. Update the `__version__` in neurobooth_os to match the planned release name, by removing the '-dev' suffix as described above.
 3. The modified `__init__.py` is committed and pushed to master
 4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release" 
 5. Increment the version in `__init__.py` and append the string '-dev' 

--- a/docs/release process.md
+++ b/docs/release process.md
@@ -11,22 +11,20 @@ The release name also appears in the deployed code so anyone looking at the envi
 Specifically, the `__init__.py` module in the neurobooth-os folder holds the attribute.  
 
 Keeping the version name in the code in sync with the release is a key part of the process:
-- When release 0.0.4 is in development, `__version__ = "v0.0.4-dev"`
-- When we're ready to release, the '-dev' part is removed and `__version__ = "v0.0.4"`. This version gets packaged into the release.
-- When the release has been created, `__version__` is incremented, and the '-dev' suffix is restored so that `__version__ = "0.0.5-dev"`.
+- When release 0.0.4 is in development, `__version__ = "v0.0.4"`
+- When the release has been created, `__version__` is incremented: `__version__ = "0.0.5"`. 
 
-(At some point all this version name shuffling can be automated.)
+(At some point this version name shuffling can be automated.)
 
-A release that isn't ready for production deployment should be flagged as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
+A release that isn't ready for production deployment should be flagged in GitHub as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
 
 The process: 
 
 Development is performed on feature branches as usual. When complete, feature branches are merged into master. Frequent merges of small branches simplifies coordination between developers and makes it easier to review code. The rest of the process is as follows:
 
-1. Update the `__version__` in neurobooth_os to match the planned release name, by removing the '-dev' suffix as described above.
-3. The modified `__init__.py` is committed and pushed to master
+1. Make sure that the committed `__version__` in neurobooth_os matches the planned release name.
 4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release". This tags the code in the release to the current state in the git history.
-5. Increment the version in `__init__.py`, append the string '-dev', and commit the changes.
+5. Increment the version in `__init__.py`, and commit the changes so developers can begin working on the next version.
 6. Deploy the candidate release into staging and complete testing 
 6. Publish the release in GitHub 
 7. Deploy the published release into production environment(s). 

--- a/docs/release process.md
+++ b/docs/release process.md
@@ -16,6 +16,8 @@ Keeping the version name in the code in sync with the release is a key part of t
 
 (At some point this version name shuffling can be automated.)
 
+Release numbering should generally follow [Semantic Versioning guidelines](https://semver.org/). Until/unless we plan to publish a release to a public index server, development release names can be used. A development release name consists of the normal three-part numbering system with ".devN" appended. 
+
 A release that isn't ready for production deployment should be flagged in GitHub as "pre-release" when created. The "pre-release" identifier is removed when the release is "published".  
 
 The process: 


### PR DESCRIPTION
Documentation only PR:

The document describes a proposed release process, summarizing recent conversations.

A subsequent PR will attempt to remove hard-coded paths and other impediments to standardizing releases and deployments. 