### PR TITLE
Reset task change

### DIFF
--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -102,10 +102,10 @@ class MbientResetPause(Task):
             f'{self.skip_key.upper()} to skip.'
         )
 
-        keys = get_keys([self.continue_key, self.skip_key, self.repeat_key])
+        keys = get_keys([self.continue_key, self.skip_key])
         if self.skip_key in keys:
             return TaskState.END_SCREEN
-        elif (self.continue_key in keys) or (self.repeat_key in keys):  # Also accept repeat key for convenience
+        elif self.continue_key in keys:
             return self.reset_mbient_wrapper()
         else:
             self.logger.error(f'Unreachable case! keys={keys}')

--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -21,7 +21,19 @@ class MbientResetPauseError(Exception):
 
 
 class MbientResetPause(Task):
-    """Pause the session so that the Mbient wearables can be reset to improve data quality."""
+    """
+    Pause the session so that the Mbient wearables can be reset to improve data quality.
+
+    This pause-like task has three phases/states.
+    These states ensure that pressing the continue key will always produce a reasonable default effect.
+    1. RESET_NO_SUCCESS: The initial state. The continue key will trigger a reset. If the reset is successful, the state
+        will advance to RESET_POST_SUCCESS. If the skip key is pressed instead, the state will advance to END_SCREEN
+        without performing a reset.
+    2. RESET_POST_SUCCESS: The continue key will advance to END_SCREEN without performing a reset. If a repeat is
+        desired, the repeat key will advance to either RESET_NO_SUCCESS or RESET_POST_SUCCESS depending on whether the
+        reset was successful.
+    3. END_SCREEN: Simply wait for the continue key to be pressed.
+    """
 
     def __init__(
             self,

--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Optional, Dict, List, Callable
+from typing import Optional, Dict, List
 from enum import IntEnum, auto
 from concurrent.futures import ThreadPoolExecutor, wait
 from neurobooth_os.tasks.task import Task
@@ -13,7 +13,7 @@ from neurobooth_os.netcomm import socket_message
 class TaskState(IntEnum):
     RESET_NO_SUCCESS = auto()
     RESET_POST_SUCCESS = auto()
-    END_SCREEN = auto
+    END_SCREEN = auto()
 
 
 class MbientResetPauseError(Exception):


### PR DESCRIPTION
The Mbient reset task flow has been reworked. RETURN will now trigger a reset and advance through all steps (assuming all Mbients successfully reconnect). Q will skip the reset. R will repeat the reset if the prior round was successful. (Leaving this as R as it will be consistent with other task repeats and we are planning to remap the button board.)

The state logic has become more complex because of the need to check if the previous round of resets was successful. Hopefully the transitions and logic are clear.