### PR TITLE
Allowing log_task_param to handle complex/nested types

### DIFF
--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import importlib
+import json
 import logging
 import os
 from collections import OrderedDict
@@ -216,7 +217,15 @@ def log_task_params(conn: connection, stimulus_id: str, log_task_id: str, task_p
     @return: None
     """
     for key, value in task_param_dictionary.items():
-        value_type = str(type(value))
+        if isinstance(value, (list, dict, tuple)):
+            value_type = 'JSON'
+            value = json.dumps(value)
+        elif isinstance(value, BaseModel):
+            value_type = 'JSON'
+            value = value.model_dump_json()
+        else:
+            value_type = str(type(value))
+
         args = {
             "log_task_id": log_task_id,
             "stimulus_id": stimulus_id,

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -124,8 +124,10 @@ def run_stm(logger):
                         task.run(**this_task_kwargs)
                     else:
                         log_task_id = meta.make_new_task_row(session.db_conn, subj_id)
-                        meta.log_task_params(session.db_conn, task_id, log_task_id,
-                                             dict(session.task_func_dict[task_id].stim_args))
+                        meta.log_task_params(
+                            session.db_conn, task_id, log_task_id,
+                            session.task_func_dict[task_id].stim_args.model_dump()
+                        )
                         task_log_entry.date_times = (
                                 "{" + datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ","
                         )


### PR DESCRIPTION
I'm using the MOT stimulus YAML define the task parameters for each individual frame. This change is needed to allow the task parameter logging to handle complex / nested types.