### PR TITLE
Implements DB application log

### DIFF
--- a/examples/run_task_database.py
+++ b/examples/run_task_database.py
@@ -32,7 +32,7 @@ conn = meta.get_conn(database)
 win = utl.make_win(full_screen=False)
 
 task_func_dict = get_task_funcs(collection_id, conn)
-task_devs_kw = meta._get_device_kwargs_by_task(collection_id, conn)
+task_devs_kw = meta.get_device_kwargs_by_task(collection_id, conn)
 
 task_karg ={"win": win,
             "path": cfg.neurobooth_config['acquisition']['local_data_dir'],

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -6,7 +6,7 @@ import os.path as op
 import datetime
 import logging
 from typing import Optional
-from neurobooth_os.log_manager import make_default_logger
+from neurobooth_os.log_manager import make_db_logger
 import argparse
 import sys
 
@@ -165,7 +165,7 @@ def parse_arguments() -> argparse.Namespace:
 
 
 def main():
-    logger = make_default_logger()
+    logger = make_db_logger()
     iphone.DISABLE_LSL = True
 
     args = parse_arguments()

--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -26,7 +26,7 @@ def neurobooth_dump(args: argparse.Namespace) -> None:
         Command line arguments.
     """
     session_root = cfg.neurobooth_config[args.server]["local_data_dir"]
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     logger.debug(f'Session Root: {session_root}')
 
     # Connect to the iPhone
@@ -105,7 +105,7 @@ def dump_file(
     delete_zero_byte
         If true, delete files from the iPhone if no data is observed.
     """
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     if op.exists(file_name_out):  # Do not overwrite a file that already exists
         logger.error(f'Cannot write {file_name_out} as it already exists!')
         return
@@ -131,7 +131,7 @@ def dump_file(
 
 
 def parse_arguments() -> argparse.Namespace:
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     parser = argparse.ArgumentParser(description='Download and save all files on the iPhone (both .json and .MOV).')
     parser.add_argument(
         '--delete-zero-byte',
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logger = logging.getLogger("default")
+        logger = logging.getLogger('db')
         logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
         logger.critical(e, exc_info=sys.exc_info())
         raise

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -7,7 +7,7 @@ from time import time
 import multiprocessing as mp
 import logging
 from neurobooth_os.iout.mbient import scan_BLE, connect_device, reset_device, MbientFailedConnection
-from neurobooth_os.log_manager import make_default_logger
+from neurobooth_os.log_manager import make_db_logger
 
 
 DESCRIPTION = """Find and reset Mbient wearable devices.
@@ -204,7 +204,7 @@ class ResetDeviceProcess(mp.Process):
         return f'{self.device_info.name} <{self.device_info.address}>: {msg}'
 
     def run(self) -> None:
-        logger = make_default_logger()
+        logger = make_db_logger()
         t0 = time()
         try:
             device = connect_device(
@@ -267,7 +267,7 @@ def reset_devices(args: argparse.Namespace, devices: ADDRESS_MAP) -> (ADDRESS_MA
 
 
 def main():
-    logger = make_default_logger()
+    logger = make_db_logger()
     try:
         args = parse_arguments()
         devices = device_discovery(args)

--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -130,7 +130,7 @@ def device_discovery(args: argparse.Namespace) -> ADDRESS_MAP:
     elif args.mac:
         devices = discovery_mac(args.mac)
 
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     logger.debug(f'Devices:')
     print_device_info(devices, print_fn=logger.debug)
 
@@ -138,7 +138,7 @@ def device_discovery(args: argparse.Namespace) -> ADDRESS_MAP:
 
 
 def discovery_scan(timeout_sec: float, n_devices: int) -> ADDRESS_MAP:
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     logger.info('Scanning for devices...')
 
     t0 = time()
@@ -156,14 +156,14 @@ def discovery_scan(timeout_sec: float, n_devices: int) -> ADDRESS_MAP:
 
 
 def discovery_mac(addresses: List[str]) -> ADDRESS_MAP:
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     devices = [DeviceInfo(name=f'CL-{i}', address=address) for i, address in enumerate(addresses)]
     logger.info(f'Using {len(devices)} devices specified via command line.')
     return devices
 
 
 def discovery_json(file: str) -> ADDRESS_MAP:
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
 
     with open(file, 'r') as f:
         devices = json.load(f)
@@ -227,7 +227,7 @@ class ResetDeviceProcess(mp.Process):
                 logger.debug(self.format_message(f'Reset timed out!'))
 
     def on_disconnect(self, status) -> None:
-        logging.getLogger('default').debug(self.format_message(f'Disconnected with status {status}.'))
+        logging.getLogger('db').debug(self.format_message(f'Disconnected with status {status}.'))
         self.disconnect_event.set()
 
     @property
@@ -252,7 +252,7 @@ def reset_devices(args: argparse.Namespace, devices: ADDRESS_MAP) -> (ADDRESS_MA
         ) for device in devices
     ]
 
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     logger.info(f'Reset in progress...')
     t0 = time()
     for t in reset_processes:

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -595,7 +595,7 @@ def gui():
         if inlet_keys != list(inlets):
             inlet_keys = list(inlets)
             window["inlet_State"].update("\n".join(inlet_keys))
-
+    logging.shutdown()
     window.close()
     window["-OUTPUT-"].__del__()
     print("Session terminated")

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -28,7 +28,7 @@ from neurobooth_os.netcomm import (
 )
 from neurobooth_os.config import neurobooth_config
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes
-from neurobooth_os.log_manager import make_default_logger
+from neurobooth_os.log_manager import make_db_logger
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.iout.split_xdf import split_sens_files, get_xdf_name
 from neurobooth_os.iout import marker_stream
@@ -37,7 +37,7 @@ import neurobooth_os.config as cfg
 server_config = cfg.neurobooth_config["control"]
 
 def setup_log(sg_handler = None):
-    logger = make_default_logger()
+    logger = make_db_logger("", "")
     logger.setLevel(logging.DEBUG)
     if sg_handler:
         logger.addHandler(sg_handler)

--- a/neurobooth_os/iout/camera_intel.py
+++ b/neurobooth_os/iout/camera_intel.py
@@ -72,7 +72,7 @@ class VidRec_Intel:
 
         self.outlet = self.createOutlet()
 
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         self.logger.debug(
             f'RealSense [{self.device_index}] ({self.serial_num}): fps={str(self.fps)}; frame_size={str(self.frameSize)}'
         )

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -84,7 +84,7 @@ class EyeTracker:
         )
         self.outlet = StreamOutlet(self.stream_info)
 
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         self.logger.debug(f'EyeLink: sample_rate={str(self.sample_rate)}')
 
         print(f"-OUTLETID-:{self.streamName}:{self.oulet_id}")

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -76,7 +76,7 @@ class VidRec_Flir:
         self.image_queue = queue.Queue(0)
         self.outlet = self.createOutlet()
 
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         self.logger.debug(f'FLIR: fps={str(self.fps)}; frame_size={str((self.sizex, self.sizey))}')
 
     def get_cam(self):

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -196,7 +196,7 @@ class IPhone:
         self.streaming = False
         self.streamName = "IPhoneFrameIndex"
         self.outlet_id = str(uuid.uuid4())
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
 
         # --------------------------------------------------------------------------------
         # Lock-based threading objects and their associated protected data
@@ -820,7 +820,7 @@ class IPhoneListeningThread(threading.Thread):
     def __init__(self, iphone: IPhone):
         self._iphone = iphone
         self._running = True
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         threading.Thread.__init__(self)
 
     def run(self):

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -38,7 +38,7 @@ def start_lsl_threads(node_name, collection_id="mvp_030", win=None, conn=None):
     logger = logging.getLogger('session')
 
     # Get params from all tasks
-    kwarg_devs = meta._get_device_kwargs_by_task(collection_id, conn)
+    kwarg_devs = meta.get_device_kwargs_by_task(collection_id, conn)
     # Get all device params from session
     kwarg_alldevs = {}
     for dc in kwarg_devs.values():

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -35,7 +35,7 @@ def start_lsl_threads(node_name, collection_id="mvp_030", win=None, conn=None):
         print("getting conn")
         conn = meta.get_conn(database)
 
-    logger = logging.getLogger('session')
+    logger = logging.getLogger('db')
 
     # Get params from all tasks
     kwarg_devs = meta.get_device_kwargs_by_task(collection_id, conn)
@@ -134,7 +134,7 @@ def start_lsl_threads(node_name, collection_id="mvp_030", win=None, conn=None):
 
 
 def close_streams(streams):
-    logger = logging.getLogger('session')
+    logger = logging.getLogger('db')
 
     for k in list(streams):
         print(f"Closing {k} stream")
@@ -148,7 +148,7 @@ def close_streams(streams):
 
 
 def reconnect_streams(streams):
-    logger = logging.getLogger('session')
+    logger = logging.getLogger('db')
 
     for k in list(streams):
         if k.split("_")[0] in ["hiFeed", "Intel", "FLIR", "IPhone"]:

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -494,7 +494,7 @@ class Mbient:
         self.streaming: bool = False
         self.n_samples_streamed = 0
 
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         self.logger.debug(self.format_message(f'acc={self.accel_params}; gyro={self.gyro_params}'))
 
     def format_message(self, msg: str) -> str:
@@ -838,7 +838,7 @@ def test_script() -> None:
     if args.decimate < 1:
         parser.error('Invalid decimate specified!')
 
-    logger = logging.getLogger('session')
+    logger = logging.getLogger('db')
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging.DEBUG)
     console_handler.setFormatter(logging.Formatter('|%(levelname)s| [%(asctime)s] L%(lineno)d> %(message)s'))

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -38,7 +38,7 @@ def get_conn(database):
 
     if database is None:
         logger.critical("Database name is a required parameter.")
-        raise  # TODO: Need appropriate exception type for database connection errors
+        raise  RuntimeError("No database name was provided to get_conn().")
 
     port = neurobooth_config["database"]["port"]
     tunnel = SSHTunnelForwarder(
@@ -53,7 +53,6 @@ def get_conn(database):
     tunnel.start()
     host = tunnel.local_bind_host
     port = tunnel.local_bind_port
-    print(host, port, database)
 
     conn = psycopg2.connect(
         database=database,

--- a/neurobooth_os/iout/microphone.py
+++ b/neurobooth_os/iout/microphone.py
@@ -81,7 +81,7 @@ class MicStream:
         )
         print(f"-OUTLETID-:Audio:{self.oulet_id}")
 
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         self.logger.debug(
             f'Microphone: sample_rate={str(self.fps)}; save_on_disk={self.save_on_disk}; channels={self.CHANNELS}'
         )

--- a/neurobooth_os/iout/mouse_tracker.py
+++ b/neurobooth_os/iout/mouse_tracker.py
@@ -33,7 +33,7 @@ class MouseStream:
         print(f"-OUTLETID-:Mouse:{self.oulet_id}")
         self.streaming = False
 
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
         self.logger.debug('Mouse: Created Object')
 
     def start(self):

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -13,6 +13,10 @@ LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(fu
 
 DEFAULT_LOG_PATH = neurobooth_config["default_log_path"]
 
+SESSION_ID: str = ""
+
+SUBJECT_ID: str = ""
+
 
 def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
     logger = logging.getLogger('session')
@@ -45,6 +49,33 @@ def make_session_logger_debug(
         logger.addHandler(console_handler)
 
     logger.setLevel(log_level)
+    return logger
+
+
+def make_db_logger(subject: str, session: str, device: str = None) -> logging.Logger:
+    """Returns a logger that logs to the database and sets the subject id and session to be used for subsequent
+    logging calls.
+
+    If the subject or session should be cleared, the argument should be an empty string. Passing None, will not reset
+    to allow this logger to be used when the function that is logging does not itself have access to the session/subject,
+    but it remains valid none-the-less
+    """
+    import neurobooth_os.iout.metadator
+
+    global SUBJECT_ID, SESSION_ID
+    if subject is not None:
+        SUBJECT_ID = subject
+    if session is not None:
+        SESSION_ID = session
+
+    logger = logging.getLogger('default')
+    logger.addHandler(neurobooth_os.iout.metadator.get_db_log_handler())
+    extra = {
+        "session": SESSION_ID,
+        "subject": SUBJECT_ID,
+        "device": device
+    }
+    logging.LoggerAdapter(logger, extra)
     return logger
 
 

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -6,16 +6,20 @@ from typing import Optional, List, Dict, Any
 import psutil
 from threading import Thread, Event
 import json
+import platform
+import traceback
 
 from neurobooth_os.config import neurobooth_config
+from neurobooth_os.iout import metadator
 
 LOG_FORMAT = logging.Formatter('|%(levelname)s| [%(asctime)s] %(filename)s, %(funcName)s, L%(lineno)d> %(message)s')
 
 DEFAULT_LOG_PATH = neurobooth_config["default_log_path"]
 
 SESSION_ID: str = ""
-
 SUBJECT_ID: str = ""
+
+DB_LOGGER: Optional[logging.Logger] = None
 
 
 def make_session_logger_debug(
@@ -41,55 +45,64 @@ def make_session_logger_debug(
     return logger
 
 
-def make_db_logger(subject: str, session: str, device: str = None) -> logging.Logger:
+def make_db_logger(subject: str = None,
+                   session: str = None,
+                   fallback_log_path: str = None) -> logging.Logger:
     """Returns a logger that logs to the database and sets the subject id and session to be used for subsequent
     logging calls.
 
-    If the subject or session should be cleared, the argument should be an empty string. Passing None, will not reset
-    to allow this logger to be used when the function that is logging does not itself have access to the session/subject,
-    but it remains valid none-the-less
+    If the subject or session should be cleared, the argument should be an empty string. Passing None, will NOT reset
     """
     import neurobooth_os.iout.metadator
 
-    global SUBJECT_ID, SESSION_ID
+    global SUBJECT_ID, SESSION_ID, DB_LOGGER
+
     if subject is not None:
         SUBJECT_ID = subject
     if session is not None:
         SESSION_ID = session
 
-    logger = logging.getLogger('db')
-    logger.addHandler(neurobooth_os.iout.metadator.get_db_log_handler())
-    extra = {
-        "session": SESSION_ID,
-        "subject": SUBJECT_ID,
-        "device": device
-    }
-    logging.LoggerAdapter(logger, extra)
-    return logger
+    # Don't reinitialize the logger
+    if DB_LOGGER is None:
+        logger = logging.getLogger('db')
+        logger.addHandler(get_db_log_handler(fallback_log_path))
+        extra = {"device": ""}
+        logging.LoggerAdapter(logger, extra)
+        DB_LOGGER = logger
+    return DB_LOGGER
 
 
-def make_default_logger(
+def get_default_log_handler(
         log_path=DEFAULT_LOG_PATH,
         log_level=logging.DEBUG,
-) -> logging.Logger:
+):
+    """Returns a log handler suitable for default logging
+    """
+
     if not os.path.exists(log_path):
         os.makedirs(log_path)
-
-    logger = logging.getLogger('default')
     time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
     file = os.path.join(log_path, f'default_{time_str}.log')
 
     file_handler = logging.FileHandler(file)
     file_handler.setLevel(log_level)
     file_handler.setFormatter(LOG_FORMAT)
-    logger.addHandler(file_handler)
+    return file_handler
+
+
+def make_default_logger(
+        log_path=DEFAULT_LOG_PATH,
+        log_level=logging.DEBUG,
+) -> logging.Logger:
+    logger = logging.getLogger('default')
+    logger.addHandler(get_default_log_handler(log_path, log_level))
 
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(log_level)
     console_handler.setFormatter(LOG_FORMAT)
     logger.addHandler(console_handler)
 
-    make_session_logger_debug(file=file)
+    # make_session_logger_debug(file=file)
 
     logger.setLevel(log_level)
     return logger
@@ -187,3 +200,92 @@ class SystemResourceLogger(Thread):
         """Stop logging and wait for the thread to complete."""
         self.sleep_event.set()
         self.join(timeout=self.log_interval_sec + 1)
+
+
+class PostgreSQLHandler(logging.Handler):
+    """
+    A :class:`logging.Handler` that logs to the `log` PostgreSQL table
+    Does not use :class:`PostgreSQL`, keeping its own connection, in autocommit
+    mode.
+    .. DANGER:
+        Beware explicit or automatic locks taken out in the main requests'
+        transaction could deadlock with this INSERT!
+        In general, avoid touching the log table entirely. SELECT queries
+        do not appear to block with INSERTs. If possible, touch the log table
+        in autocommit mode only.
+    `db_settings` is passed to :meth:`psycopg2.connect` as kwargs
+    (``connect(**db_settings)``).
+    """
+
+    _query = "INSERT INTO log_application " \
+             "(session_id, subject_id, server_type, server_id, server_time, log_level, device, " \
+             "filename, function, line_no, message, traceback)" \
+             " VALUES " \
+             " (%(session_id)s, %(subject_id)s, %(server_type)s, %(server_id)s, %(server_time)s, %(log_level)s, " \
+             " %(device)s, %(filename)s, %(function)s, %(line_no)s, %(message)s, %(traceback)s)"
+
+    # see TYPE log_level
+    _levels = ('debug', 'info', 'warning', 'error', 'critical')
+
+    def __init__(self, fallback_log_path:str = None, log_level=logging.DEBUG):
+        super(PostgreSQLHandler, self).__init__()
+        self.fallback_log_path = fallback_log_path
+        self.setLevel(log_level)
+        try:
+            self._get_logger_connection()
+        except Exception as Argument:
+            msg = "Unable to connect to database for logging. Falling back to default file logging."
+            self.handle_logging_exception()
+            logging.getLogger("db").exception(msg)
+
+    def emit(self, record):
+        try:
+            level = record.levelname.lower()
+            if level not in self._levels:
+                level = "debug"
+
+            if record.exc_info:
+                lines = traceback.format_exception(*record.exc_info)
+                traceback_text = ''.join(lines)
+            else:
+                traceback_text = None
+
+            args = {
+                "log_level": level,
+                "message": record.getMessage(),
+                "function": record.funcName,
+                "filename": record.filename,
+                "line_no": record.lineno,
+                "traceback": traceback_text,
+                "server_type": neurobooth_config["server_name"],
+                "server_id": platform.uname().node,
+                "subject_id": SUBJECT_ID,
+                "session_id": SESSION_ID,
+                "server_time": datetime.fromtimestamp(record.created),
+                "device": getattr(record, "device", None),
+            }
+
+            self.cursor.execute(self._query, args)
+        except Exception as Argument:
+            msg = "An exception occurred attempting to log to DB. Falling back to file-system log."
+            self.handle_logging_exception()
+            self.handleError(record)
+            logging.getLogger("db").exception(msg)
+
+    def _get_logger_connection(self):
+        self.connection = metadator.get_conn(neurobooth_config["database"]["dbname"])
+        self.connection.autocommit = True
+        self.cursor = self.connection.cursor()
+
+    def handle_logging_exception(self):
+        logger = logging.getLogger("db")
+        if self in logger.handlers:
+            logger.removeHandler(self)
+        default_handler = get_default_log_handler(self.fallback_log_path)
+        if default_handler not in logger.handlers:
+            logger.addHandler(default_handler)
+
+def get_db_log_handler(
+        fallback_log_path: str = DEFAULT_LOG_PATH,
+        log_level=logging.DEBUG,):
+    return PostgreSQLHandler(fallback_log_path, log_level)

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -18,17 +18,6 @@ SESSION_ID: str = ""
 SUBJECT_ID: str = ""
 
 
-def make_session_logger(session_folder: str, machine_name: str, log_level=logging.DEBUG) -> logging.Logger:
-    logger = logging.getLogger('session')
-    time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
-    file_handler = logging.FileHandler(os.path.join(session_folder, f'{machine_name}_session_{time_str}.log'))
-    file_handler.setLevel(log_level)
-    file_handler.setFormatter(LOG_FORMAT)
-    logger.addHandler(file_handler)
-    logger.setLevel(log_level)
-    return logger
-
-
 def make_session_logger_debug(
         file: Optional[str] = None,
         console: bool = False,
@@ -68,7 +57,7 @@ def make_db_logger(subject: str, session: str, device: str = None) -> logging.Lo
     if session is not None:
         SESSION_ID = session
 
-    logger = logging.getLogger('default')
+    logger = logging.getLogger('db')
     logger.addHandler(neurobooth_os.iout.metadator.get_db_log_handler())
     extra = {
         "session": SESSION_ID,

--- a/neurobooth_os/mock/mock_server_acq.py
+++ b/neurobooth_os/mock/mock_server_acq.py
@@ -48,7 +48,7 @@ def mock_acq_routine(host, port, conn):
             if not os.path.exists(ses_folder):
                 os.mkdir(ses_folder)
 
-            task_devs_kw = meta._get_device_kwargs_by_task(collection_id, conn)
+            task_devs_kw = meta.get_device_kwargs_by_task(collection_id, conn)
             if len(streams):
                 streams = reconnect_streams(streams)
             else:

--- a/neurobooth_os/mock/mock_server_stm.py
+++ b/neurobooth_os/mock/mock_server_stm.py
@@ -57,7 +57,7 @@ def mock_stm_routine(host, port, conn):
             del log_task["subject_id-date"]
 
             task_func_dict = get_task_funcs(collection_id, conn)
-            task_devs_kw = meta._get_device_kwargs_by_task(collection_id, conn)
+            task_devs_kw = meta.get_device_kwargs_by_task(collection_id, conn)
 
             if len(streams):
                 print("Checking prepared devices")

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -12,7 +12,7 @@ import json
 
 import neurobooth_os
 from neurobooth_os import config
-from neurobooth_os.log_manager import make_default_logger, make_db_logger
+from neurobooth_os.log_manager import make_db_logger
 from neurobooth_os.netcomm import NewStdout, get_client_messages
 from neurobooth_os.iout.camera_brio import VidRec_Brio
 from neurobooth_os.iout.lsl_streamer import (
@@ -39,7 +39,7 @@ def Main():
     sys.stdout = NewStdout("ACQ", target_node="control", terminal_print=True)
 
     # Initialize default logger
-    logger = make_default_logger()
+    logger = make_db_logger("", "")
     logger.info("Starting ACQ")
     try:
         run_acq(logger)

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -202,6 +202,7 @@ def run_acq(logger):
             if system_resource_logger is not None:
                 system_resource_logger.stop()
                 system_resource_logger = None
+            logging.shutdown()
 
             if "shutdown" in data:
                 sys.stdout = sys.stdout.terminal

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -1,3 +1,4 @@
+import logging
 import socket
 import sys
 import os
@@ -333,6 +334,7 @@ def run_stm(logger):
                 win.close()
                 sys.stdout = sys.stdout.terminal
                 s1.close()
+                logging.shutdown()
 
             streams = close_streams(streams)
 

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -34,8 +34,7 @@ from neurobooth_os.netcomm import (
 from neurobooth_os.tasks.wellcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
 from neurobooth_os.tasks.task_importer import get_task_funcs
-from neurobooth_os.log_manager import make_session_logger, make_default_logger, SystemResourceLogger
-
+from neurobooth_os.log_manager import make_default_logger, SystemResourceLogger, make_db_logger
 
 server_config = config.neurobooth_config["presentation"]
 
@@ -91,17 +90,18 @@ def run_stm(logger):
             log_task = eval(
                 data.replace(f"prepare:{collection_id}:{database_name}:", "")
             )
-            subject_id_date = log_task["subject_id-date"]
+            subject_id: str = log_task["subject_id"]
+            session_name = log_task["subject_id-date"]
             conn = meta.get_conn(database=database_name)
             logger.info(f"Database name is {database_name}.")
-            ses_folder = f"{server_config['local_data_dir']}{subject_id_date}"
+            ses_folder = f"{server_config['local_data_dir']}{session_name}"
 
             logger.info(f"Creating session folder: {ses_folder}")
             if not os.path.exists(ses_folder):
                 os.mkdir(ses_folder)
 
-            logger.info("Creating session logger in session folder.")
-            logger = make_session_logger(ses_folder, 'STM')
+            logger.info("Creating db logger initialized for the session.")
+            logger = make_db_logger(subject_id, session_name)
             logger.info('LOGGER CREATED')
 
             if system_resource_logger is None:
@@ -112,7 +112,7 @@ def run_stm(logger):
             del log_task["subject_id-date"]
 
             task_func_dict = get_task_funcs(collection_id, conn)
-            task_devs_kw = meta._get_device_kwargs_by_task(collection_id, conn)
+            task_devs_kw = meta.get_device_kwargs_by_task(collection_id, conn)
 
             if len(streams):
                 print("Checking prepared devices")
@@ -134,8 +134,8 @@ def run_stm(logger):
             # Shared task keyword arguments
             task_karg = {
                 "win": win,
-                "path": server_config["local_data_dir"] + f"{subject_id_date}/",
-                "subj_id": subject_id_date,
+                "path": server_config["local_data_dir"] + f"{session_name}/",
+                "subj_id": session_name,
                 "marker_outlet": streams["marker"],
                 "prompt": True,
             }
@@ -217,14 +217,14 @@ def run_stm(logger):
                     logger.info(f'SENDING record_start TO ACQ')
                     acq_result = executor.submit(
                         socket_message,
-                        f"record_start::{subject_id_date}_{tsk_strt_time}_{t_obs_id}::{task}",
+                        f"record_start::{session_name}_{tsk_strt_time}_{t_obs_id}::{task}",
                         "acquisition",
                         wait_data=10,
                     )
 
                     # Start eyetracker if device in task
                     if "Eyelink" in streams and any("Eyelink" in d for d in list(task_devs_kw[task])):
-                        fname = f"{task_karg['path']}/{subject_id_date}_{tsk_strt_time}_{t_obs_id}.edf"
+                        fname = f"{task_karg['path']}/{session_name}_{tsk_strt_time}_{t_obs_id}.edf"
                         if "calibration_task" in task:  # if not calibration record with start method
                             this_task_kwargs.update({"fname": fname, "instructions": calib_instructions})
                         else:
@@ -279,7 +279,7 @@ def run_stm(logger):
                     if events is not None
                     else "event:datestamp"
                 )
-                log_task["task_notes_file"] = f"{subject_id_date}-{task}-notes.txt"
+                log_task["task_notes_file"] = f"{session_name}-{task}-notes.txt"
 
                 if tsk_fun.task_files is not None:
                     log_task["task_output_files"] = tsk_fun.task_files

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -34,7 +34,7 @@ from neurobooth_os.netcomm import (
 from neurobooth_os.tasks.wellcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
 from neurobooth_os.tasks.task_importer import get_task_funcs
-from neurobooth_os.log_manager import make_default_logger, SystemResourceLogger, make_db_logger
+from neurobooth_os.log_manager import SystemResourceLogger, make_db_logger
 
 server_config = config.neurobooth_config["presentation"]
 
@@ -44,7 +44,7 @@ def Main():
     sys.stdout = NewStdout("STM", target_node="control", terminal_print=True)
 
     # Initialize logging to default
-    logger = make_default_logger()
+    logger = make_db_logger()
     logger.info("Starting STM")
 
     try:

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -39,7 +39,7 @@ class Task:
         task_repeatable_by_subject=True,
         **kwargs,
     ):
-        self.logger = logging.getLogger('session')
+        self.logger = logging.getLogger('db')
 
         # Common markers
         self.marker_task_start = "Task_start"

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 import neurobooth_os.config as cfg
 
-from neurobooth_os.log_manager import make_default_logger, make_db_logger, make_session_logger
+from neurobooth_os.log_manager import make_default_logger, make_db_logger
 
 log_path = r"C:\neurobooth\test_data\test_logs"
 logger = make_default_logger(log_path)
@@ -50,6 +50,17 @@ class TestLogging(unittest.TestCase):
     def test_db_logging(self):
         print(cfg.neurobooth_config)
         db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
+
+        db_log = logging.getLogger("db")
+        db_log.critical("Microphone: Entering LSL Loop",
+                        extra={"device": "playstation"})
+
+        db_log = make_db_logger("", "")
+        db_log.error("No subject or session for me")
+
+    def test_db_logging2(self):
+        print(cfg.neurobooth_config)
+        db_log = logging.getLogger("db")
         db_log.critical("Microphone: Entering LSL Loop",
                         extra={"device": "playstation"})
 

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -7,7 +7,7 @@ import unittest
 
 from neurobooth_terra import Table
 
-from neurobooth_os.log_manager import make_default_logger, make_db_logger, test_log_handler_fallback
+from neurobooth_os.log_manager import make_default_logger, make_db_logger, _test_log_handler_fallback
 from neurobooth_os.iout.metadator import get_conn
 
 log_path = r"C:\neurobooth\test_data\test_logs"
@@ -154,7 +154,7 @@ class TestLogging(unittest.TestCase):
 
     def test_fallback(self):
         db_log = make_db_logger("foo", "bar", log_path, logging.DEBUG)
-        test_log_handler_fallback()
+        _test_log_handler_fallback()
         db_log.critical("Test fallback logging. No DB Connection should be available")
         file_list = os.listdir(log_path)[0]
         filename = os.path.join(log_path, file_list)

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -3,8 +3,9 @@ import os
 import shutil
 import sys
 import unittest
+import neurobooth_os.config as cfg
 
-from neurobooth_os.log_manager import make_default_logger
+from neurobooth_os.log_manager import make_default_logger, make_db_logger, make_session_logger
 
 log_path = r"C:\neurobooth\test_data\test_logs"
 logger = make_default_logger(log_path)
@@ -45,6 +46,15 @@ class TestLogging(unittest.TestCase):
 
         self.assertTrue("Exiting" in data)
         self.assertTrue("Traceback" in data)
+
+    def test_db_logging(self):
+        print(cfg.neurobooth_config)
+        db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
+        db_log.critical("Microphone: Entering LSL Loop",
+                        extra={"device": "playstation"})
+
+        db_log = make_db_logger("", "")
+        db_log.error("No subject or session for me")
 
 
 if __name__ == '__main__':

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -51,6 +51,12 @@ class TestLogging(unittest.TestCase):
         self.assertTrue("Exiting" in data)
         self.assertTrue("Traceback" in data)
 
+    def test_db_logging_shutdown(self):
+        """Tests to ensure log handler is closed """
+        db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
+        db_log.critical("Microphone: Entering LSL Loop", extra={"device": "playstation"})
+        logging.shutdown()
+
     def test_db_logging0(self):
         """Tests logging to database using make_db_logger with session and subject set"""
         db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -3,18 +3,20 @@ import os
 import shutil
 import sys
 import unittest
-import neurobooth_os.config as cfg
 
 from neurobooth_os.log_manager import make_default_logger, make_db_logger
 
 log_path = r"C:\neurobooth\test_data\test_logs"
-logger = make_default_logger(log_path)
 
 
 class TestLogging(unittest.TestCase):
 
-    def tearDown(self):
+    def setUp(self):
+        if not os.path.exists(log_path):
+            os.makedirs(log_path)
 
+    def tearDown(self):
+        logger = logging.getLogger("default")
         handlers = logger.handlers[:]
         for handler in handlers:
             logger.removeHandler(handler)
@@ -25,17 +27,19 @@ class TestLogging(unittest.TestCase):
             files = os.listdir(log_path)
             for file in files:
                 filename = os.path.join(log_path, file)
-                os.remove(filename)
-            shutil.rmtree(log_path)
+                # TODO(larry): uncomment below
+                #os.remove(filename)
+            #shutil.rmtree(log_path)
 
     def test_default_logging(self):
 
         def do_something():
-            raise ValueError(":(")
+            raise ValueError("Raising a test error. This should get logged.")
 
         try:
             do_something()
         except Exception as e:
+            logger = make_default_logger(log_path)
             logger.critical(f"An uncaught exception occurred. Exiting: {repr(e)}")
             logger.critical(e, exc_info=sys.exc_info())
 
@@ -47,25 +51,45 @@ class TestLogging(unittest.TestCase):
         self.assertTrue("Exiting" in data)
         self.assertTrue("Traceback" in data)
 
-    def test_db_logging(self):
-        print(cfg.neurobooth_config)
+    def test_db_logging0(self):
+        """Tests logging to database using make_db_logger with session and subject set"""
         db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
+        db_log.critical("Microphone: Entering LSL Loop", extra={"device": "playstation"})
+        db_log.critical("Another one.", extra={"device": "playstation"})
 
-        db_log = logging.getLogger("db")
-        db_log.critical("Microphone: Entering LSL Loop",
-                        extra={"device": "playstation"})
-
+    def test_db_logging1(self):
+        """Tests logging to database using make_db_logger with session and subject set to empty strings"""
         db_log = make_db_logger("", "")
-        db_log.error("No subject or session for me")
+        db_log.critical("No subject or session when log created.", extra={"device": "playstation"})
 
     def test_db_logging2(self):
-        print(cfg.neurobooth_config)
-        db_log = logging.getLogger("db")
-        db_log.critical("Microphone: Entering LSL Loop",
-                        extra={"device": "playstation"})
-
+        """Tests logging to database with session and subject set to empty strings AFTER being set to values"""
+        db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
+        db_log.critical("Subject and session set for the logger", extra={"device": "playstation"})
         db_log = make_db_logger("", "")
-        db_log.error("No subject or session for me")
+        db_log.error("No subject or session for new records")
+
+    # @unittest.skip("Test requires that DB Connection not succeed (i.e. run outside VPN)")
+    def test_db_logging3(self):
+        """Tests logging fallback to local file logging.
+        """
+        db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12", log_path)
+        db_log.critical("Test fallback logging. No DB Connection should be available")
+
+        filename = os.path.join(log_path, os.listdir(log_path)[0])
+
+        with open(filename, 'r') as file:
+            data = file.read()
+        self.assertTrue("fallback" in data)
+
+    def test_db_logging_with_traceback(self):
+        """Evaluate how tracebacks are handled in database.
+        """
+        db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12", log_path)
+        try:
+            raise Exception("This is a test")
+        except Exception as Argument:
+            db_log.exception("Test db logging with traceback")
 
 
 if __name__ == '__main__':

--- a/neurobooth_os/tests/test_logging.py
+++ b/neurobooth_os/tests/test_logging.py
@@ -1,12 +1,40 @@
+import inspect
 import logging
 import os
 import shutil
 import sys
 import unittest
 
+from neurobooth_terra import Table
+
 from neurobooth_os.log_manager import make_default_logger, make_db_logger
+from neurobooth_os.iout.metadator import get_conn
 
 log_path = r"C:\neurobooth\test_data\test_logs"
+database = "mock_neurobooth_1"
+
+subject = "1111111"
+session = "1111111_2023_12_25 12:12:12"
+
+
+def get_records(conn=get_conn(database), where=None):
+    """Test utility for querying log_application table. Returns results as a dataframe"""
+    table = Table("log_application", conn=conn)
+    if where is not None:
+        task_df = table.query(where)
+    else:
+        task_df = table.query()
+    print(task_df)
+    return task_df
+
+
+def delete_records(conn=get_conn(database), where=None) -> None:
+    """Test utility for querying log_application table. Returns results as a dataframe"""
+    table = Table("log_application", conn=conn)
+    if where is not None:
+        table.delete_row(where)
+    else:
+        table.delete_row("1=1")
 
 
 class TestLogging(unittest.TestCase):
@@ -22,6 +50,7 @@ class TestLogging(unittest.TestCase):
             logger.removeHandler(handler)
             handler.close()
         logging.shutdown()
+        delete_records()
 
         if os.path.exists(log_path):
             files = os.listdir(log_path)
@@ -52,7 +81,7 @@ class TestLogging(unittest.TestCase):
         self.assertTrue("Traceback" in data)
 
     def test_db_logging_shutdown(self):
-        """Tests to ensure log handler is closed """
+        """Tests to ensure log handler is closed (or at least, doesn't blow up when closing) """
         db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
         db_log.critical("Microphone: Entering LSL Loop", extra={"device": "playstation"})
         logging.shutdown()
@@ -63,17 +92,51 @@ class TestLogging(unittest.TestCase):
         db_log.critical("Microphone: Entering LSL Loop", extra={"device": "playstation"})
         db_log.critical("Another one.", extra={"device": "playstation"})
 
+        df = get_records()
+        assert df.iloc[0]["subject_id"] == subject
+        assert df.iloc[0]["session_id"] == session
+        assert df.iloc[0]["message"] == "Microphone: Entering LSL Loop"
+
+        assert df.iloc[1]["subject_id"] == subject
+        assert df.iloc[1]["session_id"] == session
+        assert df.iloc[1]["message"] == "Another one."
+
     def test_db_logging1(self):
         """Tests logging to database using make_db_logger with session and subject set to empty strings"""
         db_log = make_db_logger("", "")
-        db_log.critical("No subject or session when log created.", extra={"device": "playstation"})
+        msg = "No subject or session when log created."
+        db_log.critical(msg, extra={"device": "playstation"})
+
+        mod_name = sys.modules[__name__].__name__ + ".py"
+        fun_name = inspect.stack()[0][3]
+
+        df = get_records()
+        assert df.shape[0] == 1
+        assert df.iloc[0]["log_level"].upper() == "CRITICAL"
+        assert df.iloc[0]["device"] == "playstation"
+        assert df.iloc[0]["subject_id"] == ""
+        assert df.iloc[0]["session_id"] == ""
+        assert df.iloc[0]["server_type"] == "control"
+        assert df.iloc[0]["server_id"] != ""
+        assert df.iloc[0]["server_time"] is not None
+        assert df.iloc[0]["filename"] == mod_name
+        assert df.iloc[0]["function"] == fun_name
+        assert df.iloc[0]["line_no"] >= 1
+        assert df.iloc[0]["message"] == msg
+        assert df.iloc[0]["traceback"] is None
 
     def test_db_logging2(self):
         """Tests logging to database with session and subject set to empty strings AFTER being set to values"""
-        db_log = make_db_logger("1111111", "1111111_2023_12_25 12:12:12")
+        db_log = make_db_logger(subject, session)
         db_log.critical("Subject and session set for the logger", extra={"device": "playstation"})
         db_log = make_db_logger("", "")
         db_log.error("No subject or session for new records")
+        df = get_records()
+        assert df.iloc[0]["subject_id"] == subject
+        assert df.iloc[0]["session_id"] == session
+
+        assert df.iloc[1]["subject_id"] == ""
+        assert df.iloc[1]["session_id"] == ""
 
     # @unittest.skip("Test requires that DB Connection not succeed (i.e. run outside VPN)")
     def test_db_logging3(self):
@@ -96,6 +159,17 @@ class TestLogging(unittest.TestCase):
             raise Exception("This is a test")
         except Exception as Argument:
             db_log.exception("Test db logging with traceback")
+        df = get_records()
+        assert df.iloc[0]["traceback"] is not None
+        assert "This is a test" in df.iloc[0]["traceback"]
+
+    def test_get_records(self):
+        """Meta-testing: Tests the get_records and delete_records utility function used in these tests"""
+        df = get_records()
+        assert(df is not None)
+        delete_records()
+        df = get_records()
+        assert df.empty
 
 
 if __name__ == '__main__':

--- a/neurobooth_os/transfer_data.py
+++ b/neurobooth_os/transfer_data.py
@@ -7,9 +7,9 @@ import argparse
 
 from neurobooth_os import config
 from neurobooth_os.util.constants import NODE_NAMES
-from neurobooth_os.log_manager import make_default_logger
+from neurobooth_os.log_manager import make_db_logger
 
-logger = make_default_logger()
+logger = make_db_logger()
 
 
 def log_output(pipe):


### PR DESCRIPTION
NOTE: This PR requires a new database table

Implements application logging to the neurobooth database specified in the config file. Log records are added to the table log_application.

Most uses of the default log and the session log have been replaced by this new logger. Uses of the session_db log were left intact.