### PR TITLE
Update DSC.py

### DIFF
--- a/neurobooth_os/tasks/DSC.py
+++ b/neurobooth_os/tasks/DSC.py
@@ -386,8 +386,11 @@ class DSC(Task_Eyetracker):
         out_fname = f"{self.subj_id}_{self.task_name}_outcomes{self.rep}.csv"
         df_res.to_csv(self.path_out + res_fname)
         df_out.to_csv(self.path_out + out_fname)
-        if len(self.task_files):
+        if len(self.task_files) >= 1:
             self.task_files = self.task_files[-1] + f", {res_fname}, {out_fname}" + "}"
+            self.task_files = self.task_files.replace("}", "") + f", {res_fname}, {out_fname}" + "}"
+
+            print(self.task_files)
         else:
             self.task_files += "{" + f"{res_fname}, {out_fname}" + "}"
 


### PR DESCRIPTION
Fix bug occurring when the DSC task is repeated, causing there to be more than one set of DSC task files output. 

The second + subsequent file names were erroneously appended to an incorrectly modified string containing earlier file names.