### PR TITLE
Update clapping_test_obs.yml

### DIFF
--- a/examples/configs/tasks/clapping_test_obs.yml
+++ b/examples/configs/tasks/clapping_test_obs.yml
@@ -1,4 +1,4 @@
-task_id: clapping_test
+task_id: clapping_test_obs
 feature_of_interest: synch
 stimulus_id: clapping_task
 instruction_id: null


### PR DESCRIPTION
fixed the name to follow the _obs protocol.  The name check seems to be needed because PySimpleGui returns the names in a function that returns all gui data from any (updated?) gui control, so we can't be sure what we're getting otherwise. 

One more reason to get rid of PySimpleGui