### PR TITLE
Fixing an error during data transfer when there is no iPhone device

### DIFF
--- a/extras/dump_iphone_video.py
+++ b/extras/dump_iphone_video.py
@@ -1,5 +1,5 @@
 import neurobooth_os.iout.iphone as iphone
-from neurobooth_os.iout.lsl_streamer import get_device_assignment
+from neurobooth_os.iout.lsl_streamer import is_device_assigned
 import neurobooth_os.config as cfg
 import re
 import os
@@ -168,7 +168,7 @@ def main():
 
     # Check if we should be running the dump on this machine.
     server_name = cfg.get_server_name_from_env()
-    if get_device_assignment('IPhone_dev_1') != server_name:
+    if is_device_assigned('IPhone_dev_1', server_name):
         logger.debug(f'IPhone not assigned to {server_name}.')
         return
 

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -124,6 +124,16 @@ def get_device_assignment(device_id: str) -> str:
     raise DeviceNotFoundException(f'{device_id} is not assigned to any server.')
 
 
+def is_device_assigned(device_id: str, server_name: str) -> bool:
+    """
+    Check whether a device is assigned to a particular server.
+    :param device_id: The ID of the device.
+    :param server_name: The name of the server.
+    :return: True if the device is assigned to a server, False otherwise.
+    """
+    return device_id in SERVER_ASSIGNMENTS[server_name]
+
+
 # --------------------------------------------------------------------------------
 # Handle the device life cycle
 # --------------------------------------------------------------------------------


### PR DESCRIPTION
The iPhone dump was throwing a DeviceNotFoundException due to the prior implementation. This small PR changes the nature of the check to avoid this error in systems without an iPhone.