### PR TITLE
iPhone File Transfer - MD5 Checks

### DIFF
--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -112,7 +112,7 @@ def dump_file(
 
     # Attempt to retrieve the file from the iPhone
     logger.info(f'Dump {file_name} -> {file_name_out}')
-    file_data = phone.dump(file_name, file_hash=file_hash, timeout_sec=timeout_sec)
+    file_data = phone.dump(file_name, expected_hash=file_hash, timeout_sec=timeout_sec)
 
     zero_byte = len(file_data) == 0
     if zero_byte:

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -62,7 +62,7 @@ def neurobooth_dump(args: argparse.Namespace) -> None:
 
         try:
             dump_file(
-                phone, file_name, op.join(sess_folder, file_name),
+                phone, file_name, op.join(sess_folder, file_name), file_hash,
                 timeout_sec=args.timeout,
                 delete_zero_byte=args.delete_zero_byte,
             )

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -71,6 +71,9 @@ def neurobooth_dump(args: argparse.Namespace) -> None:
                 f'Timeout encountered when retrieving {fname}. Discontinuing transfer to prevent out-of-order files.'
             )
             break
+        except iphone.IPhoneHashMismatch:
+            logger.error(f'Hash mismatch detected for {fname}. Skipping this file.')
+            continue
 
     logger.debug('Disconnecting iPhone')
     phone.disconnect()

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -83,7 +83,7 @@ def dump_file(
         phone: iphone.IPhone,
         file_name: str,
         file_name_out: str,
-        file_hash,
+        file_hash: str,
         timeout_sec: Optional[float] = None,
         delete_zero_byte: bool = False,
 ) -> None:

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -708,7 +708,7 @@ class IPhone:
         Retrieve a file from the iPhone.
 
         :param filename: The file (from the list returned by dumpall_getfilelist) to retrieve.
-        :param file_hash: Verify the transferred data using an MD5 hash, if specified.
+        :param file_hash: Verify the transferred data using an MD5 (base64 encoded) hash, if specified.
         :param timeout_sec: Wait the specified amount of time for the file transfer to complete. No timeout if None.
         :returns: The raw data returned from the phone, or zero bytes if timed out.
         """
@@ -727,11 +727,11 @@ class IPhone:
                 return self._dump_video_data
 
             self.logger.debug(f'iPhone [state={self._state}]: Computing Hashes')
-            dumpall_hash = b64decode(file_hash).hex()  # Transform base64 encoded string to hex encoding
-            dump_hash = md5(self._dump_video_data).hexdigest()
-            self.logger.debug(f'iPhone [state={self._state}]: dumpall_hash={dumpall_hash}; dump_hash={dump_hash}')
+            iphone_hash = b64decode(file_hash).hex()  # Transform base64 encoded string to hex encoding
+            local_hash = md5(self._dump_video_data).hexdigest()
+            self.logger.debug(f'iPhone [state={self._state}]: iphone_hash={iphone_hash}; local_hash={local_hash}')
 
-            if dumpall_hash != dump_hash:
+            if iphone_hash != local_hash:
                 self.logger.warning(f'Received file ({filename}) does not match given hash.')
                 raise IPhoneHashMismatch(f'Received file ({filename}) does not match given hash.')
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -467,12 +467,12 @@ class IPhone:
                 self._dump_video_cond.notify()
         elif tag == MessageTag.DUMP_FILE_CHUNK:
             self._update_state("@CHUNKRECEIVE")
-            self.logger.debug(f'Received File Chunk ({len(msg)/(1<<20):0.1f} MiB)')
+            self.logger.debug(f'iPhone: Received File Chunk ({len(msg)/(1<<20):0.1f} MiB)')
             with self._dump_video_cond:
                 self._dump_video_data += msg
         elif tag == MessageTag.DUMP_LAST_FILE_CHUNK:
             self._update_state("@LASTCHUNKRECEIVE")
-            self.logger.debug(f'Received Last File Chunk ({len(msg) / (1 << 20):0.1f} MiB)')
+            self.logger.debug(f'iPhone: Received Last File Chunk ({len(msg) / (1 << 20):0.1f} MiB)')
             with self._dump_video_cond:
                 self._dump_video_data += msg
                 self._dump_video_cond.notify()
@@ -480,7 +480,10 @@ class IPhone:
             self._lsl_push_sample(msg)  # Push before trying to acquire locks to ensure accurate timing
 
             message_type = msg["MessageType"]
+            if message_type == '@ERROR':
+                self.logger.error(f'iPhone: Error received from phone: {msg["Message"]}')
             self._update_state(message_type)
+
             with self._wait_for_reply_cond:
                 self._latest_message = msg
                 self._latest_message_type = message_type

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -721,7 +721,14 @@ class IPhone:
 
             if file_hash is None:
                 self.logger.warning(f'No hash check performed for {filename}')
-            elif b64decode(file_hash).hex() != md5(self._dump_video_data).hexdigest():
+                return self._dump_video_data
+
+            self.logger.debug(f'iPhone [state={self._state}]: Computing Hashes')
+            dumpall_hash = b64decode(file_hash).hex()  # Transform base64 encoded string to hex encoding
+            dump_hash = md5(self._dump_video_data).hexdigest()
+            self.logger.debug(f'iPhone [state={self._state}]: dumpall_hash={dumpall_hash}; dump_hash={dump_hash}')
+
+            if dumpall_hash != dump_hash:
                 self.logger.warning(f'Received file ({filename}) does not match given hash.')
                 raise IPhoneHashMismatch(f'Received file ({filename}) does not match given hash.')
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -666,7 +666,7 @@ class IPhone:
             return self._frame_preview_data
 
     @_handle_panic
-    def dumpall_getfilelist(self) -> Optional[List[str], List[bytes]]:
+    def dumpall_getfilelist(self) -> Tuple[Optional[List[str]], Optional[List[bytes]]]:
         """
         Fetch a list of files saved on the iPhone.
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -14,6 +14,7 @@ import time
 from typing import Dict, List, Tuple, Any, Optional, Union, ByteString
 from enum import IntEnum
 from hashlib import md5
+from base64 import b64decode
 
 from neurobooth_os.iout.usbmux import USBMux
 
@@ -666,7 +667,7 @@ class IPhone:
             return self._frame_preview_data
 
     @_handle_panic
-    def dumpall_getfilelist(self) -> Tuple[Optional[List[str]], Optional[List[bytes]]]:
+    def dumpall_getfilelist(self) -> Tuple[Optional[List[str]], Optional[List[str]]]:
         """
         Fetch a list of files saved on the iPhone.
 
@@ -697,7 +698,7 @@ class IPhone:
     def dump(
             self,
             filename: str,
-            file_hash: Optional[bytes] = None,
+            file_hash: Optional[str] = None,
             timeout_sec: Optional[float] = None,
     ) -> (bool, ByteString):
         """
@@ -720,7 +721,7 @@ class IPhone:
 
             if file_hash is None:
                 self.logger.warning(f'No hash check performed for {filename}')
-            elif file_hash != md5(self._dump_video_data).digest():
+            elif b64decode(file_hash).hex() != md5(self._dump_video_data).hexdigest():
                 self.logger.warning(f'Received file ({filename}) does not match given hash.')
                 raise IPhoneHashMismatch(f'Received file ({filename}) does not match given hash.')
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -688,8 +688,8 @@ class IPhone:
                 return None, None
 
             file_info = self._latest_message["Message"]
-            file_names = [file_name for file_name, _ in file_info]
-            file_hashes = [file_hash for _, file_hash in file_info]
+            file_names = [info['file'] for info in file_info]
+            file_hashes = [info['md5'] for info in file_info]
             if DEBUG_LOGGING:
                 self.logger.debug(f"iPhone [state={self._state}]: File List (N={len(file_info)}) = {file_names}")
             return file_names, file_hashes

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -466,10 +466,12 @@ class IPhone:
                 self._dump_video_cond.notify()
         elif tag == MessageTag.DUMP_FILE_CHUNK:
             self._update_state("@CHUNKRECEIVE")
+            self.logger.debug(f'Received File Chunk ({len(msg)/(1<<20):0.1f} MiB)')
             with self._dump_video_cond:
                 self._dump_video_data += msg
         elif tag == MessageTag.DUMP_LAST_FILE_CHUNK:
             self._update_state("@LASTCHUNKRECEIVE")
+            self.logger.debug(f'Received Last File Chunk ({len(msg) / (1 << 20):0.1f} MiB)')
             with self._dump_video_cond:
                 self._dump_video_data += msg
                 self._dump_video_cond.notify()

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -701,14 +701,14 @@ class IPhone:
     def dump(
             self,
             filename: str,
-            file_hash: Optional[str] = None,
+            expected_hash: str,
             timeout_sec: Optional[float] = None,
     ) -> (bool, ByteString):
         """
         Retrieve a file from the iPhone.
 
         :param filename: The file (from the list returned by dumpall_getfilelist) to retrieve.
-        :param file_hash: Verify the transferred data using an MD5 (base64 encoded) hash, if specified.
+        :param expected_hash: Verify the transferred data using an MD5 (base64 encoded) hash.
         :param timeout_sec: Wait the specified amount of time for the file transfer to complete. No timeout if None.
         :returns: The raw data returned from the phone, or zero bytes if timed out.
         """
@@ -722,16 +722,13 @@ class IPhone:
             except IPhonePanic as e:
                 self.panic(e)
 
-            if file_hash is None:
-                self.logger.warning(f'No hash check performed for {filename}')
-                return self._dump_video_data
-
+            # Compute/transform Hashes
             self.logger.debug(f'iPhone [state={self._state}]: Computing Hashes')
-            iphone_hash = b64decode(file_hash).hex()  # Transform base64 encoded string to hex encoding
+            iphone_hash = b64decode(expected_hash).hex()  # Transform base64 encoded string to hex encoding
             local_hash = md5(self._dump_video_data).hexdigest()
             self.logger.debug(f'iPhone [state={self._state}]: iphone_hash={iphone_hash}; local_hash={local_hash}')
 
-            if iphone_hash != local_hash:
+            if iphone_hash != local_hash:  # Compare hashes
                 self.logger.warning(f'Received file ({filename}) does not match given hash.')
                 raise IPhoneHashMismatch(f'Received file ({filename}) does not match given hash.')
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -211,7 +211,7 @@ def run_acq(logger):
             # TODO: It would be nice to generically register logging handlers at each stage of a stream's lifecycle.
             for k in streams.keys():  # Log the list of files present on the iPhone
                 if k.split("_")[0] == "IPhone":
-                    iphone_files = streams[k].dumpall_getfilelist()
+                    iphone_files, _ = streams[k].dumpall_getfilelist()
                     if iphone_files is not None:
                         logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
                     else:


### PR DESCRIPTION
The latest version of the iPhone app will now return both file names and base64-encoded file hashes when responding to a `@DUMPALL` signal. This PR addresses the altered protocol and uses the hashes to check the validity of files we receive via `@DUMP`. Currently, a hash match failure just causes the file to be skipped during the file transfer. (The assumption is that the next transfer will correctly retrieve the file, assuming the hash mismatch was due to network error or other stochastic error.)