### PR TITLE
Fixing logging-related crashes on mbient reset script. Also routing l…

### DIFF
--- a/extras/reset_mbients.py
+++ b/extras/reset_mbients.py
@@ -7,7 +7,7 @@ from time import time
 import multiprocessing as mp
 import logging
 from neurobooth_os.iout.mbient import scan_BLE, connect_device, reset_device, MbientFailedConnection
-from neurobooth_os.log_manager import make_db_logger, APP_LOG_NAME, PostgreSQLHandler
+from neurobooth_os.log_manager import make_db_logger, APP_LOG_NAME
 from neurobooth_os.config import load_config
 
 


### PR DESCRIPTION
…og output to stdout.

Note that each process has its own interpreter and thus needs its own logger instance.