### PR TITLE
System resource log

### DIFF
--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -2,7 +2,10 @@ import os
 import logging
 import sys
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List, Dict, Any
+import psutil
+from threading import Thread, Event
+import json
 
 from neurobooth_os.config import neurobooth_config
 
@@ -70,3 +73,96 @@ def make_default_logger(
 
     logger.setLevel(log_level)
     return logger
+
+
+class SystemResourceLogger(Thread):
+    """Logs CPU, network, and disk usage at regular intervals."""
+    LOG_FORMAT = logging.Formatter('[%(asctime)s] %(message)s')
+
+    def __init__(self, session_folder: str, machine_name: str, log_interval_sec: float = 10):
+        """
+        Create a new system resource logging thread.
+        :param session_folder: The folder to save the log to.
+        :param machine_name: The name of the machine the thread is running on.
+        :param log_interval_sec: How often to log resource usage (in seconds).
+        """
+        super().__init__()
+        self.logger = SystemResourceLogger.__create_log(session_folder, machine_name)
+        self.log_interval_sec = log_interval_sec
+        self.sleep_event = Event()
+
+    @staticmethod
+    def __create_log(session_folder: str, machine_name: str) -> logging.Logger:
+        logger = logging.getLogger('resource_log')
+        file_handler = logging.FileHandler(
+            os.path.join(session_folder, f'{machine_name}_system_resource.log'), mode='a',
+        )
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(SystemResourceLogger.LOG_FORMAT)
+        logger.addHandler(file_handler)
+        logger.setLevel(logging.DEBUG)
+        return logger
+
+    def run(self) -> None:
+        # Perform initial calls that return meaningless data
+        psutil.cpu_percent(percpu=True)
+
+        # Main logging loop
+        while not self.sleep_event.wait(self.log_interval_sec):  # Will return True if event set by stop()
+            results = {}
+            results.update(self.log_cpu())
+            results.update(self.log_memory())
+            results.update(self.log_disk_io())
+            results.update(self.log_network_io())
+            self.logger.info(f'JSON> {json.dumps(results)}')
+
+    def log_cpu(self) -> Dict[str, Any]:
+        cpu_pct: List[float] = psutil.cpu_percent(percpu=True)
+
+        cpu_pct_str = ', '.join([f'{i}: {pct:.1f}%' for i, pct in enumerate(cpu_pct)])
+        self.logger.info(f'CPU> {cpu_pct_str}')
+
+        return {f'CPU_{i}_pct': pct for i, pct in enumerate(cpu_pct)}
+
+    def log_memory(self) -> Dict[str, Any]:
+        ram = psutil.virtual_memory()
+        swap = psutil.swap_memory()
+
+        self.logger.info(f'RAM> {ram.total - ram.available} / {ram.total} ({ram.percent:.1f}%)')
+        self.logger.info(f'SWAP> {swap.used} / {swap.total} ({swap.percent:.1f}%)')
+
+        return {
+            'RAM_used': ram.total - ram.available,
+            'RAM_total': ram.total,
+            'SWAP_used': swap.used,
+            'SWAP_total': swap.total,
+        }
+
+    def log_disk_io(self) -> Dict[str, Any]:
+        disk_io: Dict[str, Any] = psutil.disk_io_counters(perdisk=True)
+
+        results = {}
+        for i, (name, io) in enumerate(disk_io.items()):
+            self.logger.info(f'DISK {i}> ({name}) {io.read_bytes} bytes read, {io.write_bytes} bytes written')
+            results.update({
+                f'Disk_{i}_name': name,
+                f'Disk_{i}_bytes_read': io.read_bytes,
+                f'Disk_{i}_bytes_written': io.write_bytes,
+            })
+
+        return results
+
+    def log_network_io(self) -> Dict[str, Any]:
+        net_io = psutil.net_io_counters()
+
+        self.logger.info(f'NET> {net_io.bytes_recv} bytes received, {net_io.bytes_sent} bytes sent')
+
+        return {
+            'Network_bytes_received': net_io.bytes_recv,
+            'Network_bytes_sent': net_io.bytes_sent,
+        }
+
+    def stop(self) -> None:
+        """Stop logging and wait for the thread to complete."""
+        self.sleep_event.set()
+        self.join(timeout=self.log_interval_sec + 1)

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -94,8 +94,9 @@ class SystemResourceLogger(Thread):
     @staticmethod
     def __create_log(session_folder: str, machine_name: str) -> logging.Logger:
         logger = logging.getLogger('resource_log')
+        time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
         file_handler = logging.FileHandler(
-            os.path.join(session_folder, f'{machine_name}_system_resource.log'), mode='a',
+            os.path.join(session_folder, f'{machine_name}_system_resource_{time_str}.log')
         )
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(SystemResourceLogger.LOG_FORMAT)

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -32,7 +32,7 @@ from neurobooth_os.netcomm import (
 from neurobooth_os.tasks.wellcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
 from neurobooth_os.tasks.task_importer import get_task_funcs
-from neurobooth_os.log_manager import make_session_logger, make_default_logger
+from neurobooth_os.log_manager import make_session_logger, make_default_logger, SystemResourceLogger
 
 
 server_config = config.neurobooth_config["presentation"]
@@ -65,6 +65,7 @@ def run_stm(logger):
     streams, screen_running, presented = {}, False, False
     port = server_config["port"]
     host = ''
+    system_resource_logger = None
 
     for data, connx in get_client_messages(s1, port, host):
         logger.info(f'MESSAGE RECEIVED: {data}')
@@ -100,6 +101,10 @@ def run_stm(logger):
             logger.info("Creating session logger in session folder.")
             logger = make_session_logger(ses_folder, 'STM')
             logger.info('LOGGER CREATED')
+
+            if system_resource_logger is None:
+                system_resource_logger = SystemResourceLogger(ses_folder, 'ACQ')
+                system_resource_logger.start()
 
             # delete subj_date as not present in DB
             del log_task["subject_id-date"]
@@ -327,6 +332,10 @@ def run_stm(logger):
             presented = True
 
         elif data in ["close", "shutdown"]:
+            if system_resource_logger is not None:
+                system_resource_logger.stop()
+                system_resource_logger = None
+
             if "shutdown" in data:
                 logger.info("Shutting down")
                 win.close()

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -103,7 +103,7 @@ def run_stm(logger):
             logger.info('LOGGER CREATED')
 
             if system_resource_logger is None:
-                system_resource_logger = SystemResourceLogger(ses_folder, 'ACQ')
+                system_resource_logger = SystemResourceLogger(ses_folder, 'STM')
                 system_resource_logger.start()
 
             # delete subj_date as not present in DB


### PR DESCRIPTION
Note: Low priority PR, would be better to get the other two from today into tomorrow's release.

Adds a thread that monitors and logs system resources throughout a session. Gets created in prepare ("Connect Devices") so that the log can be saved with the session data. Outputs both lines that are easier to read and parse with terminal utilities and JSON output to be parsed by a post-session analysis script.