### PR TITLE
Fixes for files, db entries, and UI issues

### DIFF
--- a/examples/configs/collections/test_no_eyelink.yml
+++ b/examples/configs/collections/test_no_eyelink.yml
@@ -1,6 +1,8 @@
 collection_id: test_no_eyelink
 is_active: true
 task_ids:
+- intro_sess_obs_1
+- gogogo_test_obs_1
 - altern_hand_test_obs_1
 - foot_tapping_test_obs_1
 - sit_to_stand_test_obs

--- a/examples/configs/tasks/gogogo_test_obs_1.yml
+++ b/examples/configs/tasks/gogogo_test_obs_1.yml
@@ -1,0 +1,7 @@
+task_id: gogogo_test_obs_1
+feature_of_interest: speech
+stimulus_id: GoGoGo_task_1
+instruction_id: gogo_1
+device_id_array:
+- Intel_D455_1
+arg_parser: iout.stim_param_reader.py::RawTaskParams()

--- a/neurobooth_os/__init__.py
+++ b/neurobooth_os/__init__.py
@@ -1,3 +1,3 @@
 """Neurobooth OS"""
 
-__version__ = "0.0.36.2"
+__version__ = "0.0.37.0"

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -679,6 +679,7 @@ def gui(logger):
                 window["-frame_preview-"].update(visible=True)
                 if not start_pressed:
                     window['Start'].update(disabled=False)
+                    write_output(window, "Please wait for inlet streams to load before pressing 'Start'", 'blue')
 
         # Create LSL inlet stream
         elif event == "-OUTLETID-":

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -324,7 +324,7 @@ def _start_ctr_msg_reader(logger, window):
     while True:
         message: Message = meta.read_next_message("CTR", conn=db_conn)
         if message is None:
-            time.sleep(1)
+            time.sleep(.5)
             continue
         msg_body: Optional[MsgBody] = None
         logger.info(f'MESSAGE RECEIVED: {message.model_dump_json()}')

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -274,7 +274,6 @@ def _stop_lsl_and_save(
 
     xdf_fname = get_xdf_name(session, rec_fname)
     xdf_path = op.join(folder, xdf_fname)
-    print(f'xdf_path: {xdf_path}')
     t0 = time.time()
     if any([tsk in task_id for tsk in ["hevelius", "MOT", "pursuit"]]):
         # Don't split large files now, just add to a backlog to handle post-session
@@ -679,7 +678,6 @@ def gui(logger):
                 window["-frame_preview-"].update(visible=True)
                 if not start_pressed:
                     window['Start'].update(disabled=False)
-                    write_output(window, "Please wait for inlet streams to load before pressing 'Start'", 'blue')
 
         # Create LSL inlet stream
         elif event == "-OUTLETID-":
@@ -730,6 +728,7 @@ def close(window):
     if "-OUTPUT-" in window.AllKeysDict:
         window["-OUTPUT-"].__del__()
     print("Session terminated")
+
 
 def terminate_system(conn, plttr, sess_info, values, window):
     if sess_info and values:

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -533,10 +533,12 @@ def gui(logger):
             tasks = _get_tasks(window, collection_id)
 
         elif event == "_init_sess_save_":
-            if values["tasks"] == "":
-                sg.PopupError("No task combo", location=get_popup_location(window))
+            if values["study_id"] == "" or values['collection_id'] == "":
+                sg.PopupError("Study and Collection are required fields", location=get_popup_location(window))
             elif values["staff_id"] == "":
-                sg.PopupError("No staff ID", location=get_popup_location(window))
+                sg.PopupError("Staff ID is required", location=get_popup_location(window))
+            elif window["subject_info"].get() == "":
+                sg.PopupError("Please select a Subject", location=get_popup_location(window))
             else:
                 log_sess["staff_id"] = values["staff_id"]
                 sess_info = _create_session_dict(

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -678,7 +678,7 @@ def gui(logger):
                 window["-frame_preview-"].update(visible=True)
                 if not start_pressed:
                     window['Start'].update(disabled=False)
-                    write_output(window, "Device connection complete. Ok to Start session")
+                    write_output(window, "Device connection complete. OK to start session")
 
         # Create LSL inlet stream
         elif event == "-OUTLETID-":

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -678,6 +678,7 @@ def gui(logger):
                 window["-frame_preview-"].update(visible=True)
                 if not start_pressed:
                     window['Start'].update(disabled=False)
+                    write_output(window, "Device connection complete. Ok to Start session")
 
         # Create LSL inlet stream
         elif event == "-OUTLETID-":

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -125,7 +125,6 @@ def _start_task_presentation(window, tasks: List[str], subject_id: str, session_
     conn = meta.get_database_connection()
     window['Start'].update(disabled=True)
     write_output(window, "\nSession started")
-    write_output(window, "\nPlease wait for all inlet streams to load before proceeding", text_color='red')
 
     if len(tasks) > 0:
         msg_body = CreateTasksRequest(tasks=tasks, subj_id=subject_id, session_id=session_id)
@@ -652,6 +651,7 @@ def gui(logger):
             session = _start_lsl_session(window, inlets, sess_info["subject_id_date"])
             window["-frame_preview-"].update(visible=True)
             window['Start'].update(disabled=False)
+            write_output(window, "\nPlease wait for all inlet streams to load before proceeding", text_color='red')
 
         # Create LSL inlet stream
         elif event == "-OUTLETID-":

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -26,7 +26,6 @@ class EyeTracker:
         win=None,
         with_lsl=True,
     ):
-        self.filename = None
         self.IP = device_args.ip
         self.sample_rate = device_args.sample_rate()
         self.device_id = device_args.device_id
@@ -192,7 +191,7 @@ class EyeTracker:
             print(f"FILE {fname_asc} already exists")
         return
 
-    def start(self, filename):
+    def start(self, filename="TEST.edf"):
         self.filename = filename
         body = NewVideoFile(stream_name=self.streamName, filename=op.split(filename)[-1])
         msg = Request(source="EyeTracker", destination="CTR", body=body)

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -26,6 +26,7 @@ class EyeTracker:
         win=None,
         with_lsl=True,
     ):
+        self.filename = None
         self.IP = device_args.ip
         self.sample_rate = device_args.sample_rate()
         self.device_id = device_args.device_id
@@ -191,7 +192,7 @@ class EyeTracker:
             print(f"FILE {fname_asc} already exists")
         return
 
-    def start(self, filename="TEST.edf"):
+    def start(self, filename):
         self.filename = filename
         body = NewVideoFile(stream_name=self.streamName, filename=op.split(filename)[-1])
         msg = Request(source="EyeTracker", destination="CTR", body=body)

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -182,7 +182,7 @@ class EyeTracker:
         if not op.exists(fname_asc):
             pout = subprocess.run(["edf2asc.exe", self.filename], shell=True)
             if not pout.stderr:
-                body = NewVideoFile(event="-new_filename-", stream_name=self.streamName, filename=op.split(fname_asc)[-1])
+                body = NewVideoFile(stream_name=self.streamName, filename=op.split(fname_asc)[-1])
                 msg = Request(source="EyeTracker", destination="CTR", body=body)
                 with get_database_connection() as conn:
                     post_message(msg, conn)
@@ -193,7 +193,7 @@ class EyeTracker:
 
     def start(self, filename="TEST.edf"):
         self.filename = filename
-        body = NewVideoFile(event="-new_filename-", stream_name=self.streamName, filename=op.split(filename)[-1])
+        body = NewVideoFile(stream_name=self.streamName, filename=op.split(filename)[-1])
         msg = Request(source="EyeTracker", destination="CTR", body=body)
         with get_database_connection() as conn:
             post_message(msg, conn)

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -185,7 +185,7 @@ class VidRec_Flir:
         self.video_out = cv2.VideoWriter(
             self.video_filename, fourcc, self.FRAME_RATE_OUT, self.frameSize
         )
-        msg_body = NewVideoFile(event='-new_filename-', stream_name=self.streamName,
+        msg_body = NewVideoFile(stream_name=self.streamName,
                                 filename=op.split(self.video_filename)[-1])
         with meta.get_database_connection() as db_conn:
             meta.post_message(Request(source='Flir', destination='CTR', body=msg_body), conn=db_conn)

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -770,7 +770,7 @@ class IPhone:
 
     @staticmethod
     def send_file_msg(stream_name, file_name, conn):
-        body = NewVideoFile(event="-new_filename-", stream_name=stream_name, filename=f"{file_name}")
+        body = NewVideoFile(stream_name=stream_name, filename=f"{file_name}")
         msg = Request(source="IPhone", destination="CTR", body=body)
         post_message(msg, conn)
 

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -226,6 +226,7 @@ def get_subject_ids(conn: connection, first_name, last_name):
 
 def get_subject_by_id(conn: connection, subject_id: str) -> Optional[Subject]:
 
+    subject_id = subject_id.strip()
     # We do two separate queries in case the contact table doesn't have any matching records,
     # due to, for example, an issue with the REDCap update timing.  We always want a result if there's a matching
     # record in the subject table.  Hitting both tables with a single join query would cause zero records to be returned

--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -304,6 +304,7 @@ def _win_gen(layout, *args):
         #    no_titlebar=False,
         grab_anywhere=False,
         default_button_element_size=(12, 1),
+        enable_close_attempted_event=True,
     )
     return window
 

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -262,6 +262,7 @@ class TaskCompletion(MsgBody):
     Message sent from STM to CTR to tell CTR to stop LSL
     """
     task_id: str
+    has_lsl_stream: bool = True  # True if the task has associated LSL streams (False for instructions, pauses)
 
     def __init__(self, **data):
         data['priority'] = MEDIUM_PRIORITY

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -244,7 +244,7 @@ class TaskInitialization(MsgBody):
     tsk_start_time: str
 
     def __init__(self, **data):
-        data['priority'] = MEDIUM_PRIORITY
+        data['priority'] = HIGH_PRIORITY
         super().__init__(**data)
 
 
@@ -265,7 +265,7 @@ class TaskCompletion(MsgBody):
     has_lsl_stream: bool = True  # True if the task has associated LSL streams (False for instructions, pauses)
 
     def __init__(self, **data):
-        data['priority'] = MEDIUM_PRIORITY
+        data['priority'] = HIGH_PRIORITY
         super().__init__(**data)
 
 
@@ -436,7 +436,7 @@ class NewVideoFile(MsgBody):
     """
     Message sent by devices, or by the controller (for Marker streams) to indicate that a new VideoFile was created
     """
-    event: str
+    event: str = "-new_filename-"
     stream_name: str
     filename: str
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -63,7 +63,7 @@ def run_acq(logger):
         try:
             message: Message = meta.read_next_message("ACQ", conn=db_conn)
             if message is None:
-                sleep(1)
+                sleep(.5)
                 continue
             msg_body: Optional[MsgBody] = None
             logger.info(f'MESSAGE RECEIVED: {message.model_dump_json()}')

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -117,10 +117,6 @@ def run_acq(logger):
             elif "StartRecording" == current_msg_type:
                 msg_body: StartRecording = message.body
 
-                status_msg = StatusMessage(text="Starting recording", status="Info")
-                status_req = Request(source="ACQ", destination="CTR", body=status_msg)
-                meta.post_message(status_req, conn=db_conn)
-
                 task = msg_body.task_id
                 fname = msg_body.fname
                 session_name = msg_body.session_name

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -186,6 +186,9 @@ def _perform_task(db_conn, device_log_entry_dict, logger, message, session, subj
             load_task_media(session, task_args)
             task: Task = task_args.task_instance
             task.run(**this_task_kwargs)
+            # Signal CTR to stop LSL rec
+            meta.post_message(Request(source='STM', destination='CTR',
+                                      body=TaskCompletion(task_id=task_id, has_lsl_stream=False)), db_conn)
         else:
             log_task_id = meta.make_new_task_row(session.db_conn, subj_id)
             meta.log_task_params(

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -69,7 +69,7 @@ def run_stm(logger):
             while paused:
                 message: Message = meta.read_next_message("STM", msg_type='paused_msg_types', conn=db_conn)
                 if message is None:
-                    sleep(1)
+                    sleep(.5)
                     continue
 
                 logger.info(f'MESSAGE RECEIVED: {message.model_dump_json()}')

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -23,7 +23,7 @@ class Calibrate(Task_Eyetracker):
         if instructions:
             self.present_instructions(prompt)
 
-        fname = self.eye_tracker.filename
+        fname = kwargs["fname"]
 
         body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
         msg = Request(source="EyeTracker", destination="CTR", body=body)

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -19,27 +19,28 @@ class Calibrate(Task_Eyetracker):
 
         super().__init__(**kwargs)
 
-    # def run(self, prompt=True, instructions=True, **kwargs):
-    #     if instructions:
-    #         self.present_instructions(prompt)
-    #     body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
-    #     msg = Request(source="EyeTracker", destination="CTR", body=body)
-    #     post_message(msg, get_database_connection())
-    #
-    #     self.fname = fname
-    #     self.fname_temp = "name8chr.edf"
-    #     self.eye_tracker.tk.openDataFile(self.fname_temp)
-    #
-    #     self.eye_tracker.calibrate()
-    #
-    #     # record for an instant so loadable in data viewer
-    #     self.eye_tracker.tk.startRecording(1, 1, 1, 1)
-    #     self.eye_tracker.tk.stopRecording()
-    #     self.eye_tracker.tk.closeDataFile()
-    #     # Download file
-    #     self.eye_tracker.tk.receiveDataFile(self.fname_temp, self.fname)
-    #
-    #     self.present_complete()
+    def run(self, prompt=True, fname="test", instructions=True, **kwargs):
+        if instructions:
+            self.present_instructions(prompt)
+
+        body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
+        msg = Request(source="EyeTracker", destination="CTR", body=body)
+        post_message(msg, get_database_connection())
+
+        self.fname = fname
+        self.fname_temp = "name8chr.edf"
+        self.eye_tracker.tk.openDataFile(self.fname_temp)
+
+        self.eye_tracker.calibrate()
+
+        # record for an instant so loadable in data viewer
+        self.eye_tracker.tk.startRecording(1, 1, 1, 1)
+        self.eye_tracker.tk.stopRecording()
+        self.eye_tracker.tk.closeDataFile()
+        # Download file
+        self.eye_tracker.tk.receiveDataFile(self.fname_temp, self.fname)
+
+        self.present_complete()
 
 
 if __name__ == "__main__":
@@ -50,7 +51,7 @@ if __name__ == "__main__":
     eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
     config.load_config()
     server_config = config.neurobooth_config.current_server()
-    filename = f"{server_config.local_data_dir}calibration.edf"
-    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=filename)
+    fname = f"{server_config.local_data_dir}calibration.edf"
+    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=fname)
     cal.run()
     cal.win.close()

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -19,8 +19,7 @@ class Calibrate(Task_Eyetracker):
 
         super().__init__(**kwargs)
 
-    def run(self, prompt=True, instructions=True, **kwargs):
-        fname = kwargs['fname']
+    def run(self, prompt=True, fname="test", instructions=True, **kwargs):
         if instructions:
             self.present_instructions(prompt)
 
@@ -42,3 +41,17 @@ class Calibrate(Task_Eyetracker):
         self.eye_tracker.tk.receiveDataFile(self.fname_temp, self.fname)
 
         self.present_complete()
+
+
+if __name__ == "__main__":
+    from neurobooth_os.iout.eyelink_tracker import EyeTracker
+    from neurobooth_os.tasks import utils
+
+    win = utils.make_win(False)
+    eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
+    config.load_config()
+    server_config = config.neurobooth_config.current_server()
+    fname = f"{server_config.local_data_dir}calibration.edf"
+    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=fname)
+    cal.run()
+    cal.win.close()

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -23,7 +23,7 @@ class Calibrate(Task_Eyetracker):
         if instructions:
             self.present_instructions(prompt)
 
-        body = NewVideoFile(event="-new_filename-", stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
+        body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
         msg = Request(source="EyeTracker", destination="CTR", body=body)
         post_message(msg, get_database_connection())
 

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -19,7 +19,8 @@ class Calibrate(Task_Eyetracker):
 
         super().__init__(**kwargs)
 
-    def run(self, prompt=True, fname="test", instructions=True, **kwarg):
+    def run(self, prompt=True, instructions=True, **kwargs):
+        fname = kwargs['fname']
         if instructions:
             self.present_instructions(prompt)
 
@@ -41,17 +42,3 @@ class Calibrate(Task_Eyetracker):
         self.eye_tracker.tk.receiveDataFile(self.fname_temp, self.fname)
 
         self.present_complete()
-
-
-if __name__ == "__main__":
-    from neurobooth_os.iout.eyelink_tracker import EyeTracker
-    from neurobooth_os.tasks import utils
-
-    win = utils.make_win(False)
-    eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
-    config.load_config()
-    server_config = config.neurobooth_config.current_server()
-    fname = f"{server_config.local_data_dir}calibration.edf"
-    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=fname)
-    cal.run()
-    cal.win.close()

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -19,9 +19,11 @@ class Calibrate(Task_Eyetracker):
 
         super().__init__(**kwargs)
 
-    def run(self, prompt=True, fname="test", instructions=True, **kwargs):
+    def run(self, prompt=True, instructions=True, **kwargs):
         if instructions:
             self.present_instructions(prompt)
+
+        fname = self.eye_tracker.filename
 
         body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
         msg = Request(source="EyeTracker", destination="CTR", body=body)
@@ -51,7 +53,7 @@ if __name__ == "__main__":
     eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
     config.load_config()
     server_config = config.neurobooth_config.current_server()
-    fname = f"{server_config.local_data_dir}calibration.edf"
-    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=fname)
+    file_name = f"{server_config.local_data_dir}calibration.edf"
+    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=file_name)
     cal.run()
     cal.win.close()

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -19,28 +19,27 @@ class Calibrate(Task_Eyetracker):
 
         super().__init__(**kwargs)
 
-    def run(self, prompt=True, fname="test", instructions=True, **kwargs):
-        if instructions:
-            self.present_instructions(prompt)
-
-        body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
-        msg = Request(source="EyeTracker", destination="CTR", body=body)
-        post_message(msg, get_database_connection())
-
-        self.fname = fname
-        self.fname_temp = "name8chr.edf"
-        self.eye_tracker.tk.openDataFile(self.fname_temp)
-
-        self.eye_tracker.calibrate()
-
-        # record for an instant so loadable in data viewer
-        self.eye_tracker.tk.startRecording(1, 1, 1, 1)
-        self.eye_tracker.tk.stopRecording()
-        self.eye_tracker.tk.closeDataFile()
-        # Download file
-        self.eye_tracker.tk.receiveDataFile(self.fname_temp, self.fname)
-
-        self.present_complete()
+    # def run(self, prompt=True, instructions=True, **kwargs):
+    #     if instructions:
+    #         self.present_instructions(prompt)
+    #     body = NewVideoFile(stream_name=self.eye_tracker.streamName, filename=op.split(fname)[-1])
+    #     msg = Request(source="EyeTracker", destination="CTR", body=body)
+    #     post_message(msg, get_database_connection())
+    #
+    #     self.fname = fname
+    #     self.fname_temp = "name8chr.edf"
+    #     self.eye_tracker.tk.openDataFile(self.fname_temp)
+    #
+    #     self.eye_tracker.calibrate()
+    #
+    #     # record for an instant so loadable in data viewer
+    #     self.eye_tracker.tk.startRecording(1, 1, 1, 1)
+    #     self.eye_tracker.tk.stopRecording()
+    #     self.eye_tracker.tk.closeDataFile()
+    #     # Download file
+    #     self.eye_tracker.tk.receiveDataFile(self.fname_temp, self.fname)
+    #
+    #     self.present_complete()
 
 
 if __name__ == "__main__":
@@ -51,7 +50,7 @@ if __name__ == "__main__":
     eye_tracker = EyeTracker(win=win, ip="192.168.100.15")
     config.load_config()
     server_config = config.neurobooth_config.current_server()
-    fname = f"{server_config.local_data_dir}calibration.edf"
-    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=fname)
+    filename = f"{server_config.local_data_dir}calibration.edf"
+    cal = Calibrate(eye_tracker=eye_tracker, win=win, fname=filename)
     cal.run()
     cal.win.close()

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -297,8 +297,11 @@ class Task:
 
     def run(self, prompt=True, duration=0, **kwargs):
         self.present_instructions(prompt)
+        event.clearEvents(eventType='keyboard')
         self.present_task(prompt, duration, **kwargs)
+        event.clearEvents(eventType='keyboard')
         self.present_complete()
+        event.clearEvents(eventType='keyboard')
         return self.events
 
     def check_if_aborted(self) -> None:

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -149,6 +149,7 @@ def countdown(period):
 
 
 def get_keys(keyList=()):
+    event.clearEvents(eventType='keyboard')
     # Wait for keys checking every 5 ms
     while True:
         press = event.getKeys()

--- a/neurobooth_os/util/nb_types.py
+++ b/neurobooth_os/util/nb_types.py
@@ -7,8 +7,8 @@ from datetime import datetime
 class Subject(BaseModel):
     subject_id: str
     first_name_birth: str
-    middle_name_birth: str
+    middle_name_birth: Optional[str]
     last_name_birth: str
     date_of_birth: datetime
-    preferred_first_name: str
-    preferred_last_name: str
+    preferred_first_name: Optional[str]
+    preferred_last_name: Optional[str]


### PR DESCRIPTION
This PR is intended to address: 
- log_sensor_file missing file paths 
- missing calibration files and erroneous log_sensor_file 'test' record
- handle null values in middle names
- prevent Start button from being enabled until both servers send SessionPrepared
- prevent Start button from being pressed twice
- eliminate (harmless) exception thrown when exiting from first GUI screen by pressing the window's X button.
- trim subject ids to remove leading and trailing whitespace
- candidate (partial?) fix for key caching 
- fix bug in gui first screen where missing data caused crashes

In addition, there should be a modest improvement in the frame-preview lag issue as message queue polling was increased from once per second to twice per second, which should reduce the messaging-related latency from 1 second on average (round-trip) to 1/2 second. 

Finally, there were a couple minor UI enhancements:
- added a "Safe to terminate" message at the end of the session 
- disabled task check-boxes when the Connect Devices button is pressed