### PR TITLE
Remove or fix device plotting issue

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -14,7 +14,6 @@ import cv2
 import numpy as np
 import psutil
 from typing import Dict
-import asyncio
 
 import PySimpleGUI as sg
 import liesl
@@ -610,10 +609,6 @@ def gui():
 
 def main():
     """The starting point of Neurobooth"""
-
-    # This is a workaround for Windows-specific bug in python 3.8 loop management
-    # TODO: Check for fix in newer Python version when we upgrade
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     cfg.load_config()  # Load Neurobooth-OS configuration
     logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -14,6 +14,7 @@ import cv2
 import numpy as np
 import psutil
 from typing import Dict
+import asyncio
 
 import PySimpleGUI as sg
 import liesl
@@ -609,6 +610,11 @@ def gui():
 
 def main():
     """The starting point of Neurobooth"""
+
+    # This is a workaround for Windows-specific bug in python 3.8 loop management
+    # TODO: Check for fix in newer Python version when we upgrade
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
     cfg.load_config()  # Load Neurobooth-OS configuration
     logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
     try:

--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -244,8 +244,6 @@ def _main_layout(sess_info, frame_sz=(270, 480)):
                 _lay_butt("Initiate servers", "-init_servs-"),
                 _space(5),
                 _lay_butt("Connect Devices", "-Connect-"),
-                _space(5),
-                _lay_butt("Plot Devices", "plot"),
             ],
             [_space()],
             [

--- a/neurobooth_os/realtime/lsl_plotter.py
+++ b/neurobooth_os/realtime/lsl_plotter.py
@@ -4,6 +4,7 @@ Created on Fri Mar 19 17:43:09 2021
 
 @author: Adonay
 """
+import asyncio
 
 import numpy as np
 import pylsl
@@ -70,11 +71,11 @@ class stream_plotter:
         self.inlets = inlets
 
         if any(
-            [
-                True
-                for k in ["Mouse", "mbient", "Audio", "EyeLink"]
-                if any(k in v for v in list(inlets))
-            ]
+                [
+                    True
+                    for k in ["Mouse", "mbient", "Audio", "EyeLink"]
+                    if any(k in v for v in list(inlets))
+                ]
         ):
             print("starting thread update_ts")
             self.thread_ts = threading.Thread(target=self.update_ts, daemon=True)
@@ -147,9 +148,9 @@ class stream_plotter:
                     inlet.line = axs[ax_ith].plot(inlet.xdata, inlet.ydata)
 
                 inlet.ydata = np.vstack(
-                    (inlet.ydata[ts.shape[0] - buff_size : -1, :], tv)
+                    (inlet.ydata[ts.shape[0] - buff_size: -1, :], tv)
                 )
-                inlet.xdata = np.hstack((inlet.xdata[ts.shape[0] - buff_size : -1], ts))
+                inlet.xdata = np.hstack((inlet.xdata[ts.shape[0] - buff_size: -1], ts))
 
                 for i, chn in enumerate(inlet.ydata.T):
                     inlet.line[i].set_data(inlet.xdata, chn)
@@ -171,6 +172,11 @@ class stream_plotter:
 
         self.pltotting_ts = False
         plt.close(fig)
+
+
+# This is a workaround for Windows-specific bug in python 3.8 loop management
+# TODO: Check for fix in newer Python version when we upgrade
+asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 def mypause(interval):

--- a/neurobooth_os/realtime/lsl_plotter.py
+++ b/neurobooth_os/realtime/lsl_plotter.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Created on Fri Mar 19 17:43:09 2021
-
-@author: Adonay
+Plots device output in realtime
 """
-import asyncio
 
 import numpy as np
 import pylsl
@@ -12,7 +9,6 @@ import matplotlib.pyplot as plt
 import matplotlib
 import cv2
 import threading
-import time
 
 
 def create_lsl_inlets(stream_ids):

--- a/neurobooth_os/realtime/lsl_plotter.py
+++ b/neurobooth_os/realtime/lsl_plotter.py
@@ -175,10 +175,6 @@ class stream_plotter:
 
 
 def mypause(interval):
-    # This is a workaround for Windows-specific bug in python 3.8 loop management
-    # TODO: Check for fix in newer Python version when we upgrade
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     backend = plt.rcParams["backend"]
     if backend in matplotlib.rcsetup.interactive_bk:
         figManager = matplotlib._pylab_helpers.Gcf.get_active()

--- a/neurobooth_os/realtime/lsl_plotter.py
+++ b/neurobooth_os/realtime/lsl_plotter.py
@@ -174,12 +174,11 @@ class stream_plotter:
         plt.close(fig)
 
 
-# This is a workaround for Windows-specific bug in python 3.8 loop management
-# TODO: Check for fix in newer Python version when we upgrade
-asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
-
 def mypause(interval):
+    # This is a workaround for Windows-specific bug in python 3.8 loop management
+    # TODO: Check for fix in newer Python version when we upgrade
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
     backend = plt.rcParams["backend"]
     if backend in matplotlib.rcsetup.interactive_bk:
         figManager = matplotlib._pylab_helpers.Gcf.get_active()


### PR DESCRIPTION
Device plotting fails on python 3.8 due to a python bug that affects only Windows.  The bug affects event loop management.  The button to invoke plotting was removed, but the plotting code was left intact. 

I attempted to work-around the issue using an approach suggested online, but without success. The approach is to set the event handling explicitly to the old windows method, using: 

`asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())`

It could either be that I didn't set it in the right location or that it is overridden further down in the code (in QT, perhaps?). 

Tested in staging.