### PR TITLE
Handle remaining config changes

### DIFF
--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -5,7 +5,7 @@ Ensures that the base neurobooth-os config file exists and makes config file ava
 
 from os import environ, path, getenv
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 import json
 
 

--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -5,7 +5,6 @@ Ensures that the base neurobooth-os config file exists and makes config file ava
 
 from os import environ, path, getenv
 from typing import Optional
-from typing_extensions import Annotated
 from pydantic import BaseModel, Field
 import json
 
@@ -62,10 +61,9 @@ class ServerSpec(BaseModel):
 
 
 class NeuroboothConfig(BaseModel):
-    default_log_path: str
     remote_data_dir: str
-    split_xdf_backlog: str
     video_task_dir: str
+    split_xdf_backlog: str
     cam_inx_lowfeed: int
     acquisition: ServerSpec
     presentation: ServerSpec
@@ -94,7 +92,6 @@ def validate_system_paths(server_name: str):
     if server_name == "presentation":
         validate_folder(neurobooth_config.video_task_dir)
     validate_folder(neurobooth_config.remote_data_dir)
-    validate_folder(neurobooth_config.default_log_path)
 
     source = neurobooth_config.server_by_name(server_name).local_data_dir
     if not path.exists(source):

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -48,17 +48,12 @@ def str_fileid_to_eval(stim_file_str):
     return task_func
 
 
-def get_database_connection(database: Optional[str] = None, validate_config_paths: bool = True) -> connection:
+def get_database_connection(database: Optional[str] = None) -> connection:
     """Gets connector to the database
 
     :param database: If provided, override the database name in the configration.
-    :param validate_config_paths: True if the config file path should be validated.
-        This should generally be True outside test scenarios
     :returns: Connector to psycopg database
     """
-    import neurobooth_os.log_manager as log_man
-    log_man.make_default_logger(log_level=logging.ERROR, validate_paths=validate_config_paths)
-
     database_info = cfg.neurobooth_config.database
     if database_info.host not in ["127.0.0.1", "localhost"]:
         # If the DB is not on this host, use SSH tunneling for access

--- a/neurobooth_os/iout/tests/test_metadator.py
+++ b/neurobooth_os/iout/tests/test_metadator.py
@@ -81,7 +81,7 @@ class TestMetadator(unittest.TestCase):
         meta.fill_task_row(vals_dict, conn)
 
     def test_fill_device_rows(self):
-        conn = meta.get_database_connection("mock_neurobooth_1", False)
+        conn = meta.get_database_connection("mock_neurobooth_1")
         collection_id = 'mvp_030'
         task_dict = meta.build_tasks_for_collection(collection_id)
         self.assertIsNotNone(task_dict)
@@ -90,7 +90,7 @@ class TestMetadator(unittest.TestCase):
             meta._fill_device_param_row(conn, device)
 
     def test_log_task_params(self):
-        conn = meta.get_database_connection("mock_neurobooth_1", False)
+        conn = meta.get_database_connection("mock_neurobooth_1")
         collection_id = 'mvp_030'
         task_dict = meta.build_tasks_for_collection(collection_id)
         self.assertIsNotNone(task_dict)

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -1,5 +1,4 @@
 import json
-import os
 import logging
 import sys
 from datetime import datetime
@@ -28,6 +27,7 @@ APP_LOGGER: Optional[logging.Logger] = None
 # Name of the Application Logger, for use in retrieving the appropriate logger from the logging module
 APP_LOG_NAME = "app"
 
+
 def make_session_logger_debug(
         file: Optional[str] = None,
         console: bool = False,
@@ -53,7 +53,6 @@ def make_session_logger_debug(
 
 def make_db_logger(subject: str = None,
                    session: str = None,
-                   fallback_log_path: str = None,
                    log_level: int = logging.DEBUG) -> logging.Logger:
     """Returns a logger that logs to the database and sets the subject id and session to be used for subsequent
     logging calls.
@@ -61,9 +60,6 @@ def make_db_logger(subject: str = None,
     NOTE: If the subject or session should be cleared, the argument should be an empty string.
     Passing None will NOT reset those values
     """
-
-    if fallback_log_path is None:
-        fallback_log_path = config.neurobooth_config.default_log_path
 
     global SUBJECT_ID, SESSION_ID, APP_LOGGER
 
@@ -75,57 +71,13 @@ def make_db_logger(subject: str = None,
     # Don't reinitialize the logger if one exists
     if APP_LOGGER is None:
         logger = logging.getLogger(APP_LOG_NAME)
-        handler = PostgreSQLHandler(fallback_log_path, log_level)
+        handler = PostgreSQLHandler(log_level)
         logger.addHandler(handler)
         logger.setLevel(log_level)
         extra = {"device": ""}
         logging.LoggerAdapter(logger, extra)
         APP_LOGGER = logger
     return APP_LOGGER
-
-
-def get_default_log_handler(
-        log_path: Optional[str] = None,
-        log_level=logging.DEBUG,
-):
-    """Returns a log handler suitable for logging when the DB isn't available
-    """
-    if log_path is None:
-        log_path = config.neurobooth_config.default_log_path
-
-    if not os.path.exists(log_path):
-        os.makedirs(log_path)
-    time_str = datetime.now().strftime("%Y-%m-%d_%Hh-%Mm-%Ss")
-    file = os.path.join(log_path, f'default_{time_str}.log')
-
-    file_handler = logging.FileHandler(file)
-    file_handler.setLevel(log_level)
-    file_handler.setFormatter(LOG_FORMAT)
-    return file_handler
-
-
-def make_default_logger(
-        log_path: Optional[str] = None,
-        log_level=logging.DEBUG,
-        validate_paths: bool = True
-) -> logging.Logger:
-    if config.neurobooth_config is None:
-        config.load_config(None, validate_paths)
-    if log_path is None:
-        log_path = config.neurobooth_config.default_log_path
-
-    logger = logging.getLogger('default')
-    logger.addHandler(get_default_log_handler(log_path, log_level))
-
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(log_level)
-    console_handler.setFormatter(LOG_FORMAT)
-    logger.addHandler(console_handler)
-
-    # make_session_logger_debug(file=file)
-
-    logger.setLevel(log_level)
-    return logger
 
 
 def log_message_received(message: Message, logger) -> None:
@@ -296,18 +248,15 @@ class PostgreSQLHandler(logging.Handler):
     # see TYPE log_level
     _levels = ('debug', 'info', 'warning', 'error', 'critical')
 
-    def __init__(self, fallback_log_path: str = None, log_level=logging.DEBUG):
+    def __init__(self, log_level=logging.DEBUG):
         super(PostgreSQLHandler, self).__init__()
-        self.fallback_log_path = fallback_log_path
         self.setLevel(log_level)
         self.name = "db_handler"
 
         try:
             self._get_logger_connection()
-        except Exception:
-            msg = "Unable to connect to database for logging. Falling back to default file logging."
-            self.fallback_to_local_handler()
-            logging.getLogger(APP_LOG_NAME).exception(msg)
+        except Exception as e:
+            print(f"Unable to connect to database for logging:  {e}")
 
     def close(self):
         """Close this log handler and its DB connection """
@@ -347,30 +296,10 @@ class PostgreSQLHandler(logging.Handler):
 
             self.cursor.execute(self._query, args)
 
-        except Exception:
-            msg = "An exception occurred attempting to log to DB. Falling back to file-system log."
-            self.fallback_to_local_handler()
-            self.handleError(record)
-            logging.getLogger(APP_LOG_NAME).exception(msg)
+        except Exception as e:
+            print(f"An exception occurred attempting to log to DB: {e}")
 
     def _get_logger_connection(self):
         self.connection = metadator.get_database_connection()
         self.connection.autocommit = True
         self.cursor = self.connection.cursor()
-
-    def fallback_to_local_handler(self):
-        logger = logging.getLogger(APP_LOG_NAME)
-        if self in logger.handlers:
-            logger.removeHandler(self)
-        default_handler = get_default_log_handler(self.fallback_log_path, logging.DEBUG)
-        if default_handler not in logger.handlers:
-            logger.addHandler(default_handler)
-
-
-def _test_log_handler_fallback():
-    """FOR TESTING PURPOSES ONLY
-    Causes logger to fall back to filesystem logging without an actual failure occurring"""
-    logger = logging.getLogger(APP_LOG_NAME)
-    for handler in logger.handlers:
-        if handler.name == "db_handler":
-            handler.fallback_to_local_handler()

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -257,6 +257,7 @@ class PostgreSQLHandler(logging.Handler):
             self._get_logger_connection()
         except Exception as e:
             print(f"Unable to connect to database for logging:  {e}")
+            raise (e)
 
     def close(self):
         """Close this log handler and its DB connection """

--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -240,7 +240,7 @@ def start_server(node_name, save_pid_txt=True):
     out = os.popen(cmd_out).read().replace("\\", "")
     df = pd.read_csv(StringIO(out), sep=",", index_col=0, names=["date", "status"])
 
-    task_name = node_name + "1"
+    task_name = node_name + "0"
     # task_name = "TaskOnEvent1"
     while True:
         if task_name in out:
@@ -264,16 +264,13 @@ def start_server(node_name, save_pid_txt=True):
             + f" /Create /TN {task_name} /TR {s.bat} /SC ONEVENT /EC Application /MO *[System/EventID=777] /f"
         )
         out = os.popen(cmd_1).read()
-        print(out)
 
     cmd_2 = cmd_str + f" /Run /TN {task_name}"
     out = os.popen(cmd_2).read()
-    print(out)
 
     sleep(0.3)
     out = os.popen(task_cmd).read()
-    print(out)
-    
+
     pids_new = get_python_pids(out)
 
     pid = [p for p in pids_new if p not in pids_old]

--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -9,7 +9,6 @@ import pandas as pd
 from io import StringIO
 
 import neurobooth_os.config as cfg
-from neurobooth_os.gui import write_output
 
 
 def setup_log(name):

--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -264,13 +264,16 @@ def start_server(node_name, save_pid_txt=True):
             + f" /Create /TN {task_name} /TR {s.bat} /SC ONEVENT /EC Application /MO *[System/EventID=777] /f"
         )
         out = os.popen(cmd_1).read()
+        print(out)
 
     cmd_2 = cmd_str + f" /Run /TN {task_name}"
     out = os.popen(cmd_2).read()
+    print(out)
 
     sleep(0.3)
     out = os.popen(task_cmd).read()
-
+    print(out)
+    
     pids_new = get_python_pids(out)
 
     pid = [p for p in pids_new if p not in pids_old]

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -1,8 +1,6 @@
 import base64
-import gc
 import os
 import sys
-import random
 from time import time, sleep
 from typing import Dict, List, Optional
 
@@ -18,7 +16,7 @@ from neurobooth_os.iout.lsl_streamer import DeviceManager
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.log_manager import SystemResourceLogger
 from neurobooth_os.msg.messages import Message, MsgBody, PrepareRequest, RecordingStoppedMsg, StartRecording, \
-    RecordingStartedMsg, MbientResetResults, StatusMessage, Request, SessionPrepared, FramePreviewReply, \
+    RecordingStartedMsg, MbientResetResults, Request, SessionPrepared, FramePreviewReply, \
     ServerStarted, ErrorMessage
 
 

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -40,13 +40,13 @@ def make_win(
         monitor_width=55,
         subj_screendist_cm=60,
         # in centimeters from subject head to middle of the screen in our setup. The eye tracker distance measured is from head to center of eye tracker
-):
+) -> visual.Window:
     mon = monitors.getAllMonitors()[0]
     custom_mon = monitors.Monitor(
         "demoMon", width=monitor_width, distance=subj_screendist_cm
     )
 
-    mon_size = monitors.Monitor(mon).getSizePix()
+    mon_size = (1920, 1080)     # TODO: Move the monitor size to the config files
     custom_mon.setSizePix(mon_size)
     custom_mon.saveMon()
     win = visual.Window(

--- a/neurobooth_os/tests/db_test_utils.py
+++ b/neurobooth_os/tests/db_test_utils.py
@@ -27,7 +27,7 @@ def delete_records(db_table, where=None) -> None:
 
 
 def get_connection():
-    c = get_database_connection(TEST_DATABASE, False)
+    c = get_database_connection(TEST_DATABASE)
     c.autocommit = True
     return c
 

--- a/neurobooth_os/tests/test_messages.py
+++ b/neurobooth_os/tests/test_messages.py
@@ -20,7 +20,7 @@ msg = Request(
               body=body
 )
 
-conn = meta.get_database_connection(database=database_name, validate_config_paths=False)
+conn = meta.get_database_connection(database=database_name)
 
 
 class TestMessages(unittest.TestCase):

--- a/neurobooth_os/tests/test_stm_server.py
+++ b/neurobooth_os/tests/test_stm_server.py
@@ -1,7 +1,5 @@
-import logging
 import unittest
 
-from neurobooth_os.iout.stim_param_reader import TaskArgs
 from neurobooth_os.msg.messages import PrepareRequest
 from neurobooth_os.server_stm import extract_task_log_entry
 from neurobooth_os.util.task_log_entry import TaskLogEntry
@@ -35,7 +33,7 @@ class TestTaskParamReader(unittest.TestCase):
         log_task_entry.task_notes_file = 'test_notes_file'
         log_task_entry.subject_id = "72"
         log_task_entry.task_output_files = {}
-        conn = meta.get_database_connection(database_name, False)
+        conn = meta.get_database_connection(database_name)
         log_task_id = meta.make_new_task_row(conn, log_task_entry.subject_id)
         log_task_entry['log_task_id'] = log_task_id
         meta.fill_task_row(log_task_entry, conn)
@@ -49,10 +47,8 @@ class TestTaskParamReader(unittest.TestCase):
         database_name = 'mock_neurobooth_1'
         log_task = meta._new_tech_log_dict()
         log_task["subject_id-date"] = "foobar"
-        from neurobooth_os.log_manager import make_default_logger
-        logger = make_default_logger(log_path, logging.DEBUG, False)
         msg = f"prepare:{collection_id}:{database_name}:{str(log_task)}"
-        stm_session, task_log_entry = prepare_session(msg, logger)
+        stm_session, task_log_entry = prepare_session(msg)
         print(stm_session)
         print(task_log_entry)
         stm_session.shutdown()
@@ -66,11 +62,9 @@ class TestTaskParamReader(unittest.TestCase):
         selected_tasks = ['task_1']
         log_task = meta._new_tech_log_dict()
         log_task["subject_id-date"] = "foobar"
-        from neurobooth_os.log_manager import make_default_logger
-        logger = make_default_logger(log_path, logging.DEBUG, False)
         msg = PrepareRequest(database_name=database_name, subject_id=subject_id, collection_id=collection_id,
                        selected_tasks=selected_tasks, date="2024-08-28")
-        stm_session, task_log_entry = prepare_session(msg, logger)
+        stm_session, task_log_entry = prepare_session(msg)
         calib_instructions, device_log_entry_dict, subj_id, task_calib = _create_tasks(msg, stm_session, task_log_entry)
 
         stm_session.shutdown()


### PR DESCRIPTION
This PR includes changes to Config to support having multiple neurobooth software installs on the same hardware.  

The biggest change is removing the fallback logging handler. This used to handle cases where the database logger was unavailable due to network or db issues, or if an error occurred before db logging could be setup. It turned out not to be useful in practice.   

There are numerous other small changes. One that should be rectified in a future PR is hardcoding the screen dimensions in pixels. This should be moved to a config file. A TODO was added to that effect.  