### PR TITLE
Correcting column headers for gaze resolution

### DIFF
--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -57,12 +57,12 @@ class EyeTracker:
             stream_info=StreamInfo("EyeLink", "Gaze", 13, self.sample_rate, "double64", self.oulet_id),
             device_id=self.device_id,
             sensor_ids=self.sensor_ids,
-            data_version=DataVersion(1, 0),
+            data_version=DataVersion(1, 1),
             columns=[
                 'R_GazeX', 'R_GazeY', 'R_PupilSize',
                 'L_GazeX', 'L_GazeY', 'L_PupilSize',
                 'Target_PositionX', 'Target_PositionY', 'Target_Distance',
-                'R_PPD', 'L_PPD',
+                'ResolutionX', 'ResolutionY',
                 'Time_EDF', 'Time_NUC'
             ],
             column_desc={
@@ -75,8 +75,8 @@ class EyeTracker:
                 'Target_PositionX': 'Horizontal location of the bullseye target (camera pixels)',
                 'Target_PositionY': 'Vertical location of the bullseye target (camera pixels)',
                 'Target_Distance': 'Distance to the bullseye target',
-                'R_PPD': 'Right eye: Angular resolution at current gaze position (pixels per visual degree)',
-                'L_PPD': 'Left eye: Angular resolution at current gaze position (pixels per visual degree)',
+                'ResolutionX': 'Horizontal angular resolution at current gaze position (pixels per visual degree)',
+                'ResolutionY': 'Vertical angular resolution at current gaze position (pixels per visual degree)',
                 'Time_EDF': 'Timestamp within the EDF file (ms)',
                 'Time_NUC': 'Local timestamp of sample receipt by the NUC machine (s)',
             },
@@ -215,10 +215,8 @@ class EyeTracker:
             t2 = t1
 
             smp = self.tk.getNewestSample()  # check smp object, see et.tk.getNextData()
-
             if smp is not None:
                 if old_sample is None or old_sample.getTime() != smp.getTime():
-
                     ppd = smp.getPPD()
                     timestamp = smp.getTime()
                     timestamp_local = local_clock()
@@ -226,19 +224,11 @@ class EyeTracker:
                     self.timestamps_local.append(timestamp_local)
 
                     values = [
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        smp.getTargetX(),
-                        smp.getTargetY(),
-                        smp.getTargetDistance(),
-                        ppd[0],
-                        ppd[1],
-                        timestamp,
-                        timestamp_local,
+                        0, 0, 0,  # Right eye position and pupil size
+                        0, 0, 0,  # Left eye position and pupil size
+                        smp.getTargetX(), smp.getTargetY(), smp.getTargetDistance(),  # Forehead target location
+                        ppd[0], ppd[1],  # Resolution
+                        timestamp, timestamp_local,  # Timing
                     ]
 
                     # Grab gaze & pupil size data


### PR DESCRIPTION
Was previously mistaken on how we received samples from the EyeLink. We get a single sample that has binocular data, and retrieve monocular sample objects from it when figuring out gaze positions and pupil size. Based on the output of EDF files using edf2asc, there is only a single resolution shared between both eyes. 

TL;DR: We are simply mislabeling X and Y as right and left.