### PR TITLE
Reset Mbient Task

### DIFF
--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -542,17 +542,17 @@ class Mbient:
         Callback for disconnect events. Attempt to reconnect to and configure the device.
         :param status: The status code passed by the callback handler.
         """
-        print(f"-WARNING mbient- {self.dev_name} diconnected prematurely")
+        print(f"-WARNING mbient- {self.dev_name} diconnected prematurely")  # Send message to GUI terminal
         self.logger.warning(self.format_message(f'Disconnected Prematurely (status={status})'))
 
         try:
             self.connect(n_attempts=3, retry_delay_sec=0.5)
             self.setup()
         except MbientFailedConnection as e:
-            print(f"Failed to reconnect {self.dev_name}... bye")
+            print(f"Failed to reconnect {self.dev_name}... bye")  # Send message to GUI terminal
             self.logger.error(self.format_message(f'Failed to Reconnect: {e}'))
         except Exception as e:
-            print(f"Couldn't setup for {self.dev_name}")
+            print(f"Couldn't setup for {self.dev_name}")  # Send message to GUI terminal
             self.logger.error(self.format_message(f'Error during reconnect: {e}'), exc_info=sys.exc_info())
 
     def reset(self, timeout_sec: float = 10) -> None:
@@ -579,11 +579,15 @@ class Mbient:
             f'Disconnect with status={status}'
         ))
 
-    def reset_and_reconnect(self, timeout_sec: float = 10) -> None:
+    def reset_and_reconnect(self, timeout_sec: float = 10) -> bool:
         """
         Stop streaming, perform a board reset (which disconnects the device), reconnect, and resume streaming.
         :param timeout_sec: How long to wait for the reset to occur before timing out.
+        :return: Whether the device is connected after the function call is complete.
         """
+        print(f'Resetting {self.dev_name}.')  # Send message to GUI terminal
+        self.logger.info(self.format_message('Resetting'))
+
         try:
             was_streaming = self.streaming
             if was_streaming:
@@ -595,9 +599,12 @@ class Mbient:
 
             if was_streaming:
                 self.start()
+
+            self.logger.info(self.format_message(f'Reset Completed'))
         except Exception as e:
             self.logger.error(self.format_message(f'Error during reset and reconnect: {e}'))
-            raise e
+        finally:
+            return self.device_wrapper.is_connected
 
     def prepare(self) -> bool:
         """
@@ -624,7 +631,7 @@ class Mbient:
 
             return True
         except (MbientFailedConnection, MbientResetTimeout) as e:
-            print(f"Failed to connect mbient {self.dev_name}")
+            print(f"Failed to connect mbient {self.dev_name}")  # Send message to GUI terminal
             self.logger.error(self.format_message(str(e)))
             return False
         except Exception as e:
@@ -685,7 +692,7 @@ class Mbient:
         libmetawear.mbl_mw_datasignal_subscribe(processor, None, self.callback)
         self.subscribed_signals.append(processor)
 
-        print(f"Mbient {self.dev_name} setup")
+        print(f"Mbient {self.dev_name} setup")  # Send message to GUI terminal
         self.logger.debug(self.format_message('Setup Completed'))
 
     def log_battery_info(self) -> None:

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -111,14 +111,13 @@ def run_acq(logger):
             connx.send(frame)
             logger.debug('Frame preview sent')
 
+        # TODO: Both reset_mbients and frame_preview should be reworked as dynamic hooks that register a callback
         elif "reset_mbients" in data:
             reset_results = {}
             for stream_name, stream in streams.items():
                 if 'mbient' in stream_name.lower():
-                    reset_results[stream_name] = True  # TODO: Implement actual reset logic
-                else:
-                    reset_results[stream_name] = False  # TODO: Temporary
-            connx.send(json.dumps(reset_results))
+                    reset_results[stream_name] = stream.reset_and_reconnect()
+            connx.send(json.dumps(reset_results).encode('utf-8'))
             logger.debug('Reset results sent')
 
         elif "record_start" in data:

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -7,6 +7,7 @@ import cv2
 import numpy as np
 from pylsl import local_clock
 import logging
+import json
 
 import neurobooth_os
 from neurobooth_os import config
@@ -109,6 +110,16 @@ def run_acq(logger):
             frame = frame_prefix + frame
             connx.send(frame)
             logger.debug('Frame preview sent')
+
+        elif "reset_mbients" in data:
+            reset_results = {}
+            for stream_name, stream in streams.items():
+                if 'mbient' in stream_name.lower():
+                    reset_results[stream_name] = True  # TODO: Implement actual reset logic
+                else:
+                    reset_results[stream_name] = False  # TODO: Temporary
+            connx.send(json.dumps(reset_results))
+            logger.debug('Reset results sent')
 
         elif "record_start" in data:
             # "record_start::filename::task_id" FILENAME = {subj_id}_{obs_id}

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -124,6 +124,7 @@ def run_stm(logger):
             tasks, subj_id, session_id = data.split(":")[1:]
             log_task["log_session_id"] = session_id
 
+            # Shared task keyword arguments
             task_karg = {
                 "win": win,
                 "path": server_config["local_data_dir"] + f"{subject_id_date}/",
@@ -131,8 +132,14 @@ def run_stm(logger):
                 "marker_outlet": streams["marker"],
                 "prompt": True,
             }
-            if streams.get("Eyelink"):
+
+            # Pass device streams as keyword arguments if needed.
+            # TODO: This needs to be cleaned up and not hard-coded
+            if streams.get("Eyelink"):  # For eye tracker tasks
                 task_karg["eye_tracker"] = streams["Eyelink"]
+            task_karg['mbients'] = {  # For the mbient reset task
+                stream_name: stream for stream_name, stream in streams.items() if 'mbient' in stream_name.lower()
+            }
 
             if presented:
                 task_func_dict = get_task_funcs(collection_id, conn)

--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -1,0 +1,67 @@
+from typing import Optional, Dict
+from enum import IntEnum, auto
+from neurobooth_os.tasks.task import Task
+from neurobooth_os.tasks.utils import get_keys
+from psychopy import visual
+from neurobooth_os.iout.mbient import Mbient
+
+
+class UserInputEvent(IntEnum):
+    CONTINUE = auto()
+    RESET = auto()
+
+
+class MbientResetPauseError(Exception):
+    pass
+
+
+class MbientResetPause(Task):
+    """Pause the session so that the Mbient wearables can be reset to improve data quality."""
+
+    def __init__(
+            self,
+            mbients: Optional[Dict[str, Mbient]] = None,
+            continue_key: str = 'return',
+            reset_key: str = 'r',
+            **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.mbients = mbients
+        self.continue_key = continue_key
+        self.reset_key = reset_key
+
+        self._screen = visual.TextStim(
+            self.win,
+            "Please wait while we reset the wearable devices.",
+            height=32,
+            color=[1, 1, 1],
+            pos=(0, 32),
+            units="pix",
+        )
+
+    def run(self, **kwargs):
+        # Present Intro Screen
+        self._screen.draw()
+        self.win.flip()
+
+        try:  # Perform resets until the continue key is pressed
+            event = self.wait_for_key()
+            while event == UserInputEvent.RESET:
+                self.reset_mbients()
+                event = self.wait_for_key()
+        except MbientResetPauseError as e:
+            self.logger.exception(e)
+
+        # Clean Up
+
+    def wait_for_key(self) -> UserInputEvent:
+        key = get_keys(keyList=[self.continue_key, self.reset_key])
+        if key == self.continue_key:
+            return UserInputEvent.CONTINUE
+        elif key == self.reset_key:
+            return UserInputEvent.RESET
+        else:
+            raise MbientResetPauseError(f'Reached "impossible" case with key={key}')
+
+    def reset_mbients(self) -> None:
+        pass

--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -30,13 +30,17 @@ class MbientResetPause(Task):
         self.continue_key = continue_key
         self.reset_key = reset_key
 
+        self.header_text_size = 48
+        self.text_size = 32
+
+        width, height = self.win.size
         self._screen = visual.TextStim(
             self.win,
             "Please wait while we reset the wearable devices.",
-            height=32,
+            height=48,
             color=[1, 1, 1],
-            pos=(0, (-self.win.size[1] / 2) + 32),
-            wrapWidth=1920,
+            pos=(0, (height / 2) - (self.header_text_size * 1.5)),
+            wrapWidth=width,
             units="pix",
         )
 
@@ -62,7 +66,7 @@ class MbientResetPause(Task):
         elif self.reset_key in keys:
             return UserInputEvent.RESET
         else:
-            raise MbientResetPauseError(f'Reached "impossible" case with key={key}')
+            raise MbientResetPauseError(f'Reached "impossible" case with keys: {keys}')
 
     def reset_mbients(self) -> None:
         pass

--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -26,7 +26,7 @@ class MbientResetPause(Task):
             **kwargs
     ):
         super().__init__(**kwargs)
-        self.mbients = mbients
+        self.mbients = mbients  # TODO: Need some way to signal ACQ mbients to reset
         self.continue_key = continue_key
         self.reset_key = reset_key
 
@@ -35,7 +35,8 @@ class MbientResetPause(Task):
             "Please wait while we reset the wearable devices.",
             height=32,
             color=[1, 1, 1],
-            pos=(0, 32),
+            pos=(0, (-self.win.size[1] / 2) + 32),
+            wrapWidth=1920,
             units="pix",
         )
 
@@ -55,10 +56,10 @@ class MbientResetPause(Task):
         # Clean Up
 
     def wait_for_key(self) -> UserInputEvent:
-        key = get_keys(keyList=[self.continue_key, self.reset_key])
-        if key == self.continue_key:
+        keys = get_keys(keyList=[self.continue_key, self.reset_key])
+        if self.continue_key in keys:
             return UserInputEvent.CONTINUE
-        elif key == self.reset_key:
+        elif self.reset_key in keys:
             return UserInputEvent.RESET
         else:
             raise MbientResetPauseError(f'Reached "impossible" case with key={key}')

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -8,9 +8,9 @@ License: BSD-3-Clause
 """
 
 from __future__ import absolute_import, division
-from psychopy import logging
-
-logging.console.setLevel(logging.CRITICAL)
+from psychopy import logging as psychopy_logging
+psychopy_logging.console.setLevel(psychopy_logging.CRITICAL)
+import logging
 import os.path as op
 from datetime import datetime
 import time
@@ -38,6 +38,7 @@ class Task:
         countdown=None,
         **kwargs,
     ):
+        self.logger = logging.getLogger('session')
 
         # Common markers
         self.marker_task_start = "Task_start"


### PR DESCRIPTION
Created a new task that will reset and reconnect the Mbients. The intent is that we will edit the database to replace coord_pause_1 with this new task. (Keeping the name and just redirected the function call.)

RCs will use the keyboard to trigger a reset and/or continue. Status is output to both the GUI and the stimulus screen. After continuing, the task will (optionally) show the old coordinate pause screen, effectively merging this task with the pause.

Notes:
- A bit of a wrinkle is that Mbients are on both STM and ACQ. They unfortunately have to be handled a bit differently for each machine. A new event was added to server_acq.py to facilitate the reset. This, alongside the frame-preview event, raises the need for a more generic way of registering device-specific events with the servers.
- Mbient reset is currently sequential. If needed, we may have to go back and parallelize this process. The same multiprocessing for the reset_mbient.py script does not work here because of multiprocessing shennanigans (cannot pickle the MetaWear objects); though multithreading would probably be OK.
- Need to test on production one Friday to make sure this works well with all five devices. Works fine on staging.