### PR TITLE
LSL Streamer Refactor

### DIFF
--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -106,7 +106,7 @@ DEVICE_START_FUNCS: Dict[str, Callable] = {
 }
 
 
-N_ASYNC_THREADS: int = 3
+N_ASYNC_THREADS: int = 3  # The maximum number of mbients on one machine
 ASYNC_STARTUP: List[str] = [
     'Mbient_BK_1',
     'Mbient_LF_1',

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -2,7 +2,7 @@ import logging
 import threading
 from neurobooth_os.iout import metadator as meta
 from typing import Any, Dict, List, Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 
 
 # --------------------------------------------------------------------------------

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -1,163 +1,291 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Nov 24 15:41:42 2020
-
-@author: adona
-"""
-import time
 import logging
-from neurobooth_os import config
+import threading
 from neurobooth_os.iout import metadator as meta
-from neurobooth_os.iout.mbient import Mbient
+from typing import Any, Dict, List, Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
-def start_lsl_threads(node_name, collection_id="mvp_030", win=None, conn=None):
-    """Initiate devices and LSL streams based on databased parameters.
+# --------------------------------------------------------------------------------
+# Wrappers for device setup procedures.
+# TODO: Handle device setup calls and imports in a more standardized/extensible fashion!!!
+# --------------------------------------------------------------------------------
+def start_eyelink_stream(win, **device_args):
+    from neurobooth_os.iout.eyelink_tracker import EyeTracker
+    return EyeTracker(win=win, **device_args)
 
-    Parameters
-    ----------
-    node_name : str
-        Name of the server where to start the lsl threads
-    collection_id : str, optional
-        Name of studies collection in the database, by default "mvp_025"
-    win : object, optional
-        Pycharm window, by default None
-    conn : object, optional
-        Connector to the database, by default None
 
-    Returns
-    -------
-    dict of streams
-        Contains the name of the device and device class
-    """
+def start_mouse_stream(_, **device_args):
+    from neurobooth_os.iout.mouse_tracker import MouseStream
+    device = MouseStream(**device_args)
+    device.start()
+    return device
 
-    if conn is None:
-        print("getting conn")
-        conn = meta.get_conn(database)
 
-    logger = logging.getLogger('session')
+def start_mbient_stream(_, **device_args):
+    from neurobooth_os.iout.mbient import Mbient
+    device = Mbient(**device_args)
+    if not device.prepare():
+        return None
+    device.start()
+    return device
 
-    # Get params from all tasks
-    kwarg_devs = meta._get_device_kwargs_by_task(collection_id, conn)
-    # Get all device params from session
-    kwarg_alldevs = {}
-    for dc in kwarg_devs.values():
-        kwarg_alldevs.update(dc)
 
-    streams = {}
-    if node_name == "acquisition":
-        from neurobooth_os.iout.microphone import MicStream
-        from neurobooth_os.iout.camera_intel import VidRec_Intel
-        from neurobooth_os.iout.flir_cam import VidRec_Flir
-        from neurobooth_os.iout.iphone import IPhone
+def start_mbient_mock_stream(_, **device_args):
+    from neurobooth_os.mock.mock_device_streamer import MockMbient
+    device = MockMbient(**device_args)
+    device.start()
+    return device
 
-        for kdev, argsdev in kwarg_alldevs.items():
-            if "Intel" in kdev:
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                streams[kdev] = VidRec_Intel(**argsdev)
-            elif "Mbient" in kdev:
-                # Don't connect mbients from STM
-                if any([d in kdev for d in ["Mbient_LF", "Mbient_RF"]]):
+
+def start_intel_stream(_, **device_args):
+    from neurobooth_os.iout.camera_intel import VidRec_Intel
+    return VidRec_Intel(**device_args)
+
+
+def start_intel_mock_stream(_, **device_args):
+    from neurobooth_os.mock.mock_device_streamer import MockCamera
+    return MockCamera(**device_args)
+
+
+def start_flir_stream(_, **device_args):
+    from neurobooth_os.iout.flir_cam import VidRec_Flir
+    return VidRec_Flir(**device_args)
+
+
+def start_iphone_stream(_, **device_args):
+    from neurobooth_os.iout.iphone import IPhone
+    device = IPhone(name="IPhoneFrameIndex", **device_args)
+    return device if device.prepare() else None
+
+
+def start_yeti_stream(_, **device_args):
+    from neurobooth_os.iout.microphone import MicStream
+    device = MicStream(**device_args)
+    device.start()
+    return device
+
+
+# --------------------------------------------------------------------------------
+# Device Configurations
+# TODO: Server assignment and device setup should all be derived from config files!!!
+# --------------------------------------------------------------------------------
+
+SERVER_ASSIGNMENTS: Dict[str, List[str]] = {
+    'acquisition': [
+        'Intel_D455_1', 'Intel_D455_2', 'Intel_D455_3', 'FLIR_blackfly_1', 'IPhone_dev_1',
+        'Mbient_BK_1', 'Mbient_LH_1', 'Mbient_LH_2', 'Mbient_RH_1', 'Mbient_RH_2',
+        'Mic_Yeti_dev_1',
+    ],
+    'presentation': ['Eyelink_1', 'Mouse', 'Mbient_LF_1', 'Mbient_LF_2', 'Mbient_RF_2'],
+    'dummy_acq': ['mock_Intel_1', 'mock_Mbient_1', 'mock_Mbient_2'],
+    'dummy_stm': [],
+}
+
+
+DEVICE_START_FUNCS: Dict[str, Callable] = {
+    'Eyelink_1': start_eyelink_stream,
+    'FLIR_blackfly_1': start_flir_stream,
+    'Intel_D455_1': start_intel_stream,
+    'Intel_D455_2': start_intel_stream,
+    'Intel_D455_3': start_intel_stream,
+    'IPhone_dev_1': start_iphone_stream,
+    'Mbient_BK_1': start_mbient_stream,
+    'Mbient_LF_1': start_mbient_stream,
+    'Mbient_LF_2': start_mbient_stream,
+    'Mbient_LH_1': start_mbient_stream,
+    'Mbient_LH_2': start_mbient_stream,
+    'Mbient_RF_2': start_mbient_stream,
+    'Mbient_RH_1': start_mbient_stream,
+    'Mbient_RH_2': start_mbient_stream,
+    'Mic_Yeti_dev_1': start_yeti_stream,
+    'Mouse': start_mouse_stream,
+    # ------------------------------
+    'mock_Intel_1': start_intel_mock_stream,
+    'mock_Mbient_1': start_mbient_mock_stream,
+    'mock_Mbient_2': start_mbient_mock_stream,
+}
+
+
+N_ASYNC_THREADS: int = 3
+ASYNC_STARTUP: List[str] = [
+    'Mbient_BK_1',
+    'Mbient_LF_1',
+    'Mbient_LF_2',
+    'Mbient_LH_1',
+    'Mbient_LH_2',
+    'Mbient_RF_2',
+    'Mbient_RH_1',
+    'Mbient_RH_2',
+]
+
+
+# --------------------------------------------------------------------------------
+# Handle the device life cycle
+# --------------------------------------------------------------------------------
+class DeviceManager:
+    def __init__(self, node_name: str):
+        self.logger = logging.getLogger('session')
+        self.streams: Dict[str, Any] = {}
+
+        if node_name not in SERVER_ASSIGNMENTS:
+            raise ValueError(f'Unrecognized node name ({node_name}) given to device manger!')
+        self.assigned_devices = SERVER_ASSIGNMENTS[node_name]
+        self.logger.debug(f'Devices assigned to {node_name}: {self.assigned_devices}')
+
+        self.marker_stream = node_name in ['presentation', 'dummy_stm']
+
+    def create_streams(self, collection_id: str = "mvp_030", win=None, conn=None) -> None:
+        """
+        Initialize devices and LSL streams.
+
+        :param collection_id: Name of study collection in the database.
+        :param win: PsychoPy window
+        :param conn: Connection to the database
+        """
+        if self.marker_stream:  # TODO: Handle the marker stream better
+            from neurobooth_os.iout import marker_stream
+            self.logger.debug(f'Device Manager Starting: marker')
+            self.streams["marker"] = marker_stream()
+
+        register_lock = threading.Lock()
+
+        def start_and_register_device(device_key: str, device_args: Dict[str, Any]) -> None:
+            self.logger.debug(f'Device Manager Starting: {device_key}')
+            device = DEVICE_START_FUNCS[device_key](win, **device_args)
+            if device is None:
+                self.logger.warning(f'Device Manager Failed to Start: {device_key}')
+                return
+            with register_lock:
+                self.streams[device_key] = device
+
+        with ThreadPoolExecutor(max_workers=N_ASYNC_THREADS) as executor:
+            futures = []
+            for device_key, device_args in DeviceManager._get_device_kwargs(collection_id, conn).items():
+                if device_key not in self.assigned_devices:
                     continue
+                if device_key in ASYNC_STARTUP:
+                    futures.append(executor.submit(start_and_register_device, device_key, device_args))
+                else:  # Run sequentially if not specified as async
+                    start_and_register_device(device_key, device_args)
 
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                streams[kdev] = Mbient(**argsdev)
-                if not streams[kdev].prepare():
-                    del streams[kdev]
+            for f in as_completed(futures):
+                f.result()  # Raise errors that occur asynchronously
+
+        self.logger.info(f'LOADED DEVICES: {list(self.streams.keys())}')
+
+    @staticmethod
+    def _get_device_kwargs(collection_id: str, conn=None) -> Dict[str, Any]:
+        """
+        Fetch the keyword arguments for each device from the database.
+
+        :param collection_id: Name of study collection in the database.
+        :param win: PsychoPy window
+        :param conn: Connection to the database
+        """
+        # Get params from all tasks
+        kwarg_devs = meta._get_device_kwargs_by_task(collection_id, conn)
+
+        # Get all device params from session
+        kwarg_alldevs = {}
+        for dc in kwarg_devs.values():
+            kwarg_alldevs.update(dc)
+
+        return kwarg_alldevs
+
+    # TODO: The below device-specific calls should all be refactored so that devices can be generically handled
+    # TODO: E.g., devices should be able to register handlers for lifecycle phases
+
+    @staticmethod
+    def is_camera(stream_name: str) -> bool:
+        """Test to see if a stream is a camera stream based on its name."""
+        return stream_name.split("_")[0] in ["hiFeed", "FLIR", "Intel", "IPhone"]
+
+    def get_camera_streams(self, task_devices: List[str]) -> List[Any]:
+        return [
+            stream for stream_name, stream in self.streams.items()
+            if DeviceManager.is_camera(stream_name) and stream_name in task_devices
+        ]
+
+    def get_mbient_streams(self) -> Dict[str, Any]:
+        return {
+            stream_name: stream for stream_name, stream in self.streams.items() if 'Mbient' in stream_name
+        }
+
+    def get_eyelink_stream(self):
+        for stream_name, stream in self.streams.items():
+            if 'Eyelink' in stream_name:
+                return stream
+        return None
+
+    def start_cameras(self, filename: str, task_devices: List[str]) -> None:
+        for stream in self.get_camera_streams(task_devices):
+            try:
+                stream.start(filename)
+            except Exception as e:
+                self.logger.exception(e)
+
+    def stop_cameras(self, task_devices: List[str]):
+        cameras = self.get_camera_streams(task_devices)
+        for stream in cameras:  # Signal cameras to stop
+            stream.stop()
+        for stream in cameras:  # Wait for cameras to actually stop
+            stream.ensure_stopped(10)
+
+    def mbient_reconnect(self) -> None:
+        from neurobooth_os.iout.mbient import Mbient
+        Mbient.task_start_reconnect(list(self.get_mbient_streams().values()))
+
+    def mbient_reset(self) -> Dict[str, bool]:
+        """Reset mbient devices in parallel."""
+        mbient_streams = self.get_mbient_streams()
+
+        if len(mbient_streams) == 0:
+            self.logger.debug('No mbients to reset.')
+            return {}
+
+        with ThreadPoolExecutor(max_workers=len(mbient_streams)) as executor:
+            # Begin concurrent reset of devices
+            reset_results = {
+                stream_name: executor.submit(stream.reset_and_reconnect)
+                for stream_name, stream in mbient_streams.items()
+            }
+
+            # Wait for resets to complete, then resolve the futures
+            wait(reset_results.values())
+            return {stream_name: result.result() for stream_name, result in reset_results.items()}
+
+    def iphone_frame_preview(self):
+        for stream_name, stream in self.streams.items():
+            if "IPhone" in stream_name:
+                return stream.frame_preview()
+        return None
+
+    def iphone_log_file_list(self):
+        for stream_name, stream in self.streams.items():
+            if "IPhone" in stream_name:
+                iphone_files = stream.dumpall_getfilelist()
+                if iphone_files is not None:
+                    self.logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
                 else:
-                    streams[kdev].start()
-            elif "FLIR" in kdev:
-                try:
-                    logger.debug(f'LSL Streamer Starting: {kdev}')
-                    streams[kdev] = VidRec_Flir(**argsdev)
-                except:
-                    logger.error(f"FLIR not connected")
-            elif "Mic_Yeti" in kdev:
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                streams[kdev] = MicStream(**argsdev)
-                streams[kdev].start()
-            elif "IPhone" in kdev:
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                success = False
-                streams[kdev] = IPhone(name="IPhoneFrameIndex", **argsdev)
-                success = streams[kdev].prepare()
-                if not success and streams.get(kdev) is not None:
-                    del streams[kdev]
+                    self.logger.warning(f'iPhone did not return a list of files to dump.')
 
-    elif node_name == "presentation":
-        from neurobooth_os.iout import marker_stream
-        from neurobooth_os.iout.mouse_tracker import MouseStream
-        from neurobooth_os.iout.eyelink_tracker import EyeTracker
+    def close_streams(self) -> None:
+        for stream_name, stream in self.streams.items():
+            print(f"Closing stream {stream_name}")
+            self.logger.debug(f'Device Manager Closing: {stream_name}')
 
-        streams["marker"] = marker_stream()
+            if DeviceManager.is_camera(stream_name):
+                stream.close()
+            else:
+                stream.stop()
 
-        for kdev, argsdev in kwarg_alldevs.items():
-            if "Eyelink" in kdev:
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                streams["Eyelink"] = EyeTracker(win=win, **argsdev)
-            elif "Mouse" in kdev:
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                streams["mouse"] = MouseStream(**argsdev)
-                streams["mouse"].start()
+    def reconnect_streams(self):
+        for stream_name, stream in self.streams.items():
+            if DeviceManager.is_camera(stream_name):
+                continue
 
-            elif any([d in kdev for d in ["Mbient_LF", "Mbient_RF"]]):
-                logger.debug(f'LSL Streamer Starting: {kdev}')
-                streams[kdev] = Mbient(**argsdev)
-                if not streams[kdev].prepare():
-                    del streams[kdev]
-                else:
-                    streams[kdev].start()
-
-    elif node_name == "dummy_acq":
-        from neurobooth_os.mock import mock_device_streamer as mock_dev
-        from neurobooth_os.iout.iphone import IPhone
-
-        for kdev, argsdev in kwarg_alldevs.items():
-            if "Intel" in kdev:
-                streams[kdev] = mock_dev.MockCamera(**argsdev)
-            elif "Mbient" in kdev:
-                streams[kdev] = mock_dev.MockMbient(**argsdev)
-                streams[kdev].start()
-            elif "IPhone" in kdev:
-                success = False
-                streams[kdev] = IPhone(name="IPhoneFrameIndex", **argsdev)
-                success = streams[kdev].prepare()
-                if not success and streams.get(kdev) is not None:
-                    del streams[kdev]
-
-    elif node_name == "dummy_stm":
-        from neurobooth_os.iout import marker_stream
-
-        streams["marker"] = marker_stream()
-
-    return streams
-
-
-def close_streams(streams):
-    logger = logging.getLogger('session')
-
-    for k in list(streams):
-        print(f"Closing {k} stream")
-        logger.debug(f'LSL Streamer Closing: {k}')
-        if k.split("_")[0] in ["hiFeed", "Intel", "FLIR", "IPhone"]:
-            streams[k].close()
-        else:
-            streams[k].stop()
-        # del streams[k]
-    return streams
-
-
-def reconnect_streams(streams):
-    logger = logging.getLogger('session')
-
-    for k in list(streams):
-        if k.split("_")[0] in ["hiFeed", "Intel", "FLIR", "IPhone"]:
-            continue
-
-        logger.debug(f'LSL Streamer Reconnecting: {k}')
-        if not streams[k].streaming:
-            print(f"Re-streaming {k} stream")
-            streams[k].start()
-        print(f"-OUTLETID-:{k}:{streams[k].outlet_id}")
-
-    return streams
+            if not stream.streaming:
+                print(f"Re-streaming {stream_name} stream")
+                self.logger.debug(f'Device Manager Reconnecting: {stream_name}')
+                stream.start()
+            print(f"-OUTLETID-:{stream_name}:{stream.outlet_id}")

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -5,7 +5,6 @@ from time import time, sleep
 from collections import OrderedDict
 import cv2
 import numpy as np
-from concurrent.futures import ThreadPoolExecutor, wait
 from pylsl import local_clock
 import logging
 import json
@@ -15,11 +14,7 @@ from neurobooth_os import config
 from neurobooth_os.log_manager import make_default_logger
 from neurobooth_os.netcomm import NewStdout, get_client_messages
 from neurobooth_os.iout.camera_brio import VidRec_Brio
-from neurobooth_os.iout.lsl_streamer import (
-    start_lsl_threads,
-    close_streams,
-    reconnect_streams,
-)
+from neurobooth_os.iout.lsl_streamer import DeviceManager
 from neurobooth_os.iout.mbient import Mbient
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.log_manager import make_session_logger
@@ -49,19 +44,14 @@ def Main():
         raise
 
 
-def is_camera(stream_name: str) -> bool:
-    """Test to see if a stream is a camera stream based on its name."""
-    return stream_name.split("_")[0] in ["FLIR", "Intel", "IPhone"]
-
-
 def run_acq(logger):
     s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    streams = {}
     lowFeed_running = False
     recording = False
     port = server_config["port"]
     host = ''
+    device_manager = None
 
     for data, connx in get_client_messages(s1, port, host):
         logger.info(f'MESSAGE RECEIVED: {data}')
@@ -95,54 +85,29 @@ def run_acq(logger):
             logger.info('LOGGER CREATED')
 
             task_devs_kw = meta._get_device_kwargs_by_task(collection_id, conn)
-            if len(streams):
-                # print("Checking prepared devices")
-                streams = reconnect_streams(streams)
-            else:
-                streams = start_lsl_threads("acquisition", collection_id, conn=conn)
 
-            devs = list(streams.keys())
-            logger.info(f'LOADED DEVICES: {str(devs)}')
+            device_manager = DeviceManager(node_name='acquisition')
+            if device_manager.streams:
+                device_manager.reconnect_streams()
+            else:
+                device_manager.create_streams(collection_id=collection_id, conn=conn)
             print("UPDATOR:-Connect-")
 
         elif "frame_preview" in data and not recording:
-            if not any("IPhone" in s for s in streams):
+            frame = device_manager.iphone_frame_preview()
+            if frame is None:
                 print("no iphone")
                 connx.send("ERROR: no iphone in LSL streams".encode("ascii"))
                 logger.debug('Frame preview unavailable')
-                continue
-
-            frame = streams[[i for i in streams if "IPhone" in i][0]].frame_preview()
-            frame_prefix = b"::BYTES::" + str(len(frame)).encode("utf-8") + b"::"
-            frame = frame_prefix + frame
-            connx.send(frame)
-            logger.debug('Frame preview sent')
+            else:
+                frame_prefix = b"::BYTES::" + str(len(frame)).encode("utf-8") + b"::"
+                frame = frame_prefix + frame
+                connx.send(frame)
+                logger.debug('Frame preview sent')
 
         # TODO: Both reset_mbients and frame_preview should be reworked as dynamic hooks that register a callback
         elif "reset_mbients" in data:
-            mbient_streams = {
-                stream_name: stream
-                for stream_name, stream in streams.items()
-                if 'mbient' in stream_name.lower()
-            }
-
-            if len(mbient_streams) == 0:
-                logger.debug('No mbients to reset.')
-                connx.send(json.dumps({}).encode('utf-8'))
-                continue
-
-            with ThreadPoolExecutor(max_workers=len(mbient_streams)) as executor:
-                # Begin concurrent reset of devices
-                reset_results = {
-                    stream_name: executor.submit(stream.reset_and_reconnect)
-                    for stream_name, stream in mbient_streams.items()
-                }
-
-                # Wait for resets to complete, then resolve the futures
-                wait(reset_results.values())
-                reset_results = {stream_name: result.result() for stream_name, result in reset_results.items()}
-
-            # Reply with the results of the reset
+            reset_results = device_manager.mbient_reset()
             connx.send(json.dumps(reset_results).encode('utf-8'))
             logger.debug('Reset results sent')
 
@@ -153,19 +118,8 @@ def run_acq(logger):
             fname, task = data.split("::")[1:]
             fname = f"{server_config['local_data_dir']}{subject_id_date}/{fname}"
 
-            # Start cameras
-            for stream_name, stream in streams.items():
-                if is_camera(stream_name) and stream_name in task_devs_kw[task]:
-                    try:
-                        stream.start(fname)
-                    except Exception as e:
-                        logger.exception(e)
-
-            # Attempt to reconnect Mbients if disconnected
-            Mbient.task_start_reconnect([
-                stream for stream_name, stream in streams.items()
-                if 'Mbient' in stream_name
-            ])
+            device_manager.start_cameras(fname, task_devs_kw[task])
+            device_manager.mbient_reconnect()  # Attempt to reconnect Mbients if disconnected
 
             elapsed_time = time() - t0
             print(f"Device start took {elapsed_time:.2f}")
@@ -176,17 +130,7 @@ def run_acq(logger):
 
         elif "record_stop" in data:
             t0 = time()
-
-            # Stop cameras
-            for stream_name, stream in streams.items():
-                if is_camera(stream_name) and stream_name in task_devs_kw[task]:
-                    stream.stop()
-
-            # Wait for cameras to actually stop
-            for stream_name, stream in streams.items():
-                if is_camera(stream_name) and stream_name in task_devs_kw[task]:
-                    stream.ensure_stopped(10)
-
+            device_manager.stop_cameras(task_devs_kw[task])
             elapsed_time = time() - t0
             print(f"Device stop took {elapsed_time:.2f}")
             logger.info(f'Device stop took {elapsed_time:.2f}')
@@ -199,16 +143,8 @@ def run_acq(logger):
                 sys.stdout = sys.stdout.terminal
                 s1.close()
 
-            # TODO: It would be nice to generically register logging handlers at each stage of a stream's lifecycle.
-            for k in streams.keys():  # Log the list of files present on the iPhone
-                if k.split("_")[0] == "IPhone":
-                    iphone_files = streams[k].dumpall_getfilelist()
-                    if iphone_files is not None:
-                        logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
-                    else:
-                        logger.warning(f'iPhone did not return a list of files to dump.')
-
-            streams = close_streams(streams)
+            device_manager.iphone_log_file_list()    # Log the list of files present on the iPhone
+            device_manager.close_streams()
 
             if "shutdown" in data:
                 if lowFeed_running:


### PR DESCRIPTION
Initial motivation was to allow async startup on Mbients. That has been accomplished, but I also took this opportunity to do a partial refactor of LSL Streamer to highlight work that needs to be done as part of the full device refactor. (I.e., device-specific logic and hardcoded configs should now be quite obvious and somewhat localized - ready for a more comprehensive patch) The refactor has been tested in staging.

Refactor changes:
- Added new DeviceManager class that now handles device creation/start/stop logic.
- Device machine assignments are now all in once place, and it is now explicit that this mapping is currently hardcoded.
- Device-specific startup processes now have their own methods. Need to fold these into device subclasses.
- The mapping from device to the startup function is now established in a dictionary to pave the way for dynamic linking via configs.
- Most device management logic in STM/ACQ has been moved to the new DeviceManager. It should now be clearer what is device-related logic and when its hardcoded device specifics.
    - STM is a little tricky. In particular, it needs direct access to the mbient and eyelink streams because these are used by tasks or have special handling. In a later refactor, we may want to provide a generic way for tasks to identify and interact with devices.