### PR TITLE
Mbient Fixes

### DIFF
--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -508,13 +508,13 @@ class Mbient:
         (The alternative is to physically push the button on the devices or scan for devices from a Windows computer.)
         We only need to do this once, so this function ensures it is only done once per machine/server.
         """
-        with self.SCAN_LOCK:
-            if self.SCAN_PERFORMED:  # Only need to scan once if multiple devices are present
+        with Mbient.SCAN_LOCK:
+            if Mbient.SCAN_PERFORMED:  # Only need to scan once if multiple devices are present
                 return
             self.logger.debug('Performing BLE Scan')
             ble_devices = scan_BLE(timeout_sec=10)
             self.logger.debug(f'BLE scan found {len(ble_devices)} devices: {[mac for _, mac in ble_devices.items()]}')
-            self.SCAN_PERFORMED = True
+            Mbient.SCAN_PERFORMED = True
 
     def connect(self, n_attempts: Optional[int] = None, retry_delay_sec: Optional[float] = None) -> None:
         """
@@ -817,7 +817,7 @@ def test_script() -> None:
 
     logger.info(f'Creating Device {args.name} at {args.mac}')
     device = Mbient(mac=args.mac, dev_name=args.name)
-    device.SCAN_PERFORMED = True  # Make repeated runs of test scrip faster; comment out if needed.
+    Mbient.SCAN_PERFORMED = True  # Make repeated runs of test script faster; comment out if needed.
 
     def _test_data_handler(epoch: float, acc: Any, gyro: Any) -> None:
         """Prints data to the console"""

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -159,7 +159,7 @@ def run_acq(logger):
 
             # Attempt to reconnect Mbients if disconnected
             Mbient.task_start_reconnect([
-                stream for stream_name, stream in streams
+                stream for stream_name, stream in streams.items()
                 if 'Mbient' in stream_name
             ])
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -126,6 +126,11 @@ def run_acq(logger):
                 if 'mbient' in stream_name.lower()
             }
 
+            if len(mbient_streams) == 0:
+                logger.debug('No mbients to reset.')
+                connx.send(json.dumps({}).encode('utf-8'))
+                continue
+
             with ThreadPoolExecutor(max_workers=len(mbient_streams)) as executor:
                 # Begin concurrent reset of devices
                 reset_results = {

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -20,6 +20,7 @@ from neurobooth_os.iout.lsl_streamer import (
     close_streams,
     reconnect_streams,
 )
+from neurobooth_os.iout.mbient import Mbient
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.log_manager import make_session_logger
 
@@ -150,14 +151,11 @@ def run_acq(logger):
                         except:
                             continue
 
-            for k in streams.keys():  # Attempt to reconnect mbients if disconnected
-                if "Mbient" in k:
-                    try:
-                        if not streams[k].device_wrapper.is_connected:
-                            streams[k].attempt_reconnect()
-                    except Exception as e:
-                        print(e)
-                        pass
+            # Attempt to reconnect Mbients if disconnected
+            Mbient.task_start_reconnect([
+                stream for stream_name, stream in streams
+                if 'Mbient' in stream_name
+            ])
 
             elapsed_time = time() - t0
             print(f"Device start took {elapsed_time:.2f}")

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -5,7 +5,6 @@ from time import time, sleep
 from collections import OrderedDict
 import cv2
 import numpy as np
-from typing import Dict, Any
 from concurrent.futures import ThreadPoolExecutor, wait
 from pylsl import local_clock
 import logging

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -5,6 +5,7 @@ from time import time
 from datetime import datetime
 import copy
 from collections import OrderedDict  # NOT an unused import, very naughtily used by an eval
+from concurrent.futures import ThreadPoolExecutor, wait
 
 from psychopy import prefs
 
@@ -21,6 +22,7 @@ from neurobooth_os.iout.lsl_streamer import (
     reconnect_streams,
 )
 from neurobooth_os.iout import metadator as meta
+from neurobooth_os.iout.mbient import Mbient
 
 from neurobooth_os.netcomm import (
     socket_message,
@@ -205,36 +207,32 @@ def run_stm(logger):
                 print(f"Waiting for CTR took: {elapsed_time:.2f}")
                 logger.info(f'Waiting for CTR took: {elapsed_time:.2f}')
 
-                # Start eyetracker if device in task
-                if streams.get("Eyelink") and any(
-                    "Eyelink" in d for d in list(task_devs_kw[task])
-                ):
-                    fname = f"{task_karg['path']}/{subject_id_date}_{tsk_strt_time}_{t_obs_id}.edf"
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    # Start recording on ACQ in parallel to starting on STM
+                    logger.info(f'SENDING record_start TO ACQ')
+                    acq_result = executor.submit(
+                        socket_message,
+                        f"record_start::{subject_id_date}_{tsk_strt_time}_{t_obs_id}::{task}",
+                        "acquisition",
+                        wait_data=10,
+                    )
 
-                    # if not calibration record with start method
-                    if "calibration_task" in task:
-                        this_task_kwargs.update(
-                            {"fname": fname, "instructions": calib_instructions}
-                        )
-                    else:
-                        streams["Eyelink"].start(fname)
+                    # Start eyetracker if device in task
+                    if "Eyelink" in streams and any("Eyelink" in d for d in list(task_devs_kw[task])):
+                        fname = f"{task_karg['path']}/{subject_id_date}_{tsk_strt_time}_{t_obs_id}.edf"
+                        if "calibration_task" in task:  # if not calibration record with start method
+                            this_task_kwargs.update({"fname": fname, "instructions": calib_instructions})
+                        else:
+                            streams["Eyelink"].start(fname)
 
-                # Start rec in ACQ and run task
-                logger.info(f'SENDING record_start TO ACQ')
-                _ = socket_message(
-                    f"record_start::{subject_id_date}_{tsk_strt_time}_{t_obs_id}::{task}",
-                    "acquisition",
-                    wait_data=10,
-                )
+                    # Attempt to reconnect Mbients if disconnected
+                    Mbient.task_start_reconnect([
+                        stream for stream_name, stream in streams
+                        if 'Mbient' in stream_name
+                    ])
 
-                for k in streams.keys():  # Attempt to reconnect mbients if disconnected
-                    if "Mbient" in k:
-                        try:
-                            if not streams[k].device_wrapper.is_connected:
-                                streams[k].attempt_reconnect()
-                        except Exception as e:
-                            print(e)
-                            pass
+                    wait([acq_result])  # Wait for ACQ to finish
+                    acq_result.result()  # Raise any exceptions swallowed by the executor
 
                 if len(tasks) == 0:
                     this_task_kwargs.update({"last_task": True})
@@ -249,24 +247,18 @@ def run_stm(logger):
                 events = tsk_fun.run(**this_task_kwargs)
                 logger.debug(f"TASK FUNCTION RETURNED")
 
-                # Stop rec in ACQ
-                t0 = t00 = time()
-                logger.info(f'SENDING record_stop TO ACQ')
-                _ = socket_message("record_stop", "acquisition", wait_data=15)
-                elapsed_time = time() - t0
-                print(f"ACQ stop took: {elapsed_time:.2f}")
-                logger.info(f"ACQ stop took: {elapsed_time:.2f}")
-                # mbient stop streaming
-                for k in streams.keys():
-                    if "Mbient" in k:
-                        streams[k].lsl_push = False
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    # Stop recording on ACQ in parallel to stopping on STM
+                    logger.info(f'SENDING record_stop TO ACQ')
+                    acq_result = executor.submit(socket_message, "record_stop", "acquisition", wait_data=15)
 
-                # Stop eyetracker
-                if streams.get("Eyelink") and any(
-                    "Eyelink" in d for d in list(task_devs_kw[task])
-                ):
-                    if "calibration_task" not in task:
-                        streams["Eyelink"].stop()
+                    # Stop eyetracker
+                    if "Eyelink" in streams and any("Eyelink" in d for d in list(task_devs_kw[task])):
+                        if "calibration_task" not in task:
+                            streams["Eyelink"].stop()
+
+                    wait([acq_result])  # Wait for ACQ to finish
+                    acq_result.result()  # Raise any exceptions swallowed by the executor
 
                 # Signal CTR to start LSL rec and wait for start confirmation
                 print(f"Finished task: {task}")

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -227,7 +227,7 @@ def run_stm(logger):
 
                     # Attempt to reconnect Mbients if disconnected
                     Mbient.task_start_reconnect([
-                        stream for stream_name, stream in streams
+                        stream for stream_name, stream in streams.items()
                         if 'Mbient' in stream_name
                     ])
 

--- a/neurobooth_os/tasks/mbient_reset.py
+++ b/neurobooth_os/tasks/mbient_reset.py
@@ -126,7 +126,15 @@ class MbientResetPause(Task):
 
             # Wait for all resets to complete, then resolve the futures
             wait([acq_results, *stm_results.values()])
-            acq_results = json.loads(acq_results.result())  # Parse result from ACQ
+
+            # Parse result from ACQ
+            acq_results = acq_results.result()
+            if acq_results is not None:
+                acq_results = json.loads(acq_results)
+            else:
+                self.logger.warn('Received None response from ACQ reset_mbients.')
+                acq_results = {}
+
             stm_results = {stream_name: result.result() for stream_name, result in stm_results.items()}
 
             # Combine results from all serves


### PR DESCRIPTION
An assortment of mbient-related fixes. Device startup is still sequential (want to do alongside a slightly more involved refactoring of LSL streamer).

Changes:
- BLE Scan now properly only happens once on each server.
- Refactored the reconnect attempt at the start of each task.
    - These now happen in parallel on each machine
    - These now only try to reconnect once instead of 3 times every task to prevent major session slowdown.
    - Additional print statements to the GUI terminal
- **Device start and stop now happens in on ACQ and STM at the same time.** Previously, ACQ would start devices and then STM. Now, STM sends the message to ACQ and moves along to do its devices. It then waits for the response from ACQ before moving on. This should improve task start/stop times in general.
- Cleaned up handling of camera start/stop in ACQ while I was in the area.

Need to test changes regarding Mbient disconnect behavior in person.
