### PR TITLE
Removing iphone dumpall from ACQ shutdown

### DIFF
--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -260,15 +260,6 @@ class DeviceManager:
                 return stream.frame_preview()
         return None
 
-    def iphone_log_file_list(self):
-        for stream_name, stream in self.streams.items():
-            if "IPhone" in stream_name:
-                iphone_files, _ = stream.dumpall_getfilelist()
-                if iphone_files is not None:
-                    self.logger.info(f'iPhone has {len(iphone_files)} waiting for dump: {iphone_files}')
-                else:
-                    self.logger.warning(f'iPhone did not return a list of files to dump.')
-
     def close_streams(self) -> None:
         for stream_name, stream in self.streams.items():
             print(f"Closing stream {stream_name}")

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -155,7 +155,6 @@ def run_acq(logger):
             sys.stdout = sys.stdout.terminal
             s1.close()
 
-            device_manager.iphone_log_file_list()    # Log the list of files present on the iPhone
             device_manager.close_streams()
 
             if lowFeed_running:


### PR DESCRIPTION
The dumpall at the end of ACQ shutdown is purely for logging purposes, but has been causing issues because the dumpall has been running slowly recently. This PR simply removes the dumpall call and related logging.