### PR TITLE
Add task targets to eyelink tablet

### DIFF
--- a/neurobooth_os/tasks/fixations.py
+++ b/neurobooth_os/tasks/fixations.py
@@ -81,6 +81,7 @@ class Fixation_Target_Multiple(Task_Eyetracker):
 
             # Send event to eyetracker and to LSL separately
             self.sendMessage(self.marker_trial_start, False)
+            self.update_tablet_background(self.target.pos[0], self.target.pos[1])
             self.show_text(
                 screen=self.target,
                 msg="Trial",
@@ -91,6 +92,7 @@ class Fixation_Target_Multiple(Task_Eyetracker):
             self.sendMessage(self.marker_trial_end, False)
 
         self.sendMessage(self.marker_task_end)
+        self.sendCommand('clear_screen 0')
 
         if prompt:
             func_kwargs = locals()

--- a/neurobooth_os/tasks/fixations.py
+++ b/neurobooth_os/tasks/fixations.py
@@ -16,6 +16,7 @@ import os.path as op
 
 import neurobooth_os
 from neurobooth_os.tasks.task import Task_Eyetracker
+from neurobooth_os.tasks.task import Eyelink_HostPC
 from neurobooth_os.tasks import utils
 
 
@@ -55,7 +56,7 @@ class Fixation_Target(Task_Eyetracker):
             )
 
 
-class Fixation_Target_Multiple(Task_Eyetracker):
+class Fixation_Target_Multiple(Eyelink_HostPC):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -81,7 +82,7 @@ class Fixation_Target_Multiple(Task_Eyetracker):
 
             # Send event to eyetracker and to LSL separately
             self.sendMessage(self.marker_trial_start, False)
-            self.update_tablet_background(self.target.pos[0], self.target.pos[1])
+            self.update_screen(self.target.pos[0], self.target.pos[1])
             self.show_text(
                 screen=self.target,
                 msg="Trial",
@@ -92,7 +93,7 @@ class Fixation_Target_Multiple(Task_Eyetracker):
             self.sendMessage(self.marker_trial_end, False)
 
         self.sendMessage(self.marker_task_end)
-        self.sendCommand('clear_screen 0')
+        self.clear_screen()
 
         if prompt:
             func_kwargs = locals()

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -10,7 +10,7 @@ from psychopy import core
 import pylink
 import neurobooth_os
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix, peak_vel2freq, deg2rad
-from neurobooth_os.tasks.task import Task_Eyetracker
+# from neurobooth_os.tasks.task import Task_Eyetracker
 from neurobooth_os.tasks.task import Eyelink_HostPC as Tablet
 import numpy as np
 from pylsl import local_clock
@@ -24,7 +24,7 @@ def countdown(period):
         t2 = local_clock()
 
 
-class Saccade(Task_Eyetracker):
+class Saccade(Tablet):
     def __init__(
         self,
         amplitude_deg=30,
@@ -92,7 +92,7 @@ class Saccade(Task_Eyetracker):
         self.target.size = self.pointer_size_pixel
         self.target.draw()
         self.win.flip()
-        self.Tablet.update_screen(0, 0)
+        self.update_screen(0, 0)
         # self.doDriftCorrect([int(0 + self.mon_size[0] / 2.0),
         #                        int(self.mon_size[1] / 2.0 - 0), 0, 1])
         self.win.color = (0, 0, 0)
@@ -107,7 +107,7 @@ class Saccade(Task_Eyetracker):
             self.target.pos = (0, 0)
             self.target.draw()
             self.win.flip()
-            self.Tablet.update_screen(0, 0)
+            self.update_screen(0, 0)
             self.send_target_loc(self.target.pos)
 
             # core.wait(self.wait_center + self.jitter_percent*self.wait_center*np.random.random(1)[0])
@@ -119,7 +119,7 @@ class Saccade(Task_Eyetracker):
             self.target.pos = (tar_x, tar_y)
             self.target.draw()
             self.win.flip()
-            self.Tablet.update_screen(tar_x, tar_y)
+            self.update_screen(tar_x, tar_y)
             self.send_target_loc(self.target.pos)
 
             # update the target position
@@ -135,7 +135,7 @@ class Saccade(Task_Eyetracker):
         # clear the window
         self.win.color = (0, 0, 0)
         self.win.flip()
-        self.Tablet.clear_screen()
+        self.clear_screen()
 
         # Stop recording
         self.setOfflineMode()

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -91,19 +91,7 @@ class Saccade(Task_Eyetracker):
         self.target.size = self.pointer_size_pixel
         self.target.draw()
         self.win.flip()
-
-        self.sendCommand('clear_screen 0')
-        self.sendCommand('draw_cross %d %d 10' % tuple(self.pos_psych2pix([0, 0])))
-        self.sendCommand('draw_cross %d %d 10' % tuple(self.pos_psych2pix([tar_x, tar_y])))
-        box_len_pix = 50
-        box_coords_top = self.pos_psych2pix([tar_x-box_len_pix, tar_y-box_len_pix])
-        box_coords_bot = self.pos_psych2pix([tar_x+box_len_pix, tar_y+box_len_pix])
-        self.sendCommand('draw_box %d %d %d %d 12' % tuple(box_coords_top + box_coords_bot))
-        self.sendCommand('draw_cross %d %d 10' % tuple(self.pos_psych2pix([-1*tar_x, -1*tar_y])))
-        box_coords_top = self.pos_psych2pix([-1*tar_x-box_len_pix, -1*tar_y-box_len_pix])
-        box_coords_bot = self.pos_psych2pix([-1*tar_x+box_len_pix, -1*tar_y+box_len_pix])
-        self.sendCommand('draw_box %d %d %d %d 12' % tuple(box_coords_top + box_coords_bot))
-
+        self.update_tablet_background(0, 0)
         # self.doDriftCorrect([int(0 + self.mon_size[0] / 2.0),
         #                        int(self.mon_size[1] / 2.0 - 0), 0, 1])
         self.win.color = (0, 0, 0)
@@ -118,6 +106,7 @@ class Saccade(Task_Eyetracker):
             self.target.pos = (0, 0)
             self.target.draw()
             self.win.flip()
+            self.update_tablet_background(0, 0)
             self.send_target_loc(self.target.pos)
 
             # core.wait(self.wait_center + self.jitter_percent*self.wait_center*np.random.random(1)[0])
@@ -129,6 +118,7 @@ class Saccade(Task_Eyetracker):
             self.target.pos = (tar_x, tar_y)
             self.target.draw()
             self.win.flip()
+            self.update_tablet_background(tar_x, tar_y)
             self.send_target_loc(self.target.pos)
 
             # update the target position
@@ -144,12 +134,12 @@ class Saccade(Task_Eyetracker):
         # clear the window
         self.win.color = (0, 0, 0)
         self.win.flip()
+        self.sendCommand('clear_screen 0')
 
         # Stop recording
         self.setOfflineMode()
 
         self.sendMessage(self.marker_task_end)
-        self.sendCommand('clear_screen 0')
 
         # Send trial variables to record in the EDF data file
         self.sendMessage(f"!V TRIAL_VAR amp_x {amp_x:.2f}")
@@ -170,17 +160,18 @@ class Saccade(Task_Eyetracker):
 
 
 if __name__ == "__main__":
-    from neurobooth_os.iout.eyelink_tracker import EyeTracker
+    # from neurobooth_os.iout.eyelink_tracker import EyeTracker
     from neurobooth_os.tasks import utils
-    from neurobooth_os.tasks.eye_tracker_calibrate import Calibrate
+    # from neurobooth_os.tasks.eye_tracker_calibrate import Calibrate
     
-    # task = Saccade()
-    # task.run(prompt=False)
+    # # task = Saccade()
+    # # task.run(prompt=False)
 
     win = utils.make_win(False, 200)
-    eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
-    cal = Calibrate(eye_tracker=eye_tracker, win=win)
-    cal.run()
+    # eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
+    # cal = Calibrate(eye_tracker=eye_tracker, win=win)
+    # cal.run()
     
-    task = Saccade(eye_tracker=eye_tracker, win=win, direction="vertical", amplitude_deg=30)
+    # task = Saccade(eye_tracker=eye_tracker, win=win, direction="vertical", amplitude_deg=30)
+    task = Saccade(win=win, direction="vertical", amplitude_deg=30)
     task.run(prompt=False)

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -11,6 +11,7 @@ import pylink
 import neurobooth_os
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix, peak_vel2freq, deg2rad
 from neurobooth_os.tasks.task import Task_Eyetracker
+from neurobooth_os.tasks.task import Eyelink_HostPC as Tablet
 import numpy as np
 from pylsl import local_clock
 
@@ -91,7 +92,7 @@ class Saccade(Task_Eyetracker):
         self.target.size = self.pointer_size_pixel
         self.target.draw()
         self.win.flip()
-        self.update_tablet_background(0, 0)
+        self.Tablet.update_screen(0, 0)
         # self.doDriftCorrect([int(0 + self.mon_size[0] / 2.0),
         #                        int(self.mon_size[1] / 2.0 - 0), 0, 1])
         self.win.color = (0, 0, 0)
@@ -106,7 +107,7 @@ class Saccade(Task_Eyetracker):
             self.target.pos = (0, 0)
             self.target.draw()
             self.win.flip()
-            self.update_tablet_background(0, 0)
+            self.Tablet.update_screen(0, 0)
             self.send_target_loc(self.target.pos)
 
             # core.wait(self.wait_center + self.jitter_percent*self.wait_center*np.random.random(1)[0])
@@ -118,7 +119,7 @@ class Saccade(Task_Eyetracker):
             self.target.pos = (tar_x, tar_y)
             self.target.draw()
             self.win.flip()
-            self.update_tablet_background(tar_x, tar_y)
+            self.Tablet.update_screen(tar_x, tar_y)
             self.send_target_loc(self.target.pos)
 
             # update the target position
@@ -134,7 +135,7 @@ class Saccade(Task_Eyetracker):
         # clear the window
         self.win.color = (0, 0, 0)
         self.win.flip()
-        self.sendCommand('clear_screen 0')
+        self.Tablet.clear_screen()
 
         # Stop recording
         self.setOfflineMode()

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -10,8 +10,7 @@ from psychopy import core
 import pylink
 import neurobooth_os
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix, peak_vel2freq, deg2rad
-# from neurobooth_os.tasks.task import Task_Eyetracker
-from neurobooth_os.tasks.task import Eyelink_HostPC as Tablet
+from neurobooth_os.tasks.task import Eyelink_HostPC
 import numpy as np
 from pylsl import local_clock
 
@@ -24,7 +23,7 @@ def countdown(period):
         t2 = local_clock()
 
 
-class Saccade(Tablet):
+class Saccade(Eyelink_HostPC):
     def __init__(
         self,
         amplitude_deg=30,

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -91,6 +91,19 @@ class Saccade(Task_Eyetracker):
         self.target.size = self.pointer_size_pixel
         self.target.draw()
         self.win.flip()
+
+        self.sendCommand('clear_screen 0')
+        self.sendCommand('draw_cross %d %d 10' % tuple(self.pos_psych2pix([0, 0])))
+        self.sendCommand('draw_cross %d %d 10' % tuple(self.pos_psych2pix([tar_x, tar_y])))
+        box_len_pix = 50
+        box_coords_top = self.pos_psych2pix([tar_x-box_len_pix, tar_y-box_len_pix])
+        box_coords_bot = self.pos_psych2pix([tar_x+box_len_pix, tar_y+box_len_pix])
+        self.sendCommand('draw_box %d %d %d %d 12' % tuple(box_coords_top + box_coords_bot))
+        self.sendCommand('draw_cross %d %d 10' % tuple(self.pos_psych2pix([-1*tar_x, -1*tar_y])))
+        box_coords_top = self.pos_psych2pix([-1*tar_x-box_len_pix, -1*tar_y-box_len_pix])
+        box_coords_bot = self.pos_psych2pix([-1*tar_x+box_len_pix, -1*tar_y+box_len_pix])
+        self.sendCommand('draw_box %d %d %d %d 12' % tuple(box_coords_top + box_coords_bot))
+
         # self.doDriftCorrect([int(0 + self.mon_size[0] / 2.0),
         #                        int(self.mon_size[1] / 2.0 - 0), 0, 1])
         self.win.color = (0, 0, 0)
@@ -136,6 +149,7 @@ class Saccade(Task_Eyetracker):
         self.setOfflineMode()
 
         self.sendMessage(self.marker_task_end)
+        self.sendCommand('clear_screen 0')
 
         # Send trial variables to record in the EDF data file
         self.sendMessage(f"!V TRIAL_VAR amp_x {amp_x:.2f}")
@@ -156,8 +170,17 @@ class Saccade(Task_Eyetracker):
 
 
 if __name__ == "__main__":
-
+    from neurobooth_os.iout.eyelink_tracker import EyeTracker
+    from neurobooth_os.tasks import utils
+    from neurobooth_os.tasks.eye_tracker_calibrate import Calibrate
+    
     # task = Saccade()
     # task.run(prompt=False)
-    task = Saccade(direction="vertical", amplitude_deg=30)
+
+    win = utils.make_win(False, 200)
+    eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
+    cal = Calibrate(eye_tracker=eye_tracker, win=win)
+    cal.run()
+    
+    task = Saccade(eye_tracker=eye_tracker, win=win, direction="vertical", amplitude_deg=30)
     task.run(prompt=False)

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -160,9 +160,6 @@ class Saccade(Eyelink_HostPC):
 
 
 if __name__ == "__main__":
-
-    from neurobooth_os.tasks import utils
-    win = utils.make_win(False, 200)
     
-    task = Saccade(win=win, direction="vertical", amplitude_deg=30)
+    task = Saccade(direction="vertical", amplitude_deg=30)
     task.run(prompt=False)

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -160,18 +160,9 @@ class Saccade(Task_Eyetracker):
 
 
 if __name__ == "__main__":
-    # from neurobooth_os.iout.eyelink_tracker import EyeTracker
-    from neurobooth_os.tasks import utils
-    # from neurobooth_os.tasks.eye_tracker_calibrate import Calibrate
-    
-    # # task = Saccade()
-    # # task.run(prompt=False)
 
+    from neurobooth_os.tasks import utils
     win = utils.make_win(False, 200)
-    # eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
-    # cal = Calibrate(eye_tracker=eye_tracker, win=win)
-    # cal.run()
     
-    # task = Saccade(eye_tracker=eye_tracker, win=win, direction="vertical", amplitude_deg=30)
     task = Saccade(win=win, direction="vertical", amplitude_deg=30)
     task.run(prompt=False)

--- a/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
+++ b/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
@@ -79,6 +79,7 @@ class Pursuit(Task_Eyetracker):
         self.target.pos = (tar_x, tar_y)
         self.target.draw()
         self.win.flip()
+        self.update_tablet_background(tar_x, tar_y)
         self.send_target_loc(self.target.pos)
 
         frame = 0
@@ -88,6 +89,7 @@ class Pursuit(Task_Eyetracker):
             self.target.pos = (tar_x, tar_y)
             self.target.draw()
             self.win.flip()
+            self.update_tablet_background(tar_x, tar_y)
             self.send_target_loc(self.target.pos)
 
             flip_time = core.getTime()
@@ -119,6 +121,7 @@ class Pursuit(Task_Eyetracker):
         # clear the window
         self.win.color = (0, 0, 0)
         self.win.flip()
+        self.sendCommand('clear_screen 0')
 
         # Stop recording
         self.setOfflineMode()

--- a/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
+++ b/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
@@ -11,10 +11,10 @@ from psychopy import core
 import pylink
 import neurobooth_os
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix, peak_vel2freq, deg2rad
-from neurobooth_os.tasks.task import Task_Eyetracker
+from neurobooth_os.tasks.task import Eyelink_HostPC
 
 
-class Pursuit(Task_Eyetracker):
+class Pursuit(Eyelink_HostPC):
     def __init__(
         self,
         amplitude_deg=30,
@@ -79,7 +79,7 @@ class Pursuit(Task_Eyetracker):
         self.target.pos = (tar_x, tar_y)
         self.target.draw()
         self.win.flip()
-        self.update_tablet_background(tar_x, tar_y)
+        self.update_screen(tar_x, tar_y)
         self.send_target_loc(self.target.pos)
 
         frame = 0
@@ -89,7 +89,7 @@ class Pursuit(Task_Eyetracker):
             self.target.pos = (tar_x, tar_y)
             self.target.draw()
             self.win.flip()
-            self.update_tablet_background(tar_x, tar_y)
+            self.update_screen(tar_x, tar_y)
             self.send_target_loc(self.target.pos)
 
             flip_time = core.getTime()
@@ -121,7 +121,7 @@ class Pursuit(Task_Eyetracker):
         # clear the window
         self.win.color = (0, 0, 0)
         self.win.flip()
-        self.sendCommand('clear_screen 0')
+        self.clear_screen()
 
         # Stop recording
         self.setOfflineMode()

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -361,6 +361,30 @@ class Task_Eyetracker(Task):
         if self.eye_tracker is not None:
             self.eye_tracker.tk.doDriftCorrect(*vals)
 
+    def update_tablet_background(self, x, y):
+        '''Draw a cross and a box on the eyelink tablet.
+           x and y are positions in 0 centered psychopy coordinate space.
+           See pos_psych2pix above
+        '''
+
+        # First clear tablet screen
+        self.sendCommand('clear_screen 0')
+
+        # convert from 0 centered to top-left centered coordinate space
+        top_left_xy = self.pos_psych2pix([x, y])
+
+        # draw cross at top_left centered x,y position
+        self.sendCommand('draw_cross %d %d 10' % tuple(top_left_xy))
+
+        # draw box around cross
+        box_len_pix = 50 ## this is box_length of 100 pixels
+        # box coords are defined in a single list as x,y at the diagonal vertices
+        # color is defined by number - 12 is for red
+        box_coords_top = [top_left_xy[0]-box_len_pix, top_left_xy[1]-box_len_pix]
+        box_coords_bot = [top_left_xy[0]+box_len_pix, top_left_xy[1]+box_len_pix]
+        self.sendCommand('draw_box %d %d %d %d 12' % tuple(box_coords_top + box_coords_bot))
+
+
     def gaze_contingency():
         # move task
         pass

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -370,8 +370,21 @@ class Task_Eyetracker(Task):
 
 class Color(Enum):
     BLACK = 0
-    RED = 12
-    GREEN = 10
+    BLUE = 1
+    GREEN = 2
+    CYAN = 3
+    RED = 4
+    MAGENTA = 5
+    BROWN = 6
+    LIGHTGRAY = 7
+    DARKGRAY = 8
+    LIGHTBLUE = 9
+    LIGHTGREEN = 10
+    LIGHTCYAN = 11
+    LIGHTRED = 12
+    BRIGHTMAGENTA = 13
+    YELLOW = 14
+    BRIGHTWHITE = 15
 
 
 class Eyelink_HostPC(Task_Eyetracker):
@@ -395,7 +408,7 @@ class Eyelink_HostPC(Task_Eyetracker):
         '''Draw a cross at the x,y position on the screen of the specified colour
            x, y must be in the top-left centered coordinate space 
         '''
-        self.sendCommand('draw_cross %d %d %d' % tuple(x, y, colour.value))
+        self.sendCommand('draw_cross %d %d %d' % (x, y, colour.value))
         
     def draw_box(self, x: int, y: int, length: int, breadth: int, colour: Color, filled: bool = False) -> None:
         '''
@@ -415,11 +428,13 @@ class Eyelink_HostPC(Task_Eyetracker):
         box_coords_bot_y = y+half_box_brd_in_pix
 
         if not filled:
-            self.sendCommand('draw_box %d %d %d %d %d' % tuple(box_coords_top_x, box_coords_top_y,
+            self.sendCommand('draw_box %d %d %d %d %d' % (box_coords_top_x, box_coords_top_y,
                                                                box_coords_bot_x, box_coords_bot_y,
                                                                colour.value))
         else:
-            # add command for filled box
+            self.sendCommand('draw_filled_box %d %d %d %d %d' % (box_coords_top_x, box_coords_top_y,
+                                                               box_coords_bot_x, box_coords_bot_y,
+                                                               colour.value))
             pass
 
     def update_screen(self, x: float, y: float) -> None:
@@ -439,11 +454,11 @@ class Eyelink_HostPC(Task_Eyetracker):
         top_left_y = xy[1]
 
         # draw cross at top_left centered x,y position
-        self.draw_box(top_left_x, top_left_y, Color.GREEN)
+        self.draw_cross(top_left_x, top_left_y, Color.LIGHTGREEN)
 
         # draw box around cross
         box_len_in_pix = 100
-        self.draw_box(top_left_x, top_left_y, box_len_in_pix, box_len_in_pix, Color.RED)
+        self.draw_box(top_left_x, top_left_y, box_len_in_pix, box_len_in_pix, Color.LIGHTRED)
 
     def clear_screen(self, colour: Color = Color.BLACK) -> None:
         '''Clear the HostPC screen and leave a Black background by default'''

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -361,9 +361,11 @@ class Task_Eyetracker(Task):
         if self.eye_tracker is not None:
             self.eye_tracker.tk.doDriftCorrect(*vals)
 
-    def update_tablet_background(self, x, y):
-        '''Draw a cross and a box on the eyelink tablet.
+    def update_tablet_background(self, x: float, y: float) -> None:
+        '''
+           Draw a cross and a box on the eyelink tablet.
            x and y are positions in 0 centered psychopy coordinate space.
+           x and y can be int or float
            See pos_psych2pix above
         '''
 
@@ -377,13 +379,12 @@ class Task_Eyetracker(Task):
         self.sendCommand('draw_cross %d %d 10' % tuple(top_left_xy))
 
         # draw box around cross
-        box_len_pix = 50 ## this is box_length of 100 pixels
+        half_box_len_in_pix = 50 ## this is box_length of 100 pixels
         # box coords are defined in a single list as x,y at the diagonal vertices
-        # color is defined by number - 12 is for red
-        box_coords_top = [top_left_xy[0]-box_len_pix, top_left_xy[1]-box_len_pix]
-        box_coords_bot = [top_left_xy[0]+box_len_pix, top_left_xy[1]+box_len_pix]
+        # color is defined by number - 12 is for red, 10 is for green
+        box_coords_top = [top_left_xy[0]-half_box_len_in_pix, top_left_xy[1]-half_box_len_in_pix]
+        box_coords_bot = [top_left_xy[0]+half_box_len_in_pix, top_left_xy[1]+half_box_len_in_pix]
         self.sendCommand('draw_box %d %d %d %d 12' % tuple(box_coords_top + box_coords_bot))
-
 
     def gaze_contingency():
         # move task

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -368,7 +368,14 @@ class Task_Eyetracker(Task):
         pass
 
 
-class Color(Enum):
+class EyelinkColor(Enum):
+    '''
+       Color codes accepted by the Eyetracker.
+       The source of these codes is from the comments in the examples
+       provided by SR Research - specifically saccade.py
+       Example script can be found in:
+       C:\Program Files (x86)\SR Research\EyeLink\SampleExperiments\Python\examples\Psychopy_examples
+    '''
     BLACK = 0
     BLUE = 1
     GREEN = 2
@@ -404,13 +411,13 @@ class Eyelink_HostPC(Task_Eyetracker):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
     
-    def draw_cross(self, x: int, y: int, colour: Color) -> None:
+    def draw_cross(self, x: int, y: int, colour: EyelinkColor) -> None:
         '''Draw a cross at the x,y position on the screen of the specified colour
            x, y must be in the top-left centered coordinate space 
         '''
         self.sendCommand('draw_cross %d %d %d' % (x, y, colour.value))
         
-    def draw_box(self, x: int, y: int, length: int, breadth: int, colour: Color, filled: bool = False) -> None:
+    def draw_box(self, x: int, y: int, length: int, breadth: int, colour: EyelinkColor, filled: bool = False) -> None:
         '''
            Draw a rectangle of size length by breadth (in pixels) around a point 
            x,y on the screen. x, y must be in the top-left centered coordinate
@@ -454,13 +461,13 @@ class Eyelink_HostPC(Task_Eyetracker):
         top_left_y = xy[1]
 
         # draw cross at top_left centered x,y position
-        self.draw_cross(top_left_x, top_left_y, Color.LIGHTGREEN)
+        self.draw_cross(top_left_x, top_left_y, EyelinkColor.LIGHTGREEN)
 
         # draw box around cross
         box_len_in_pix = 100
-        self.draw_box(top_left_x, top_left_y, box_len_in_pix, box_len_in_pix, Color.LIGHTRED)
+        self.draw_box(top_left_x, top_left_y, box_len_in_pix, box_len_in_pix, EyelinkColor.LIGHTRED)
 
-    def clear_screen(self, colour: Color = Color.BLACK) -> None:
+    def clear_screen(self, colour: EyelinkColor = EyelinkColor.BLACK) -> None:
         '''Clear the HostPC screen and leave a Black background by default'''
         self.sendCommand('clear_screen %d' % colour.value)
 

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -9,20 +9,40 @@ License: BSD-3-Clause
 
 import os.path as op
 
-from neurobooth_os.tasks.task import Task
+from neurobooth_os.tasks.task import Task_Eyetracker
 from neurobooth_os.tasks import utils
 import neurobooth_os
 
 
-class Passage_Reading(Task):
+class Passage_Reading(Task_Eyetracker):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     def present_task(self, prompt=True, duration=0, **kwargs):
+        
+        def _update_tablet_screen_with_passage():
+            self.sendCommand('draw_box %d %d %d %d 12' % tuple([192,108,192+1536,108+864]))
+            text = ['Bamboo walls are getting to be very popular. They are',
+                    'strong, easy to use, and good-looking. They provide a',
+                    'good background and can create a look of a Japanese',
+                    'garden. Bamboo is one of the largest and most rapidly',
+                    'growing grasses all over the world. Many varieties of',
+                    'bamboo are grown in Asia, although it is also grown in',
+                    'America. Last year we bought a new home and have',
+                    'been working on the flower garden. In a few more',
+                    'days, we will be done with the bamboo wall in our',
+                    'garden, We have really enjoyed the project.']
+            y = 108+43
+            x = 960
+            for t in text:
+                self.sendCommand('draw_text %d %d 10 %s' % (x, y, t))
+                y = y + 86
+        
         fname = op.join(
             neurobooth_os.__path__[0], "tasks/assets/passage_reading_1536x864.jpg"
         )
         screen = utils.create_image_screen(self.win, fname)
+        _update_tablet_screen_with_passage()
         self.show_text(screen=screen, msg="Task", audio=None, wait_time=5)
 
         if prompt:
@@ -32,6 +52,8 @@ class Passage_Reading(Task):
                 func=self.present_task,
                 waitKeys=False,
             )
+        
+        self.sendCommand('clear_screen 0')
 
 if __name__ == "__main__":
 

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -22,6 +22,22 @@ class Passage_Reading(Task_Eyetracker):
         
         def _update_tablet_screen_with_passage():
             self.sendCommand('draw_box %d %d %d %d 12' % tuple([192,108,192+1536,108+864]))
+            text = ['Bamboo walls are getting to be very popular. They are',
+                    'strong, easy to use, and good-looking. They provide a',
+                    'good background and can create a look of a Japanese',
+                    'garden. Bamboo is one of the largest and most rapidly',
+                    'growing grasses all over the world. Many varieties of',
+                    'bamboo are grown in Asia, although it is also grown in',
+                    'America. Last year we bought a new home and have',
+                    'been working on the flower garden. In a few more',
+                    'days, we will be done with the bamboo wall in our',
+                    'garden, We have really enjoyed the project.']
+            y = 108+43
+            x = 960
+            for t in text:
+                self.sendCommand('draw_text %d %d 10 %s' % (x, y, t))
+                y = y + 86
+
         
         fname = op.join(
             neurobooth_os.__path__[0], "tasks/assets/passage_reading_1536x864.jpg"

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -22,22 +22,6 @@ class Passage_Reading(Task_Eyetracker):
         
         def _update_tablet_screen_with_passage():
             self.sendCommand('draw_box %d %d %d %d 12' % tuple([192,108,192+1536,108+864]))
-            text = ['Bamboo walls are getting to be very popular. They are',
-                    'strong, easy to use, and good-looking. They provide a',
-                    'good background and can create a look of a Japanese',
-                    'garden. Bamboo is one of the largest and most rapidly',
-                    'growing grasses all over the world. Many varieties of',
-                    'bamboo are grown in Asia, although it is also grown in',
-                    'America. Last year we bought a new home and have',
-                    'been working on the flower garden. In a few more',
-                    'days, we will be done with the bamboo wall in our',
-                    'garden, We have really enjoyed the project.']
-            y = 108+43
-            x = 960
-            for t in text:
-                self.sendCommand('draw_text %d %d 10 %s' % (x, y, t))
-                y = y + 86
-
         
         fname = op.join(
             neurobooth_os.__path__[0], "tasks/assets/passage_reading_1536x864.jpg"

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -9,19 +9,21 @@ License: BSD-3-Clause
 
 import os.path as op
 
-from neurobooth_os.tasks.task import Task_Eyetracker
+# from neurobooth_os.tasks.task import Task_Eyetracker
+from neurobooth_os.tasks.task import Eyelink_HostPC
+from neurobooth_os.tasks.task import EyelinkColor
 from neurobooth_os.tasks import utils
 import neurobooth_os
 
 
-class Passage_Reading(Task_Eyetracker):
+class Passage_Reading(Eyelink_HostPC):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     def present_task(self, prompt=True, duration=0, **kwargs):
         
         def _update_tablet_screen_with_passage():
-            self.sendCommand('draw_box %d %d %d %d 12' % tuple([192,108,192+1536,108+864]))
+            self.draw_box(int(self.SCN_W/2), int(self.SCN_H/2), 1536, 864, EyelinkColor.LIGHTRED)
         
         fname = op.join(
             neurobooth_os.__path__[0], "tasks/assets/passage_reading_1536x864.jpg"
@@ -38,7 +40,7 @@ class Passage_Reading(Task_Eyetracker):
                 waitKeys=False,
             )
         
-        self.sendCommand('clear_screen 0')
+        self.clear_screen()
 
 if __name__ == "__main__":
 

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -22,21 +22,6 @@ class Passage_Reading(Task_Eyetracker):
         
         def _update_tablet_screen_with_passage():
             self.sendCommand('draw_box %d %d %d %d 12' % tuple([192,108,192+1536,108+864]))
-            text = ['Bamboo walls are getting to be very popular. They are',
-                    'strong, easy to use, and good-looking. They provide a',
-                    'good background and can create a look of a Japanese',
-                    'garden. Bamboo is one of the largest and most rapidly',
-                    'growing grasses all over the world. Many varieties of',
-                    'bamboo are grown in Asia, although it is also grown in',
-                    'America. Last year we bought a new home and have',
-                    'been working on the flower garden. In a few more',
-                    'days, we will be done with the bamboo wall in our',
-                    'garden, We have really enjoyed the project.']
-            y = 108+43
-            x = 960
-            for t in text:
-                self.sendCommand('draw_text %d %d 10 %s' % (x, y, t))
-                y = y + 86
         
         fname = op.join(
             neurobooth_os.__path__[0], "tasks/assets/passage_reading_1536x864.jpg"


### PR DESCRIPTION
Added a function to draw a standard target (green cross with a red box around it) on the eyelink tablet screen. The target can be dynamically updated on screen depending on where the function is called in the task. Edited tasks to update target on eyelink screen. Passage reading is a WIP and simply draws a box where the bamboo text sits, this will be replaced with the bamboo text image in a later change.  