### PR TITLE
Partial fix to name query that includes apostrophe

### DIFF
--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -95,7 +95,7 @@ def get_subject_ids(conn: connection, first_name, last_name):
 def _escape_name_string(name: str) -> str:
     """ Escapes a single quote in the name (as in, e.g. "O'neil"), if one exists."""
     if "'" in name:
-        return f"""{name}"""
+        return f'''{name}'''
     else:
         return name
 

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -83,8 +83,8 @@ def get_study_ids() -> List[str]:
 
 def get_subject_ids(conn: connection, first_name, last_name):
     table_subject = Table("subject", conn=conn)
-    f_name = _escape_name_string(f_name)
-    l_name = _escape_name_string(l_name)
+    first_name = _escape_name_string(first_name)
+    last_name = _escape_name_string(last_name)
 
     subject_df = table_subject.query(
         where=f"LOWER(first_name_birth)=LOWER('{first_name}') AND LOWER(last_name_birth)=LOWER('{last_name}')"

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -95,7 +95,7 @@ def get_subject_ids(conn: connection, first_name, last_name):
 def _escape_name_string(name: str) -> str:
     """ Escapes a single quote in the name (as in, e.g. "O'neil"), if one exists."""
     if "'" in name:
-        return f'''{name}'''
+        return f'''{name.replace("'", "''")}'''
     else:
         return name
 

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -95,11 +95,9 @@ def get_subject_ids(conn: connection, first_name, last_name):
 def _escape_name_string(name: str) -> str:
     """ Escapes a single quote in the name (as in, e.g. "O'neil"), if one exists."""
     if "'" in name:
-        return name.replace("'", r"\'")
+        return f"""{name}"""
     else:
         return name
-
-
 
 
 def get_collection_ids(study_id) -> List[str]:

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -83,10 +83,23 @@ def get_study_ids() -> List[str]:
 
 def get_subject_ids(conn: connection, first_name, last_name):
     table_subject = Table("subject", conn=conn)
+    f_name = _escape_name_string(f_name)
+    l_name = _escape_name_string(l_name)
+
     subject_df = table_subject.query(
         where=f"LOWER(first_name_birth)=LOWER('{first_name}') AND LOWER(last_name_birth)=LOWER('{last_name}')"
     )
     return subject_df
+
+
+def _escape_name_string(name: str) -> str:
+    """ Escapes a single quote in the name (as in, e.g. "O'neil"), if one exists."""
+    if "'" in name:
+        return name.replace("'", r"\'")
+    else:
+        return name
+
+
 
 
 def get_collection_ids(study_id) -> List[str]:


### PR DESCRIPTION
Handles "O'Neil" such that it will be found if it is in the Neurobooth database. Previous behavior is to crash the gui with a DB exception. 

Note that hyphens already work correctly if they are in the subject table.  Next task is to see what prevents them from getting into the subject table correctly 