### PR TITLE
Config File Loading Patch

### DIFF
--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -169,6 +169,7 @@ def main():
     iphone.DISABLE_LSL = True
 
     args = parse_arguments()
+    cfg.load_config()
     t0 = datetime.datetime.now()
     logger.info('Running Dump')
     neurobooth_dump(args)

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -165,11 +165,11 @@ def parse_arguments() -> argparse.Namespace:
 
 
 def main():
+    cfg.load_config()
     logger = make_default_logger()
     iphone.DISABLE_LSL = True
 
     args = parse_arguments()
-    cfg.load_config()
     t0 = datetime.datetime.now()
     logger.info('Running Dump')
     neurobooth_dump(args)

--- a/extras/run_xdf_split_postproces.py
+++ b/extras/run_xdf_split_postproces.py
@@ -1,8 +1,9 @@
 from neurobooth_os.iout.metadator import get_conn
 from neurobooth_os.iout.split_xdf import create_h5_from_csv
-from neurobooth_os.config import neurobooth_config
+import neurobooth_os.config as config
 
-conn = get_conn(neurobooth_config['database']['dbname'])
+config.load_config()
+conn = get_conn(config.neurobooth_config['database']['dbname'])
 # location of the csv file containing path filename and task ID
 dont_split_xdf_fpath = "C:/neurobooth"
 create_h5_from_csv(dont_split_xdf_fpath, conn)

--- a/extras/test_eyelink_task_rec.py
+++ b/extras/test_eyelink_task_rec.py
@@ -30,6 +30,7 @@ os.chdir(r"C:\neurobooth-eel\neurobooth_os\\")
 print(os.getcwd())
 
 server_name = "presentation"
+config.load_config()
 server_config = config.neurobooth_config[server_name]
 
 def fake_task(**kwarg):

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -27,7 +27,6 @@ from neurobooth_os.netcomm import (
     node_info,
     socket_message,
 )
-from neurobooth_os.config import neurobooth_config
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes
 from neurobooth_os.log_manager import make_default_logger
 import neurobooth_os.iout.metadator as meta
@@ -389,7 +388,7 @@ def _get_ports(database):
 def gui():
     """Start the Graphical User Interface.
     """
-    database = neurobooth_config["database"]["dbname"]
+    database = cfg.neurobooth_config["database"]["dbname"]
     database, nodes, host_ctr, port_ctr = _get_ports(database=database)
 
     conn = meta.get_conn(database=database)

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -600,10 +600,10 @@ def gui():
 
 def main():
     """The starting point of Neurobooth"""
+    cfg.load_config()  # Load Neurobooth-OS configuration
     logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
     try:
         logger.info("Starting GUI")
-        cfg.load_config()  # Load Neurobooth-OS configuration
         gui()
     except Exception as e:
         logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -16,7 +16,7 @@ from neurobooth_terra import Table
 
 import neurobooth_os
 from neurobooth_os.log_manager import make_default_logger
-from neurobooth_os.config import neurobooth_config
+import neurobooth_os.config as cfg
 
 
 def get_conn(database):
@@ -38,13 +38,13 @@ def get_conn(database):
         logger.critical("Database name is a required parameter.")
         raise  # TODO: Need appropriate exception type for database connection errors
 
-    port = neurobooth_config["database"]["port"]
+    port = cfg.neurobooth_config["database"]["port"]
     tunnel = SSHTunnelForwarder(
-        neurobooth_config["database"]["remote_address"],
-        ssh_username=neurobooth_config["database"]["remote_username"],
+        cfg.neurobooth_config["database"]["remote_address"],
+        ssh_username=cfg.neurobooth_config["database"]["remote_username"],
         ssh_config_file="~/.ssh/config",
         ssh_pkey="~/.ssh/id_rsa",
-        remote_bind_address=(neurobooth_config["database"]["host"], port),
+        remote_bind_address=(cfg.neurobooth_config["database"]["host"], port),
         #TODO address in config
         local_bind_address=("localhost", 6543),
     )
@@ -55,8 +55,8 @@ def get_conn(database):
 
     conn = psycopg2.connect(
         database=database,
-        user=neurobooth_config["database"]["user"],
-        password=neurobooth_config["database"]["pass"],
+        user=cfg.neurobooth_config["database"]["user"],
+        password=cfg.neurobooth_config["database"]["pass"],
         host=host,
         port=port,
     )

--- a/neurobooth_os/iout/split_xdf.py
+++ b/neurobooth_os/iout/split_xdf.py
@@ -17,7 +17,7 @@ from h5io import write_hdf5
 
 from neurobooth_os.iout import metadator as meta
 from neurobooth_terra import Table
-from neurobooth_os.config import neurobooth_config, get_server_name_from_env
+import neurobooth_os.config as cfg
 
 
 def compute_clocks_diff():
@@ -201,7 +201,7 @@ def create_h5_from_csv(dont_split_xdf_fpath, conn, server_name=None):
     """
 
     if server_name is None:
-        server_name = get_server_name_from_env()
+        server_name = cfg.get_server_name_from_env()
         if server_name is None:
             raise Exception("A server name is required if the Windows user is not in (CTR, ACQ, or STM)")
 
@@ -220,7 +220,7 @@ def create_h5_from_csv(dont_split_xdf_fpath, conn, server_name=None):
             # change to NAS path if necessary
             if not os.path.exists(row[0]):
                 row[0] = row[0].replace('\\', '/')
-                row[0] = row[0].replace(neurobooth_config[server_name]["local_data_dir"][:-1], neurobooth_config["remote_data_dir"])
+                row[0] = row[0].replace(cfg.neurobooth_config[server_name]["local_data_dir"][:-1], cfg.neurobooth_config["remote_data_dir"])
             out = split_sens_files(row[0], task_id=row[1], conn=conn)
 
             if len(out) == 0:

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -11,8 +11,6 @@ from neurobooth_os.config import neurobooth_config
 
 LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
 
-DEFAULT_LOG_PATH = neurobooth_config["default_log_path"]
-
 
 def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
     logger = logging.getLogger('session')
@@ -49,9 +47,12 @@ def make_session_logger_debug(
 
 
 def make_default_logger(
-        log_path=DEFAULT_LOG_PATH,
-        log_level=logging.DEBUG,
+        log_path: Optional[str] = None,
+        log_level: int = logging.DEBUG,
 ) -> logging.Logger:
+    if log_path is None:
+        log_path = neurobooth_config["default_log_path"]
+
     if not os.path.exists(log_path):
         os.makedirs(log_path)
 

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -7,7 +7,7 @@ import psutil
 from threading import Thread, Event
 import json
 
-from neurobooth_os.config import neurobooth_config
+import neurobooth_os.config as config
 
 LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
 
@@ -51,7 +51,7 @@ def make_default_logger(
         log_level: int = logging.DEBUG,
 ) -> logging.Logger:
     if log_path is None:
-        log_path = neurobooth_config["default_log_path"]
+        log_path = config.neurobooth_config["default_log_path"]
 
     if not os.path.exists(log_path):
         os.makedirs(log_path)

--- a/neurobooth_os/mock/mock_server_acq.py
+++ b/neurobooth_os/mock/mock_server_acq.py
@@ -33,6 +33,7 @@ def mock_acq_routine(host, port, conn):
         Connector to the database
     """
 
+    config.load_config()
     streams = {}
     s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     recording = False

--- a/neurobooth_os/mock/mock_server_stm.py
+++ b/neurobooth_os/mock/mock_server_stm.py
@@ -37,6 +37,7 @@ def mock_stm_routine(host, port, conn):
         connector to the database
     """
 
+    config.load_config()
     streams = {}
     s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     for data, connx in get_client_messages(s1, port=port, host=host):

--- a/neurobooth_os/mock/tests/test_mock_database.py
+++ b/neurobooth_os/mock/tests/test_mock_database.py
@@ -2,7 +2,7 @@ import psycopg2
 from sshtunnel import SSHTunnelForwarder
 
 from neurobooth_os.mock import insert_mock_rows, delete_mock_rows
-from neurobooth_os.config import neurobooth_config
+import neurobooth_os.config as cfg
 
 
 def test_neurobooth_mock():
@@ -10,7 +10,7 @@ def test_neurobooth_mock():
 
     with SSHTunnelForwarder(
         "neurodoor.nmr.mgh.harvard.edu",
-        ssh_username=neurobooth_config["database"]["remote_username"],
+        ssh_username=cfg.neurobooth_config["database"]["remote_username"],
         ssh_config_file="~/.ssh/config",
         ssh_pkey="~/.ssh/id_rsa",
         remote_bind_address=("192.168.100.1", 5432),
@@ -18,9 +18,9 @@ def test_neurobooth_mock():
     ) as tunnel:
 
         with psycopg2.connect(
-            database=neurobooth_config["database"]["name"],
-            user=neurobooth_config["database"]["user"],
-            password=neurobooth_config["database"]["pass"],
+            database=cfg.neurobooth_config["database"]["name"],
+            user=cfg.neurobooth_config["database"]["user"],
+            password=cfg.neurobooth_config["database"]["pass"],
             host=tunnel.local_bind_host,
             port=tunnel.local_bind_port,
         ) as conn_mock:

--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -8,7 +8,7 @@ import os
 import pandas as pd
 from io import StringIO
 
-from neurobooth_os.config import neurobooth_config
+import neurobooth_os.config as cfg
 
 
 def setup_log(name):
@@ -137,8 +137,8 @@ def node_info(node_name):
     port int
         port number
     """
-    host = neurobooth_config[node_name]["name"]
-    port = neurobooth_config[node_name]["port"]
+    host = cfg.neurobooth_config[node_name]["name"]
+    port = cfg.neurobooth_config[node_name]["port"]
     logger.debug(f"Host is {host}, and port is {port}.")
     return host, port
 
@@ -208,7 +208,7 @@ def start_server(node_name, save_pid_txt=True):
     """
 
     if node_name in ["acquisition", "presentation"]:
-        s = neurobooth_config[node_name]
+        s = cfg.neurobooth_config[node_name]
     else:
         print("Not a known node name")
         return None
@@ -283,7 +283,7 @@ def get_python_pids(output_tasklist):
 def kill_remote_pid(pids, node_name):
 
     if node_name in ["acquisition", "presentation"]:
-        s = neurobooth_config[node_name]
+        s = cfg.neurobooth_config[node_name]
     else:
         print("Not a known node name")
         return None

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -34,11 +34,10 @@ def countdown(period):
 
 
 def main():
+    config.load_config()  # Load Neurobooth-OS configuration
     logger = make_default_logger()  # Initialize default logger
     try:
         logger.info("Starting ACQ")
-
-        config.load_config()  # Load Neurobooth-OS configuration
 
         os.chdir(neurobooth_os.__path__[0])
         sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -24,7 +24,6 @@ from neurobooth_os.iout.mbient import Mbient
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.log_manager import make_session_logger, SystemResourceLogger
 
-server_config = config.neurobooth_config["acquisition"]
 
 def countdown(period):
     t1 = local_clock()
@@ -34,14 +33,16 @@ def countdown(period):
         t2 = local_clock()
 
 
-def Main():
-    os.chdir(neurobooth_os.__path__[0])
-    sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)
-
-    # Initialize default logger
-    logger = make_default_logger()
-    logger.info("Starting ACQ")
+def main():
+    logger = make_default_logger()  # Initialize default logger
     try:
+        logger.info("Starting ACQ")
+
+        config.load_config()  # Load Neurobooth-OS configuration
+
+        os.chdir(neurobooth_os.__path__[0])
+        sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)
+
         run_acq(logger)
     except Exception as e:
         logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
@@ -60,7 +61,7 @@ def run_acq(logger):
     streams = {}
     lowFeed_running = False
     recording = False
-    port = server_config["port"]
+    port = config.neurobooth_config['acquisition']["port"]
     host = ''
     system_resource_logger = None
 
@@ -88,7 +89,7 @@ def run_acq(logger):
             subject_id_date = log_task["subject_id-date"]
 
             conn = meta.get_conn(database=database_name)
-            ses_folder = f"{server_config['local_data_dir']}{subject_id_date}"
+            ses_folder = f"{config.neurobooth_config['acquisition']['local_data_dir']}{subject_id_date}"
             if not os.path.exists(ses_folder):
                 os.mkdir(ses_folder)
 
@@ -156,7 +157,7 @@ def run_acq(logger):
             print("Starting recording")
             t0 = time()
             fname, task = data.split("::")[1:]
-            fname = f"{server_config['local_data_dir']}{subject_id_date}/{fname}"
+            fname = f"{config.neurobooth_config['acquisition']['local_data_dir']}{subject_id_date}/{fname}"
 
             # Start cameras
             for stream_name, stream in streams.items():
@@ -234,4 +235,5 @@ def run_acq(logger):
             print(data)
 
 
-Main()
+if __name__ == '__main__':
+    main()

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -37,18 +37,16 @@ from neurobooth_os.tasks.task_importer import get_task_funcs
 from neurobooth_os.log_manager import make_session_logger, make_default_logger, SystemResourceLogger
 
 
-server_config = config.neurobooth_config["presentation"]
-
-
-def Main():
-    os.chdir(neurobooth_os.__path__[0])
-    sys.stdout = NewStdout("STM", target_node="control", terminal_print=True)
-
-    # Initialize logging to default
-    logger = make_default_logger()
-    logger.info("Starting STM")
-
+def main():
+    logger = make_default_logger()  # Initialize logging to default
     try:
+        logger.info("Starting STM")
+
+        config.load_config()  # Load Neurobooth-OS configuration
+
+        os.chdir(neurobooth_os.__path__[0])
+        sys.stdout = NewStdout("STM", target_node="control", terminal_print=True)
+
         run_stm(logger)
     except Exception as e:
         logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
@@ -65,7 +63,7 @@ def run_stm(logger):
         win = utl.make_win(full_screen=True)
 
     streams, screen_running, presented = {}, False, False
-    port = server_config["port"]
+    port = config.neurobooth_config['presentation']["port"]
     host = ''
     system_resource_logger = None
 
@@ -94,7 +92,7 @@ def run_stm(logger):
             subject_id_date = log_task["subject_id-date"]
             conn = meta.get_conn(database=database_name)
             logger.info(f"Database name is {database_name}.")
-            ses_folder = f"{server_config['local_data_dir']}{subject_id_date}"
+            ses_folder = f"{config.neurobooth_config['presentation']['local_data_dir']}{subject_id_date}"
 
             logger.info(f"Creating session folder: {ses_folder}")
             if not os.path.exists(ses_folder):
@@ -134,7 +132,7 @@ def run_stm(logger):
             # Shared task keyword arguments
             task_karg = {
                 "win": win,
-                "path": server_config["local_data_dir"] + f"{subject_id_date}/",
+                "path": config.neurobooth_config['presentation']["local_data_dir"] + f"{subject_id_date}/",
                 "subj_id": subject_id_date,
                 "marker_outlet": streams["marker"],
                 "prompt": True,
@@ -352,4 +350,5 @@ def run_stm(logger):
     exit()
 
 
-Main()
+if __name__ == '__main__':
+    main()

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -38,11 +38,10 @@ from neurobooth_os.log_manager import make_session_logger, make_default_logger, 
 
 
 def main():
+    config.load_config()  # Load Neurobooth-OS configuration
     logger = make_default_logger()  # Initialize logging to default
     try:
         logger.info("Starting STM")
-
-        config.load_config()  # Load Neurobooth-OS configuration
 
         os.chdir(neurobooth_os.__path__[0])
         sys.stdout = NewStdout("STM", target_node="control", terminal_print=True)

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
 
     win = utils.make_win(False)
     eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
+    config.load_config()
     server_config = config.neurobooth_config[config.get_server_name_from_env()]
     fname = f"{server_config['local_data_dir']}calibration.edf"
     cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=fname)

--- a/neurobooth_os/transfer_data.py
+++ b/neurobooth_os/transfer_data.py
@@ -9,8 +9,6 @@ from neurobooth_os import config
 from neurobooth_os.util.constants import NODE_NAMES
 from neurobooth_os.log_manager import make_default_logger
 
-logger = make_default_logger()
-
 
 def log_output(pipe):
     for line in iter(pipe.readline, b''):  # b'\n'-separated lines
@@ -18,7 +16,6 @@ def log_output(pipe):
 
 
 def main(args: argparse.Namespace):
-    config.load_config()
     destination = config.neurobooth_config["remote_data_dir"]
     source = config.neurobooth_config[args.source_node_name]["local_data_dir"]
 
@@ -57,6 +54,8 @@ def parse_arguments() -> argparse.Namespace:
 
 
 if __name__ == "__main__":
+    config.load_config()
+    logger = make_default_logger()
     try:
         main(parse_arguments())
     except Exception as e:

--- a/neurobooth_os/transfer_data.py
+++ b/neurobooth_os/transfer_data.py
@@ -18,9 +18,8 @@ def log_output(pipe):
 
 
 def main(args: argparse.Namespace):
-
+    config.load_config()
     destination = config.neurobooth_config["remote_data_dir"]
-
     source = config.neurobooth_config[args.source_node_name]["local_data_dir"]
 
     try:


### PR DESCRIPTION
Right now, the Neurobooth config file is loaded on module import. This makes it difficult to run secondary post-processing scripts on other machines. (E.g., we had wanted to re-use the XDF split code in Neurobooth OS to regenerate corrected HDF5 files, but we would currently have trouble running such a script on the cluster.)

This PR makes loading the configs an explicit function call instead of code that is automatically run on import. It also allows specifying a config file in different locations and disabling of file path validation. (These are not things we would want to do in active Nuerobooth sessions, but may be necessary for secondary scripts leveraging Neurobooth code.)