### PR TITLE
Mbient Reset Script Update

### DIFF
--- a/extras/reset_mbients.bat
+++ b/extras/reset_mbients.bat
@@ -1,2 +1,2 @@
 call C:\Users\ACQ\anaconda3\Scripts\activate.bat C:\Users\ACQ\anaconda3\envs\neurobooth-staging
-call start /W ipython C:\neurobooth-os\extras\reset_mbients.py
+call start /W ipython C:\neurobooth-os\extras\reset_mbients.py --json=~\mbients.json

--- a/extras/reset_mbients.bat
+++ b/extras/reset_mbients.bat
@@ -1,2 +1,3 @@
 call C:\Users\ACQ\anaconda3\Scripts\activate.bat C:\Users\ACQ\anaconda3\envs\neurobooth-staging
-call start /W ipython C:\neurobooth-os\extras\reset_mbients.py --json=~\mbients.json
+call python C:\neurobooth-os\extras\reset_mbients.py --json=%USERPROFILE%\mbients.json
+pause

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -35,6 +35,16 @@ def parse_arguments() -> argparse.Namespace:
         type=int,
         help='Specify a timeout (in seconds) for resetting the devices.'
     )
+    parser.add_argument(
+        '--mac',
+        default=[],
+        required=False,
+        action='append',
+        type=str,
+        help='Instead of scanning for devices, specify the MAC address. '
+             'This argument can be specified multiple times to reset multiple devices.'
+    )
+
     args = parser.parse_args()
 
     if args.scan_timeout <= 0:
@@ -132,15 +142,20 @@ def main():
     logger = make_default_logger()
     args = parse_arguments()
 
-    t0 = time()
-    logger.info('Scanning for devices...')
-    devices = scan_BLE(timeout_sec=args.scan_timeout, n_devices=args.n_devices)
-    logger.info(f'Identified {len(devices)} devices. Scan took {time() - t0:0.1f} sec.')
-    if len(devices) == 0:
-        logger.error('No devices found!')
-        return
-    elif len(devices) < args.n_devices:
-        logger.warning('Not all devices found!')
+    if args.mac:
+        devices = {f'CL-{i}': address for i, address in enumerate(args.mac)}
+        logger.debug(f'Using {len(devices)} devices specified via command line: {devices}')
+    else:
+        t0 = time()
+        logger.info('Scanning for devices...')
+        devices = scan_BLE(timeout_sec=args.scan_timeout, n_devices=args.n_devices)
+        logger.info(f'Identified {len(devices)} devices. Scan took {time() - t0:0.1f} sec.')
+        if len(devices) == 0:
+            logger.error('No devices found!')
+            return
+        elif len(devices) < args.n_devices:
+            logger.warning('Not all devices found!')
+
     for k, v in devices.items():
         logger.debug(f'Device {k} Address: {v}')
 

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -7,7 +7,8 @@ Created on Fri May 27 14:49:22 2022
 
 from mbientlab.metawear import MetaWear, libmetawear
 from time import sleep
-from neurobooth_os.iout.lsl_streamer import scann_BLE
+from neurobooth_os.iout.mbient import scan_BLE
+from neurobooth_os.logging import make_default_logger
 
 
 def connect(device):
@@ -56,17 +57,23 @@ def reset_dev(MAC):
     return True
 
 
-if __name__ == "__main__":
+def main():
+    logger = make_default_logger()
+
     macs = {
         "Mbient_LH_2": "E8:95:D6:F7:39:D2",
         "Mbient_RH_2": "FE:07:3E:37:F5:9C",
         "Mbient_RF_2": "E5:F6:FB:6D:11:8A",
         "Mbient_LF_2": "DA:B0:96:E4:7F:A3",
         "Mbient_BK_1": "D7:B0:7E:C2:A1:23",
-        }
-    
+    }
+
     print('resetting mbients (will take ~ 1 min)...')
-    scann_BLE(2)
+    devices = scan_BLE(2)
+    logger.info(f'Identified {len(devices)} devices')
+    for k, v in devices.items():
+        logger.debug(f'Device {k} Address: {v}')
+
     for k, v in macs.items():
         success = reset_dev(v)
         if not success:
@@ -75,3 +82,7 @@ if __name__ == "__main__":
             print(f"Success in resetting {k} {v}")
 
     sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -88,6 +88,7 @@ class ResetDeviceThread(threading.Thread):
         device = MetaWear(self.address)
 
         success = False
+        self.logger.debug(f'Attempting connection to {self.address}')
         for i in range(self.connect_attempts):
             try:
                 if i > 0:  # Do not immediately try to reconnect if it just failed.
@@ -147,12 +148,13 @@ def main():
             reset_timeout=args.reset_timeout,
         ) for _, address in devices.items()
     ]
+    logger.info(f'Reset in progress...')
     t0 = time()
     for t in reset_threads:
         t.start()
     for t in reset_threads:
         t.join()
-    logger.debug(f'Device reset {time() - t0:0.1f} sec.')
+    logger.info(f'Device reset {time() - t0:0.1f} sec.')
 
     success = [t.address for t in reset_threads if t.success]
     failure = [t.address for t in reset_threads if not t.success]

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -190,7 +190,7 @@ class ResetDeviceProcess(mp.Process):
         :param connect_attempts: The number of times to try to connect to the device before giving up.
         :param reset_timeout: How long to wait for the device to reset before giving up.
         """
-        super().__init__()
+        super().__init__(target=self.run)
         self.device_info = device_info
         self.connect_attempts = connect_attempts
         self.reset_timeout = reset_timeout

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import os
 import sys
 import argparse
+import json
+from typing import Dict, List
 from mbientlab.metawear import MetaWear, libmetawear
 from time import sleep, time
 import threading
@@ -9,21 +12,52 @@ from neurobooth_os.iout.mbient import scan_BLE
 from neurobooth_os.logging import make_default_logger
 
 
-def parse_arguments() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description='Find and reset Mbient wearable devices.')
+DESCRIPTION = """Find and reset Mbient wearable devices.
 
-    group = parser.add_argument_group(title='Scanning Arguments')
+This script has three modes of device discovery:
+    1. Scan: This is the default mode of discovery. The script will scan for nearby BLE devices until it either reaches
+    the timeout or finds the specified number of devices with the Metawear GATT service UUID.
+    Example (scan for either 10 sec or until 5 devices are found):
+        python reset_mbients.py --scan-timeout=10 --n-devices=5
+    
+    2. MAC via command line: MAC addresses can be specified via the command line using the --mac argument. The argument
+    can be specified multiple times to reset multiple devices.
+    Example (reset the devices with MAC addresses E8:95:D6:F7:39:D2 and FE:07:3E:37:F5:9C):
+        python reset_mbients.py --mac=E8:95:D6:F7:39:D2 --mac=FE:07:3E:37:F5:9C
+        
+    3. MAC va JSON file: This is simular to discovery mode 2, except it allows each MAC address to be associated with a
+    device name. The JSON file should be a dictionary where each key is a device name and each value is the
+    corresponding MAC Address.
+    Example (reset the devices in device.json):
+        python reset_mbients.py --json=device.json
+        
+        >>>contents of device.json
+        {
+        "Mbient_LH_2": "E8:95:D6:F7:39:D2",
+        "Mbient_RH_2": "FE:07:3E:37:F5:9C",
+        "Mbient_RF_2": "E5:F6:FB:6D:11:8A",
+        "Mbient_LF_2": "DA:B0:96:E4:7F:A3",
+        "Mbient_BK_1": "D7:B0:7E:C2:A1:23"
+        }
+        <<<
+"""
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+
+    group = parser.add_argument_group(title='Device Discovery')
     group.add_argument(
         '--n-devices',
         default=5,
         type=int,
-        help='The number of expected devices'
+        help='The number of expected devices when scanning. (I.e., stop scanning once this many devices are found.)'
     )
     group.add_argument(
         '--scan-timeout',
         default=10,
         type=int,
-        help='Specify a timeout (in seconds) for identifying the devices.'
+        help='Specify a timeout (in seconds) for scanning for devices.'
     )
     group.add_argument(
         '--mac',
@@ -33,6 +67,13 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         help='Instead of scanning for devices, specify the MAC address. '
              'This argument can be specified multiple times to reset multiple devices.'
+    )
+    group.add_argument(
+        '--json',
+        default=None,
+        type=str,
+        help='Instead of scanning for devices, specify a JSON file containing a dictionary '
+             'of DEVICE_NAME: MAC_ADDRESS pairs.'
     )
 
     group = parser.add_argument_group(title='Reset Arguments')
@@ -64,21 +105,26 @@ def parse_arguments() -> argparse.Namespace:
 
 
 class ResetDeviceThread(threading.Thread):
-    def __init__(self, address: str, connect_attempts: int, reset_timeout: float):
+    def __init__(self, address: str, name: str, connect_attempts: int, reset_timeout: float):
         """
         When started, this thread will try to connect to and reset the specified Mbient device.
 
         :param address: The MAC address of the device to reset.
+        :param name: The device's name (for logging).
         :param connect_attempts: The number of times to try to connect to the device before giving up.
         :param reset_timeout: How long to wait for the device to reset before giving up.
         """
         super().__init__()
         self.address = address
+        self.name = name
         self.connect_attempts = connect_attempts
         self.reset_timeout = reset_timeout
         self.logger = logging.getLogger('default')
         self.disconnect_event = threading.Event()
         self.success = False
+
+    def format_message(self, msg: str) -> str:
+        return f'{self.name} [{self.address}]: {msg}'
 
     def run(self) -> None:
         t0 = time()
@@ -90,9 +136,9 @@ class ResetDeviceThread(threading.Thread):
             self.logger.exception(e)
         finally:
             if self.success:
-                self.logger.debug(f'Reset for {self.address} took {time() - t0:0.1f} sec.')
+                self.logger.debug(self.format_message(f'Reset took {time() - t0:0.1f} sec.'))
             else:
-                self.logger.debug(f'Reset timeout reached for {self.address}')
+                self.logger.debug(self.format_message(f'Reset timed out!'))
 
     def connect(self) -> MetaWear:
         """
@@ -103,7 +149,7 @@ class ResetDeviceThread(threading.Thread):
         device = MetaWear(self.address)
 
         success = False
-        self.logger.debug(f'Attempting connection to {self.address}')
+        self.logger.debug(self.format_message(f'Attempting Connection'))
         for i in range(self.connect_attempts):
             try:
                 if i > 0:  # Do not immediately try to reconnect if it just failed.
@@ -113,16 +159,16 @@ class ResetDeviceThread(threading.Thread):
                 success = True
                 break
             except Exception as e:
-                self.logger.debug(f'Failed to connect to {self.address} on attempt {i+1}: {e}')
+                self.logger.debug(self.format_message(f'Failed to connect on attempt {i + 1}: {e}'))
 
         if not success:
-            raise Exception(f'Unable to connect to {self.address}')
+            raise Exception(self.format_message(f'Unable to connect!'))
 
         device.on_disconnect = lambda status: self.on_disconnect(status)
         return device
 
     def on_disconnect(self, status) -> None:
-        self.logger.debug(f'Disconnected {self.address} with status {status}.')
+        self.logger.debug(self.format_message(f'Disconnected with status {status}.'))
         self.disconnect_event.set()
 
     @staticmethod
@@ -142,34 +188,83 @@ class ResetDeviceThread(threading.Thread):
         libmetawear.mbl_mw_debug_disconnect(board)
 
 
-def main():
-    logger = make_default_logger()
-    args = parse_arguments()
+ADDRESS_MAP = Dict[str, str]  # Type alias for return of discovery functions
 
-    if args.mac:
-        devices = {f'CL-{i}': address for i, address in enumerate(args.mac)}
-        logger.debug(f'Using {len(devices)} devices specified via command line: {devices}')
+
+class DeviceDiscoveryException(Exception):
+    pass
+
+
+def device_discovery(args: argparse.Namespace) -> ADDRESS_MAP:
+    if args.json is not None:
+        devices = discovery_json(args.json)
+    elif args.mac:
+        devices = discovery_mac(args.mac)
     else:
-        t0 = time()
-        logger.info('Scanning for devices...')
-        devices = scan_BLE(timeout_sec=args.scan_timeout, n_devices=args.n_devices)
-        logger.info(f'Identified {len(devices)} devices. Scan took {time() - t0:0.1f} sec.')
-        if len(devices) == 0:
-            logger.error('No devices found!')
-            return
-        elif len(devices) < args.n_devices:
-            logger.warning('Not all devices found!')
+        devices = discovery_scan(timeout_sec=args.scan_timeout, n_devices=args.n_devices)
 
+    logger = logging.getLogger('default')
     for k, v in devices.items():
         logger.debug(f'Device {k} Address: {v}')
 
+    return devices
+
+
+def discovery_scan(timeout_sec: float, n_devices: int) -> ADDRESS_MAP:
+    logger = logging.getLogger('default')
+    logger.info('Scanning for devices...')
+
+    t0 = time()
+    devices = scan_BLE(timeout_sec=timeout_sec, n_devices=n_devices)
+    logger.info(f'Scan took {time() - t0:0.1f} sec.')
+
+    if len(devices) == 0:
+        raise DeviceDiscoveryException('No devices found!')
+    elif len(devices) < n_devices:
+        logger.warning(f'Only {len(devices)} of {n_devices} devices found!')
+    else:
+        logger.info(f'Scan identified {len(devices)} devices.')
+
+    return devices
+
+
+def discovery_mac(addresses: List[str]) -> ADDRESS_MAP:
+    logger = logging.getLogger('default')
+    devices = {f'CL-{i}': address for i, address in enumerate(addresses)}
+    logger.info(f'Using {len(devices)} devices specified via command line.')
+    return devices
+
+
+def discovery_json(file: str) -> ADDRESS_MAP:
+    logger = logging.getLogger('default')
+
+    with open(file, 'r') as f:
+        devices = json.load(f)
+
+    # File validation checks
+    if not isinstance(devices, dict):
+        raise DeviceDiscoveryException(f'{file} should contain a dictionary mapping device names to MAC addresses.')
+    if len(devices) == 0:
+        raise DeviceDiscoveryException(f'No devices specified in {file}!')
+    for k, v in devices.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise DeviceDiscoveryException(f'{file} should contain a dictionary mapping device names to MAC addresses.')
+
+    logger.info(f'Using {len(devices)} devices specified in: {file}')
+    return devices
+
+
+def reset_devices(args: argparse.Namespace, devices: ADDRESS_MAP) -> None:
     reset_threads = [
         ResetDeviceThread(
             address=address,
+            name=name,
             connect_attempts=args.n_connect_attempts,
             reset_timeout=args.reset_timeout,
-        ) for _, address in devices.items()
+        ) for name, address in devices.items()
     ]
+
+    logger = logging.getLogger('default')
     logger.info(f'Reset in progress...')
     t0 = time()
     for t in reset_threads:
@@ -185,11 +280,20 @@ def main():
         logger.warning(f'Failed to reset {len(failure)} devices: {failure}')
 
 
-if __name__ == "__main__":
+def main():
+    logger = make_default_logger()
     try:
-        main()
+        args = parse_arguments()
+        devices = device_discovery(args)
+        reset_devices(args, devices)
+    except DeviceDiscoveryException as e:
+        logger.exception(e)
+        raise e
     except Exception as e:
-        logger = logging.getLogger('default')
         logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
         logger.critical(e, exc_info=sys.exc_info())
         raise e
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -198,6 +198,7 @@ class ResetDeviceProcess(mp.Process):
         manager = mp.Manager()
         self.disconnect_event = manager.Event()
         self.namespace = manager.Namespace()  # Used to pass variables between processes
+        self.namespace.success = False
 
     def format_message(self, msg: str) -> str:
         return f'{self.device_info.name} <{self.device_info.address}>: {msg}'

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -12,7 +12,7 @@ from neurobooth_os.logging import make_default_logger
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Find and reset Mbient wearable devices.')
 
-    group = parser.add_argument_group(help='Scanning Arguments')
+    group = parser.add_argument_group(title='Scanning Arguments')
     group.add_argument(
         '--n-devices',
         default=5,
@@ -35,7 +35,7 @@ def parse_arguments() -> argparse.Namespace:
              'This argument can be specified multiple times to reset multiple devices.'
     )
 
-    group = parser.add_argument_group(help='Reset Arguments')
+    group = parser.add_argument_group(title='Reset Arguments')
     group.add_argument(
         '--n-connect-attempts',
         default=3,
@@ -48,7 +48,7 @@ def parse_arguments() -> argparse.Namespace:
         type=int,
         help='Specify a timeout (in seconds) for resetting the devices.'
     )
-    
+
     args = parser.parse_args()
 
     if args.scan_timeout <= 0:

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -48,7 +48,7 @@ class DeviceInfo(NamedTuple):
 
 
 def parse_arguments() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser = argparse.ArgumentParser(description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     group = parser.add_argument_group(title='Device Discovery')
     group.add_argument(

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -11,31 +11,21 @@ from neurobooth_os.logging import make_default_logger
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Find and reset Mbient wearable devices.')
-    parser.add_argument(
+
+    group = parser.add_argument_group(help='Scanning Arguments')
+    group.add_argument(
         '--n-devices',
         default=5,
         type=int,
         help='The number of expected devices'
     )
-    parser.add_argument(
-        '--n-connect-attempts',
-        default=3,
-        type=int,
-        help='The number of times to attempt to connect to a device.'
-    )
-    parser.add_argument(
+    group.add_argument(
         '--scan-timeout',
         default=10,
         type=int,
         help='Specify a timeout (in seconds) for identifying the devices.'
     )
-    parser.add_argument(
-        '--reset-timeout',
-        default=10,
-        type=int,
-        help='Specify a timeout (in seconds) for resetting the devices.'
-    )
-    parser.add_argument(
+    group.add_argument(
         '--mac',
         default=[],
         required=False,
@@ -45,6 +35,20 @@ def parse_arguments() -> argparse.Namespace:
              'This argument can be specified multiple times to reset multiple devices.'
     )
 
+    group = parser.add_argument_group(help='Reset Arguments')
+    group.add_argument(
+        '--n-connect-attempts',
+        default=3,
+        type=int,
+        help='The number of times to attempt to connect to a device.'
+    )
+    group.add_argument(
+        '--reset-timeout',
+        default=10,
+        type=int,
+        help='Specify a timeout (in seconds) for resetting the devices.'
+    )
+    
     args = parser.parse_args()
 
     if args.scan_timeout <= 0:

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -126,7 +126,6 @@ class ResetDeviceThread(threading.Thread):
         libmetawear.mbl_mw_macro_erase_all(board)
         libmetawear.mbl_mw_debug_reset_after_gc(board)
         libmetawear.mbl_mw_debug_disconnect(board)
-        device.disconnect()
 
 
 def main():

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -6,26 +6,8 @@ Created on Tue Nov 24 15:41:42 2020
 """
 import time
 import logging
-
 from neurobooth_os import config
 from neurobooth_os.iout import metadator as meta
-
-from mbientlab.warble import BleScanner
-from time import sleep
-
-
-def scann_BLE(sleep_period=10):
-    print("scanning for devices...")
-    devices = {}
-
-    def handler(result):
-        devices[result.mac] = result.name
-
-    BleScanner.set_handler(handler)
-    BleScanner.start()
-
-    sleep(sleep_period)
-    BleScanner.stop()
 
 
 def start_lsl_threads(node_name, collection_id="mvp_030", win=None, conn=None):
@@ -61,7 +43,7 @@ def start_lsl_threads(node_name, collection_id="mvp_030", win=None, conn=None):
     for dc in kwarg_devs.values():
         kwarg_alldevs.update(dc)
 
-    scann_BLE()
+    # scan_BLE()
 
     streams = {}
     if node_name == "acquisition":

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -4,6 +4,7 @@ import uuid
 from ctypes import c_void_p, cast, POINTER
 from time import sleep
 from threading import Event, Lock
+import multiprocessing as mp
 from sys import argv
 import logging
 from typing import Dict
@@ -24,8 +25,8 @@ def scan_BLE(timeout_sec: float = 10, n_devices: int = 5) -> Dict[str, str]:
     :returns: A dictionary of device names as keys and MAC addresses as values.
     """
     devices = {}
-    event = Event()
-    lock = Lock()
+    event = mp.Event()
+    lock = mp.Lock()
 
     def handler(result):
         """Callback function invoked when a new device is identified."""


### PR DESCRIPTION
This is code for a faster, parallelized mbient reset script. Instead of hardcoded MAC addresses, three device discovery types are supported. The script may be further refactored at a later date to move the connect and reset logic into mbient.py.

The BLE scan has also been reworked to be actually useful and has been commented out of the lsl_streamer start_threads sequence.