### PR TITLE
fix task duration countdown for movement tasks

### DIFF
--- a/neurobooth_os/__init__.py
+++ b/neurobooth_os/__init__.py
@@ -1,3 +1,3 @@
 """Neurobooth OS"""
 
-__version__ = "0.0.37.3"
+__version__ = "0.0.37.4"

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -211,7 +211,7 @@ def _perform_task(db_conn, device_log_entry_dict, message, session, subj_id: str
             meta.post_message(Request(source='STM', destination='CTR', body=init_task_body), conn=db_conn)
             session.logger.info(f'Initiating task:{task_id}:{task_id}:{log_task_id}:{tsk_start_time}')
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                 future1 = executor.submit(_wait_for_lsl_recording_to_start, db_conn, session)
                 future2 = executor.submit(_start_acq, session, task_id, tsk_start_time)
                 # Wait for all futures to complete

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -113,7 +113,7 @@ def present(
             get_keys()
     if audio is not None:
         audio.play()
-    countdown(wait_time, abort_keys)
+    countdown(wait_time)  # TODO: add abort keys back after debugging
     if waitKeys:
         get_keys()
 

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -113,7 +113,7 @@ def present(
             get_keys()
     if audio is not None:
         audio.play()
-    countdown(wait_time)  # TODO: add abort keys back after debugging
+    countdown(wait_time, abort_keys)  # TODO: add abort keys back after debugging
     if waitKeys:
         get_keys()
 
@@ -143,17 +143,34 @@ def get_end_screen(win, root_pckg):
 
 
 def countdown(period: float, abort_keys: Optional[List] = None) -> None:
+
+    def get_abort_key(keyList=()):
+        press = event.getKeys()
+        if press:
+            if not keyList:
+                return press
+            elif any([k in keyList for k in press]):
+                return press
+        return None
+
     t1 = local_clock()
     t2 = t1
 
     while t2 - t1 < period:
         if abort_keys is not None and abort_keys:
-            if get_keys(abort_keys):
+            if get_abort_key(abort_keys):
                 return
         t2 = local_clock()
 
 
 def get_keys(keyList=()):
+
+    def delay(period: float) -> None:
+        t1 = local_clock()
+        t2 = t1
+        while t2 - t1 < period:
+            t2 = local_clock()
+
     event.clearEvents(eventType='keyboard')
     # Wait for keys checking every 5 ms
     while True:
@@ -163,8 +180,8 @@ def get_keys(keyList=()):
                 return press
             elif any([k in keyList for k in press]):
                 return press
+        delay(0.005)
 
-        countdown(0.005)
 
 
 def play_video(win, mov, wait_time=1, stop=True):


### PR DESCRIPTION
1 address issue in task utils where countdown was hanging indefinitely while checking for abort keys
2 make server_stm create the proper number of threads for its tasks