### PR TITLE
Fix instruction kwarg return type

### DIFF
--- a/environment_staging.yml
+++ b/environment_staging.yml
@@ -112,7 +112,7 @@ dependencies:
       - pillow==10.0.1
       - proglog==0.1.10
       - psutil==5.9.6
-      - psychopy==2023.2.3
+      - psychopy==2023.1.2
       - psychtoolbox==3.0.19.0
       - psycopg2==2.9.9
       - pycap==2.6.0

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -62,7 +62,6 @@ def run_stm(logger):
     host: str = ''
     session: Optional[StmSession] = None
     task_log_entry: Optional[TaskLogEntry] = None
-    task_func_dict: Dict[str, TaskArgs] = {}
     for data, socket_conn in get_client_messages(socket_1, port, host):
         logger.info(f'MESSAGE RECEIVED: {data}')
 
@@ -76,7 +75,7 @@ def run_stm(logger):
             task_log_entry.log_session_id = session_id
 
             if presented:
-                task_func_dict = get_task_arguments(session.collection_id, session.db_conn)
+                session.task_func_dict = get_task_arguments(session.collection_id, session.db_conn)
 
             # Preload tasks media
             t0 = time()

--- a/neurobooth_os/tasks/task_importer.py
+++ b/neurobooth_os/tasks/task_importer.py
@@ -98,7 +98,7 @@ def get_task_arguments(collection_id, conn):
         task_args: TaskArgs = _get_task_arg(task_id, conn)
         task_stim_id = task_args.stim_args.stimulus_id
         task_func_dict[task_stim_id] = task_args
-
+    print(task_func_dict)
     return task_func_dict
 
 
@@ -117,7 +117,7 @@ def _get_task_arg(task_id: str, conn) -> TaskArgs:
     TaskArgs object
     """
 
-    task_stim_id, task_dev, task_sens, instr_kwargs= meta.get_task_param(
+    task_stim_id, task_dev, task_sens, instr_kwargs = meta.get_task_param(
         task_id, conn
     )  # xtask_sens -> sens_id, always end with id
     stim_file, stim_kwargs = meta.get_stimulus_kwargs_from_file(task_stim_id)
@@ -139,8 +139,8 @@ def _get_task_arg(task_id: str, conn) -> TaskArgs:
                              task_constructor_callable=stim_func,
                              stim_args=parser,
                              instr_args=instr_kwargs)
-        return task_args
-    task_args = TaskArgs(task_id=task_id,
-                         task_constructor_callable=stim_func,
-                         stim_args=parser)
+    else:
+        task_args = TaskArgs(task_id=task_id,
+                             task_constructor_callable=stim_func,
+                             stim_args=parser)
     return task_args

--- a/neurobooth_os/tasks/task_importer.py
+++ b/neurobooth_os/tasks/task_importer.py
@@ -130,17 +130,17 @@ def _get_task_arg(task_id: str, conn) -> TaskArgs:
     parser_func = str_fileid_to_eval(arg_parser)
     parser = parser_func(**stim_kwargs)
 
-    if instr_kwargs.instruction_file is not None:
-        instr_kwargs.instruction_file = op.join(
-            cfg.neurobooth_config["video_tasks"], instr_kwargs.instruction_file
-        )
-        task_args = TaskArgs(task_id=task_id,
-                             task_constructor_callable=stim_func,
-                             stim_args=parser,
-                             instr_args=instr_kwargs)
-    else:
-        task_args = TaskArgs(task_id=task_id,
-                             task_constructor_callable=stim_func,
-                             stim_args=parser)
-
-    return task_args
+    if instr_kwargs is not None:
+        if instr_kwargs.instruction_file is not None:
+            instr_kwargs.instruction_file = op.join(
+                cfg.neurobooth_config["video_tasks"], instr_kwargs.instruction_file
+            )
+            task_args = TaskArgs(task_id=task_id,
+                                 task_constructor_callable=stim_func,
+                                 stim_args=parser,
+                                 instr_args=instr_kwargs)
+        else:
+            task_args = TaskArgs(task_id=task_id,
+                                 task_constructor_callable=stim_func,
+                                 stim_args=parser)
+        return task_args

--- a/neurobooth_os/tasks/task_importer.py
+++ b/neurobooth_os/tasks/task_importer.py
@@ -135,12 +135,12 @@ def _get_task_arg(task_id: str, conn) -> TaskArgs:
             instr_kwargs.instruction_file = op.join(
                 cfg.neurobooth_config["video_tasks"], instr_kwargs.instruction_file
             )
-            task_args = TaskArgs(task_id=task_id,
-                                 task_constructor_callable=stim_func,
-                                 stim_args=parser,
-                                 instr_args=instr_kwargs)
-        else:
-            task_args = TaskArgs(task_id=task_id,
-                                 task_constructor_callable=stim_func,
-                                 stim_args=parser)
+        task_args = TaskArgs(task_id=task_id,
+                             task_constructor_callable=stim_func,
+                             stim_args=parser,
+                             instr_args=instr_kwargs)
         return task_args
+    task_args = TaskArgs(task_id=task_id,
+                         task_constructor_callable=stim_func,
+                         stim_args=parser)
+    return task_args


### PR DESCRIPTION
Fix:
- psychopy version
- return type (and conditional branch logic) for creating instruction keyword arguments model
- handling "presented" state in stm loop 

tested in staging