### PR TITLE
Script to Remap in Incorrect subject ID

### DIFF
--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -73,7 +73,7 @@ def parse_arguments() -> Arguments:
     )
 
 
-DATA_FILE_PATTERN = re.compile(r'.*(\d+)_([\d-]*)_.*')
+DATA_FILE_PATTERN = re.compile(r'.*?(\d+)_(\d+-\d+-\d+)[_-].*')
 
 
 def fix_filename(args: Arguments, filename: str) -> Optional[str]:
@@ -108,6 +108,7 @@ def relabel_filesystem(args: Arguments, data_dir: str) -> None:
     :param args: Structure describing the affected session and correct subject ID.
     :param data_dir: The directory to iterate over. Should contain session-level directories.
     """
+    # TODO: Keep track of how many files we rename. Maybe add logging overall
     for session_dir in os.listdir(data_dir):
         session_path = os.path.join(data_dir, session_dir)
         if not os.path.isdir(session_path) or (session_dir != args.old_session):
@@ -245,7 +246,7 @@ def relabel_log_sensor_file(log_task_ids: List[str], args: Arguments, conn: conn
     with conn.cursor() as cursor:
         for log_sensor_file_id, sensor_file_path in zip(log_sensor_file_ids, sensor_file_paths):
             cursor.execute(
-                "UPDATE log_task SET sensor_file_path = %s WHERE log_sensor_file_id = %s",
+                "UPDATE log_sensor_file SET sensor_file_path = %s WHERE log_sensor_file_id = %s",
                 (sensor_file_path, log_sensor_file_id)
             )
 

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -48,7 +48,7 @@ def parse_arguments() -> Arguments:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--id',
-        type=int,
+        type=str,
         required=True,
         help='The (incorrect/existing) subject ID of the affected session.',
     )
@@ -60,15 +60,15 @@ def parse_arguments() -> Arguments:
     )
     parser.add_argument(
         '--new-id',
-        type=int,
+        type=str,
         required=True,
         help='The correct subject ID.'
     )
 
     args = parser.parse_args()
     return Arguments(
-        old_id=str(args.id),
-        new_id=str(args.new_id),
+        old_id=args.id,
+        new_id=args.new_id,
         date=args.date,
     )
 

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -7,9 +7,12 @@ import os
 import re
 import argparse
 import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 import neurobooth_os.config as nb_config
+
+if TYPE_CHECKING:
+    from psycopg2.extensions import connection
 
 
 class Arguments(NamedTuple):
@@ -27,6 +30,11 @@ class Arguments(NamedTuple):
         return f'{self.new_id}_{self.date.isoformat()}'
 
 
+class RelabelException(Exception):
+    """A generic exception that occurs when attempting to relabel subject IDs."""
+    pass
+
+
 def main() -> None:
     args = parse_arguments()
 
@@ -35,62 +43,6 @@ def main() -> None:
 
     relabel_database(args, database_info=configs.database)
     relabel_filesystem(args, data_dir=configs.remote_data_dir)
-
-
-DATA_FILE_PATTERN = re.compile(r'.*(\d+)_([\d-]*)_.*')
-
-
-def fix_filename(args: Arguments, filename: str) -> Optional[str]:
-    """
-    Check to see if a file corresponds to the affected session, and, if so, return the corrected file name.
-
-    :param args: Structure describing the affected session and correct subject ID.
-    :param filename: The file name to check.
-    :return: None if the file name does not adhere to the expected pattern or is from a different session.
-        The corrected file name otherwise.
-    """
-    # Check that the filename matches the expected pattern of a date file
-    match = re.match(DATA_FILE_PATTERN, filename)
-    if match is None:
-        return None
-
-    # Check that the file corresponds to the affected session
-    subj_id = match.group(1)
-    date = datetime.date.fromisoformat(match.group(2))
-    if (subj_id != args.old_id) or (date != args.date):
-        return None
-
-    return filename.replace(args.old_session, args.new_session)
-
-
-def relabel_database(args: Arguments, database_info: nb_config.DatabaseSpec) -> None:
-    pass
-
-
-def relabel_filesystem(args: Arguments, data_dir: str) -> None:
-    """
-    Iterate through the given data directory, identify the impacted session, and update both the session directory
-    and contained files. Note that this function can be imported and called from outside neurobooth OS (e.g., if data
-    makes its way into long-term storage).
-
-    :param args: Structure describing the affected session and correct subject ID.
-    :param data_dir: The directory to iterate over. Should contain session-level directories.
-    """
-    for session_dir in os.listdir(data_dir):
-        session_path = os.path.join(data_dir, session_dir)
-        if not os.path.isdir(session_path) or (session_dir != args.old_session):
-            continue
-
-        for file in os.listdir(session_path):
-            new_file = fix_filename(file)
-            if new_file is None:
-                continue
-
-            old_path = os.path.join(session_path, file)
-            new_path = os.path.join(session_path, new_file)
-            os.rename(old_path, new_path)  # Rename file
-
-        os.rename(session_path, os.path.join(data_dir, args.new_session))  # Rename session directory
 
 
 def parse_arguments() -> Arguments:
@@ -120,6 +72,109 @@ def parse_arguments() -> Arguments:
         new_id=str(args.new_id),
         date=args.date,
     )
+
+
+DATA_FILE_PATTERN = re.compile(r'.*(\d+)_([\d-]*)_.*')
+
+
+def fix_filename(args: Arguments, filename: str) -> Optional[str]:
+    """
+    Check to see if a file corresponds to the affected session, and, if so, return the corrected file name.
+
+    :param args: Structure describing the affected session and correct subject ID.
+    :param filename: The file name to check.
+    :return: None if the file name does not adhere to the expected pattern or is from a different session.
+        The corrected file name otherwise.
+    """
+    # Check that the filename matches the expected pattern of a date file
+    match = re.match(DATA_FILE_PATTERN, filename)
+    if match is None:
+        return None
+
+    # Check that the file corresponds to the affected session
+    subj_id = match.group(1)
+    date = datetime.date.fromisoformat(match.group(2))
+    if (subj_id != args.old_id) or (date != args.date):
+        return None
+
+    return filename.replace(args.old_session, args.new_session)
+
+
+def relabel_filesystem(args: Arguments, data_dir: str) -> None:
+    """
+    Iterate through the given data directory, identify the impacted session, and update both the session directory
+    and contained files. Note that this function can be imported and called from outside neurobooth OS (e.g., if data
+    makes its way into long-term storage).
+
+    :param args: Structure describing the affected session and correct subject ID.
+    :param data_dir: The directory to iterate over. Should contain session-level directories.
+    """
+    for session_dir in os.listdir(data_dir):
+        session_path = os.path.join(data_dir, session_dir)
+        if not os.path.isdir(session_path) or (session_dir != args.old_session):
+            continue
+
+        for file in os.listdir(session_path):
+            new_file = fix_filename(file)
+            if new_file is None:
+                continue
+
+            old_path = os.path.join(session_path, file)
+            new_path = os.path.join(session_path, new_file)
+            os.rename(old_path, new_path)  # Rename file
+
+        os.rename(session_path, os.path.join(data_dir, args.new_session))  # Rename session directory
+
+
+def relabel_database(args: Arguments, database_info: nb_config.DatabaseSpec) -> None:
+    from neurobooth_os.iout import metadator
+    conn: connection = metadator.get_conn(database_info.dbname)
+
+    check_subject_table(args.new_id, conn)
+    relabel_log_session(args, conn)
+    relabel_log_task(args, conn)
+    # TODO: log_file?
+    # TODO: log_sensor_file
+
+    relabel_log_application(args, conn)
+
+
+def check_subject_table(subject_id: str, conn: connection) -> None:
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM subject WHERE subject_id = %s", subject_id)
+        if cursor.fetchone() == 0:
+            raise RelabelException(
+                f'ID {subject_id} cannot be found in the database. Make sure the new subject has been added in REDCap.'
+            )
+
+
+def relabel_log_session(args: Arguments, conn: connection) -> None:
+    # TODO: Look into returning log_session_id to support other updates
+    with conn.cursor() as cursor:
+        cursor.execute(
+            "UPDATE log_session SET subject_id = %s WHERE subject_id = %s AND date = %s",
+            (args.new_id, args.old_id, args.date),
+        )
+
+
+def relabel_log_task(args: Arguments, conn: connection) -> None:
+    # TODO: Look into returning log_task_id to support other updates
+    # TODO: Need to handle subject_id, task_notes_file and task_output_files
+    pass
+
+
+def relabel_log_application(args: Arguments, conn: connection) -> None:
+    # Note: We will not try to alter any log messages, just associate them with the corrected ID/session
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            UPDATE log_application SET
+                subject_id = %s,
+                session_id = %s
+            WHERE subject_id = %s AND session_id = %s
+            """,
+            (args.new_id, args.new_session, args.old_id, args.old_session),
+        )
 
 
 if __name__ == '__main__':

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -269,8 +269,10 @@ def relabel_log_task(log_session_ids: List[int], args: RelabelParams, conn: conn
     # Update impacted rows. We could speed this up, but there isn't a pressing need.
     with conn.cursor() as cursor:
         for log_task_id, task_notes_file, task_output_file in zip(log_task_ids, task_notes_files, task_output_files):
-            if (task_notes_file is not None) and (None in task_output_file):
-                raise RelabelException(f'Error renaming files for log_task_id={log_task_id}.')
+            if task_notes_file is None:
+                raise RelabelException(f'Error renaming task notes for log_task_id={log_task_id}.')
+            if (task_output_file is not None) and (None in task_output_file):
+                raise RelabelException(f'Error renaming output file for log_task_id={log_task_id}.')
 
             LOGGER.info(f'UPDATE log_task {log_task_id}: {task_notes_file}, {task_output_file}')
             cursor.execute(
@@ -320,7 +322,7 @@ def relabel_log_sensor_file(log_task_ids: List[str], args: RelabelParams, conn: 
     # Update impacted rows. We could speed this up, but there isn't a pressing need.
     with conn.cursor() as cursor:
         for log_sensor_file_id, sensor_file_path in zip(log_sensor_file_ids, sensor_file_paths):
-            if (sensor_file_path is not None) and (None in sensor_file_path):
+            if None in sensor_file_path:
                 raise RelabelException(f'Error renaming files for log_sensor_file_id={log_sensor_file_id}.')
 
             LOGGER.info(f'UPDATE log_sensor_file {log_sensor_file_id}: {sensor_file_path}')

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -261,7 +261,10 @@ def relabel_log_task(log_session_ids: List[int], args: RelabelParams, conn: conn
 
     # Correct file names; there can be multiple task output files per row
     task_notes_files = [fix_filename(args, f) for f in task_notes_files]
-    task_output_files = [[fix_filename(args, f) for f in files] for files in task_output_files]
+    task_output_files = [
+        [fix_filename(args, f) for f in files] if files else files
+        for files in task_output_files
+    ]
 
     # Update impacted rows. We could speed this up, but there isn't a pressing need.
     with conn.cursor() as cursor:
@@ -309,7 +312,10 @@ def relabel_log_sensor_file(log_task_ids: List[str], args: RelabelParams, conn: 
                 sensor_file_paths.append(sensor_file_path)
 
     # Correct file names; there can be multiple sensor files per row
-    sensor_file_paths = [[fix_filename(args, f) for f in files] for files in sensor_file_paths]
+    sensor_file_paths = [
+        [fix_filename(args, f) for f in files] if files else files
+        for files in sensor_file_paths
+    ]
 
     # Update impacted rows. We could speed this up, but there isn't a pressing need.
     with conn.cursor() as cursor:

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -1,0 +1,126 @@
+"""
+This script can be used to relabel an incorrectly chosen subject ID in the database and on the file system.
+REDCap-derived database tables are not affected by this script.
+"""
+
+import os
+import re
+import argparse
+import datetime
+from typing import NamedTuple, Optional
+
+import neurobooth_os.config as nb_config
+
+
+class Arguments(NamedTuple):
+    """Defines the affected session and the correct ID"""
+    old_id: str
+    new_id: str
+    date: datetime.date
+
+    @property
+    def old_session(self) -> str:
+        return f'{self.old_id}_{self.date.isoformat()}'
+
+    @property
+    def new_session(self) -> str:
+        return f'{self.new_id}_{self.date.isoformat()}'
+
+
+def main() -> None:
+    args = parse_arguments()
+
+    nb_config.load_config()
+    configs = nb_config.neurobooth_config_pydantic
+
+    relabel_database(args, database_info=configs.database)
+    relabel_filesystem(args, data_dir=configs.remote_data_dir)
+
+
+DATA_FILE_PATTERN = re.compile(r'.*(\d+)_([\d-]*)_.*')
+
+
+def fix_filename(args: Arguments, filename: str) -> Optional[str]:
+    """
+    Check to see if a file corresponds to the affected session, and, if so, return the corrected file name.
+
+    :param args: Structure describing the affected session and correct subject ID.
+    :param filename: The file name to check.
+    :return: None if the file name does not adhere to the expected pattern or is from a different session.
+        The corrected file name otherwise.
+    """
+    # Check that the filename matches the expected pattern of a date file
+    match = re.match(DATA_FILE_PATTERN, filename)
+    if match is None:
+        return None
+
+    # Check that the file corresponds to the affected session
+    subj_id = match.group(1)
+    date = datetime.date.fromisoformat(match.group(2))
+    if (subj_id != args.old_id) or (date != args.date):
+        return None
+
+    return filename.replace(args.old_session, args.new_session)
+
+
+def relabel_database(args: Arguments, database_info: nb_config.DatabaseSpec) -> None:
+    pass
+
+
+def relabel_filesystem(args: Arguments, data_dir: str) -> None:
+    """
+    Iterate through the given data directory, identify the impacted session, and update both the session directory
+    and contained files. Note that this function can be imported and called from outside neurobooth OS (e.g., if data
+    makes its way into long-term storage).
+
+    :param args: Structure describing the affected session and correct subject ID.
+    :param data_dir: The directory to iterate over. Should contain session-level directories.
+    """
+    for session_dir in os.listdir(data_dir):
+        session_path = os.path.join(data_dir, session_dir)
+        if not os.path.isdir(session_path) or (session_dir != args.old_session):
+            continue
+
+        for file in os.listdir(session_path):
+            new_file = fix_filename(file)
+            if new_file is None:
+                continue
+
+            old_path = os.path.join(session_path, file)
+            new_path = os.path.join(session_path, new_file)
+            os.rename(old_path, new_path)  # Rename file
+
+        os.rename(session_path, os.path.join(data_dir, args.new_session))  # Rename session directory
+
+
+def parse_arguments() -> Arguments:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--id',
+        type=int,
+        required=True,
+        help='The (incorrect/existing) subject ID of the affected session.',
+    )
+    parser.add_argument(
+        '--date',
+        type=datetime.date.fromisoformat,
+        required=True,
+        help='ISO-formatted (YYYY-MM-DD) date of the affected session.'
+    )
+    parser.add_argument(
+        '--new-id',
+        type=int,
+        required=True,
+        help='The correct subject ID.'
+    )
+
+    args = parser.parse_args()
+    return Arguments(
+        old_id=str(args.id),
+        new_id=str(args.new_id),
+        date=args.date,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -269,7 +269,7 @@ def relabel_log_task(log_session_ids: List[int], args: RelabelParams, conn: conn
     # Update impacted rows. We could speed this up, but there isn't a pressing need.
     with conn.cursor() as cursor:
         for log_task_id, task_notes_file, task_output_file in zip(log_task_ids, task_notes_files, task_output_files):
-            if task_notes_file is None or None in task_output_file:
+            if (task_notes_file is not None) and (None in task_output_file):
                 raise RelabelException(f'Error renaming files for log_task_id={log_task_id}.')
 
             LOGGER.info(f'UPDATE log_task {log_task_id}: {task_notes_file}, {task_output_file}')
@@ -320,7 +320,7 @@ def relabel_log_sensor_file(log_task_ids: List[str], args: RelabelParams, conn: 
     # Update impacted rows. We could speed this up, but there isn't a pressing need.
     with conn.cursor() as cursor:
         for log_sensor_file_id, sensor_file_path in zip(log_sensor_file_ids, sensor_file_paths):
-            if None in sensor_file_path:
+            if (sensor_file_path is not None) and (None in sensor_file_path):
                 raise RelabelException(f'Error renaming files for log_sensor_file_id={log_sensor_file_id}.')
 
             LOGGER.info(f'UPDATE log_sensor_file {log_sensor_file_id}: {sensor_file_path}')

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -42,10 +42,10 @@ class RelabelException(Exception):
 
 
 def main() -> None:
+    nb_config.load_config()
     args = parse_arguments()
 
     try:
-        nb_config.load_config()
         configs = nb_config.neurobooth_config_pydantic
 
         LOGGER.info('Applying Database Updates')

--- a/extras/relabel_subject_id.py
+++ b/extras/relabel_subject_id.py
@@ -7,13 +7,11 @@ import os
 import re
 import argparse
 import datetime
-from typing import TYPE_CHECKING, NamedTuple, Optional, List
+from typing import NamedTuple, Optional, List
 from itertools import chain
+from psycopg2.extensions import connection
 
 import neurobooth_os.config as nb_config
-
-if TYPE_CHECKING:
-    from psycopg2.extensions import connection
 
 
 class Arguments(NamedTuple):


### PR DESCRIPTION
Performs file name updates on NAS and handles log_ table updates in the database.

Added some structure to the existing neurobooth configs. (Should probably have done this in it's own PR.) Can propagate to the rest of the code base to remove mirrored structure if no major potential merge conflicts are anticipated.

Hard to unit test this script because it is 99% database and file system side effects