### PR TITLE
GUI to add a subject, bypassing REDCap

### DIFF
--- a/environment_staging.yml
+++ b/environment_staging.yml
@@ -163,4 +163,3 @@ dependencies:
       - git+https://github.com/neurobooth/neurobooth-terra.git#egg=neurobooth_terra
       - h5py==3.10.0
       - h5io==0.2.1
-prefix: /Users/aquarius/anaconda3/envs/neurobooth-staging

--- a/environment_staging.yml
+++ b/environment_staging.yml
@@ -163,3 +163,4 @@ dependencies:
       - git+https://github.com/neurobooth/neurobooth-terra.git#egg=neurobooth_terra
       - h5py==3.10.0
       - h5io==0.2.1
+prefix: /Users/aquarius/anaconda3/envs/neurobooth-staging

--- a/examples/configs/add_subject_options.yml
+++ b/examples/configs/add_subject_options.yml
@@ -1,0 +1,206 @@
+study_options:
+  "HD study": "01"
+  "test study": "00"
+
+gender_options:
+  "Male": 1
+  "Female": 2
+
+country_options:
+  "United States of America": 1
+  "Albania": 2
+  "Algeria": 3
+  "Andorra": 4
+  "Angola": 5
+  "Antigua and Barbuda": 6
+  "Argentina": 7
+  "Armenia": 8
+  "Australia": 9
+  "Austria": 10
+  "Azerbaijan": 11
+  "The Bahamas": 12
+  "Bahrain": 13
+  "Bangladesh": 14
+  "Barbados": 15
+  "Belarus": 16
+  "Belgium": 17
+  "Belize": 18
+  "Benin": 19
+  "Bhutan": 20
+  "Bolivia": 21
+  "Bosnia and Herzegovina": 22
+  "Botswana": 23
+  "Brazil": 24
+  "Brunei": 25
+  "Bulgaria": 26
+  "Burkina Faso": 27
+  "Burundi": 28
+  "Cambodia": 29
+  "Cameroon": 30
+  "Canada": 31
+  "Cape Verde": 32
+  "Central African Republic": 33
+  "Chad": 34
+  "Chile": 35
+  "China": 36
+  "Colombia": 37
+  "Comoros": 38
+  "Costa Rica": 39
+  "Cote d'Ivoire": 40
+  "Croatia": 41
+  "Cuba": 42
+  "Cyprus": 43
+  "Czech Republic": 44
+  "Denmark": 45
+  "Djibouti": 46
+  "Dominica": 47
+  "Dominican Republic": 48
+  "East Timor (Timor-Leste)": 49
+  "Ecuador": 50
+  "Egypt": 51
+  "El Salvador": 52
+  "Equatorial Guinea": 53
+  "Eritrea": 54
+  "Estonia": 55
+  "Ethiopia": 56
+  "Fiji": 57
+  "Finland": 58
+  "France": 59
+  "Gabon": 60
+  "The Gambia": 61
+  "Georgia": 62
+  "Germany": 63
+  "Ghana": 64
+  "Greece": 65
+  "Grenada": 66
+  "Guatemala": 67
+  "Guinea": 68
+  "Guinea-Bissau": 69
+  "Guyana": 70
+  "Haiti": 71
+  "Honduras": 72
+  "Hungary": 73
+  "Iceland": 74
+  "India": 75
+  "Indonesia": 76
+  "Iran": 77
+  "Iraq": 78
+  "Ireland": 79
+  "Israel": 80
+  "Italy": 81
+  "Jamaica": 82
+  "Japan": 83
+  "Jordan": 84
+  "Kazakhstan": 85
+  "Kenya": 86
+  "Kiribati": 87
+  "Kosovo": 88
+  "Kuwait": 89
+  "Kyrgyzstan": 90
+  "Laos": 91
+  "Latvia": 92
+  "Lebanon": 93
+  "Lesotho": 94
+  "Liberia": 95
+  "Libya": 96
+  "Liechtenstein": 97
+  "Lithuania": 98
+  "Luxembourg": 99
+  "Macedonia": 100
+  "Madagascar": 101
+  "Malawi": 102
+  "Malaysia": 103
+  "Maldives": 104
+  "Mali": 105
+  "Malta": 106
+  "Marshall Islands": 107
+  "Mauritania": 108
+  "Mauritius": 109
+  "Mexico": 110
+  "Moldova": 111
+  "Monaco": 112
+  "Mongolia": 113
+  "Montenegro": 114
+  "Morocco": 115
+  "Mozambique": 116
+  "Myanmar (Burma)": 117
+  "Namibia": 118
+  "Nauru": 119
+  "Nepal": 120
+  "Netherlands": 121
+  "New Zealand": 122
+  "Nicaragua": 123
+  "Niger": 124
+  "Nigeria": 125
+  "Norway": 126
+  "Oman": 127
+  "Pakistan": 128
+  "Palau": 129
+  "Panama": 130
+  "Papua New Guinea": 131
+  "Paraguay": 132
+  "Peru": 133
+  "Philippines": 134
+  "Poland": 135
+  "Portugal": 136
+  "Qatar": 137
+  "Romania": 138
+  "Russia": 139
+  "Rwanda": 140
+  "Saint Kitts and Nevis": 141
+  "Saint Lucia": 142
+  "Saint Vincent and the Grenadines": 143
+  "Samoa": 144
+  "San Marino": 145
+  "Sao Tome and Principe": 146
+  "Saudi Arabia": 147
+  "Senegal": 148
+  "Serbia": 149
+  "Seychelles": 150
+  "Sierra Leone": 151
+  "Singapore": 152
+  "Slovakia": 153
+  "Slovenia": 154
+  "Solomon Islands": 155
+  "Somalia": 156
+  "South Africa": 157
+  "South Sudan": 158
+  "Spain": 159
+  "Sri Lanka": 160
+  "Sudan": 161
+  "Suriname": 162
+  "Swaziland": 163
+  "Sweden": 164
+  "Switzerland": 165
+  "Syria": 166
+  "Taiwan": 167
+  "Tajikistan": 168
+  "Tanzania": 169
+  "Thailand": 170
+  "Togo": 171
+  "Tonga": 172
+  "Trinidad and Tobago": 173
+  "Tunisia": 174
+  "Turkey": 175
+  "Turkmenistan": 176
+  "Tuvalu": 177
+  "Uganda": 178
+  "Ukraine": 179
+  "United Arab Emirates": 180
+  "United Kingdom": 181
+  "Uruguay": 183
+  "Uzbekistan": 184
+  "Vanuatu": 185
+  "Vatican City (Holy See)": 186
+  "Venezuela": 187
+  "Vietnam": 188
+  "Yemen": 189
+  "Zambia": 190
+  "Zimbabwe": 191
+  "Republic of the Congo": 192
+  "North Korea": 193
+  "South Korea": 194
+  "Afghanistan": 195
+  "Bermuda": 196
+  "Federated States of Micronesia": 197
+

--- a/extras/add_subject.bat
+++ b/extras/add_subject.bat
@@ -1,0 +1,2 @@
+call %NB_CONDA_INSTALL%\Scripts\activate.bat %NB_CONDA_ENV%
+start /W ipython --pdb %NB_INSTALL%\extras\add_subject.py

--- a/extras/add_subject.py
+++ b/extras/add_subject.py
@@ -53,8 +53,6 @@ def launch_gui() -> None:
     load_config_by_service_name("CTR")
     conn = metadator.get_database_connection()
 
-    placeholder_dob = "YYYY-MM-DD"
-
     options = load_add_subject_options()
     study_options = options.study_options
     gender_options = options.gender_options
@@ -76,8 +74,8 @@ def launch_gui() -> None:
 
     [sg.Column([[
         sg.Text("Date of Birth:", size=(12, 1), font=font),
-        sg.Input(key="-DOB-", size=(20, 1), default_text=placeholder_dob, tooltip="Format: YYYY-MM-DD", font=font,
-                 background_color="white", text_color="black", enable_events=True),
+        sg.Input(key="-DOB-", size=(20, 1), default_text="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font,
+                 background_color="white", text_color="black"),
         sg.CalendarButton("Pick Date", target="-DOB-", format="%Y-%m-%d", size=(10, 1), font=font)
     ]], pad=(0, 10))],
 
@@ -119,10 +117,6 @@ def launch_gui() -> None:
             if study_code:
                 subject_id = get_next_subject_id(study_code, conn)
                 window["-SUBJECT_ID-"].update(subject_id)
-        
-        if event == "-DOB-":
-            if values["-DOB-"] == placeholder_dob:
-                window["-DOB-"].update("")
 
         if event == "Submit":
             submit_success = submit_event(values, options, conn)
@@ -132,9 +126,6 @@ def launch_gui() -> None:
                     "-BIRTHPLACE-","-SUBJECT_ID-", "-STUDY-",
                 ]:
                     window[key].update("")
-                
-                if not values["-DOB-"]:
-                    window["-DOB-"].update(placeholder_dob)
 
     conn.close()
     window.close()

--- a/extras/add_subject.py
+++ b/extras/add_subject.py
@@ -53,6 +53,8 @@ def launch_gui() -> None:
     load_config_by_service_name("CTR")
     conn = metadator.get_database_connection()
 
+    placeholder_dob = "YYYY-MM-DD"
+
     options = load_add_subject_options()
     study_options = options.study_options
     gender_options = options.gender_options
@@ -74,8 +76,8 @@ def launch_gui() -> None:
 
     [sg.Column([[
         sg.Text("Date of Birth:", size=(12, 1), font=font),
-        sg.Input(key="-DOB-", size=(20, 1), default_text="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font,
-                 background_color="white", text_color="black"),
+        sg.Input(key="-DOB-", size=(20, 1), default_text=placeholder_dob, tooltip="Format: YYYY-MM-DD", font=font,
+                 background_color="white", text_color="black", enable_events=True),
         sg.CalendarButton("Pick Date", target="-DOB-", format="%Y-%m-%d", size=(10, 1), font=font)
     ]], pad=(0, 10))],
 
@@ -117,6 +119,10 @@ def launch_gui() -> None:
             if study_code:
                 subject_id = get_next_subject_id(study_code, conn)
                 window["-SUBJECT_ID-"].update(subject_id)
+        
+        if event == "-DOB-":
+            if values["-DOB-"] == placeholder_dob:
+                window["-DOB-"].update("")
 
         if event == "Submit":
             submit_success = submit_event(values, options, conn)
@@ -126,6 +132,9 @@ def launch_gui() -> None:
                     "-BIRTHPLACE-","-SUBJECT_ID-", "-STUDY-",
                 ]:
                     window[key].update("")
+                
+                if not values["-DOB-"]:
+                    window["-DOB-"].update(placeholder_dob)
 
     conn.close()
     window.close()

--- a/extras/add_subject.py
+++ b/extras/add_subject.py
@@ -59,48 +59,51 @@ def launch_gui() -> None:
     country_options = options.country_options
 
     layout = [
-        [sg.Column([[
-            sg.Text("Study:", size=(12, 1), font=font),
-            sg.Combo(list(study_options.keys()), key="-STUDY-", readonly=True, enable_events=True, size=(30, 1), font=font),
-            sg.Text("Subject ID:", size=(12, 1), font=font),
-            sg.Input(key="-SUBJECT_ID-", size=(30, 1), disabled=True, readonly=True, font=font)
-        ]], pad=(0, 10))],
+    [sg.Column([[
+        sg.Text("Study:", size=(12, 1), font=font),
+        sg.Combo(list(study_options.keys()), key="-STUDY-", readonly=True, enable_events=True, size=(30, 1), font=font),
+        sg.Text("Subject ID:", size=(12, 1), font=font),
+        sg.Input(key="-SUBJECT_ID-", size=(30, 1), disabled=True, readonly=True, font=font,
+                 background_color="white", text_color="black")
+    ]], pad=(0, 10))],
 
-        [sg.Column([[
-            sg.Text("Gender:", size=(12, 1), font=font),
-            sg.Combo(list(gender_options.keys()), key="-GENDER-", readonly=True, size=(30, 1), font=font)
-        ]], pad=(0, 10))],
+    [sg.Column([[
+        sg.Text("Gender:", size=(12, 1), font=font),
+        sg.Combo(list(gender_options.keys()), key="-GENDER-", readonly=True, size=(30, 1), font=font)
+    ]], pad=(0, 10))],
 
-        [sg.Column([[
-            sg.Text("Date of Birth:", size=(12, 1), font=font),
-            sg.Input(key="-DOB-", size=(20, 1), default_text="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font),
-            sg.CalendarButton("Pick Date", target="-DOB-", format="%Y-%m-%d", size=(10, 1), font=font)
-        ]], pad=(0, 10))],
+    [sg.Column([[
+        sg.Text("Date of Birth:", size=(12, 1), font=font),
+        sg.Input(key="-DOB-", size=(20, 1), default_text="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font,
+                 background_color="white", text_color="black"),
+        sg.CalendarButton("Pick Date", target="-DOB-", format="%Y-%m-%d", size=(10, 1), font=font)
+    ]], pad=(0, 10))],
 
-        [sg.Column([[
-            sg.Text("First Name:", size=(12, 1), font=font),
-            sg.Input(key="-FNAME-", size=(20, 1), font=font),
-            sg.Text("Middle Name:", size=(12, 1), pad=((20, 0), 0), font=font),
-            sg.Input(key="-MNAME-", size=(20, 1), font=font),
-            sg.Text("Last Name:", size=(12, 1), pad=((20, 0), 0), font=font),
-            sg.Input(key="-LNAME-", size=(20, 1), font=font)
-        ]], pad=(0, 10))],
+    [sg.Column([[
+        sg.Text("First Name:", size=(12, 1), font=font),
+        sg.Input(key="-FNAME-", size=(20, 1), font=font, background_color="white", text_color="black"),
+        sg.Text("Middle Name:", size=(12, 1), pad=((20, 0), 0), font=font),
+        sg.Input(key="-MNAME-", size=(20, 1), font=font, background_color="white", text_color="black"),
+        sg.Text("Last Name:", size=(12, 1), pad=((20, 0), 0), font=font),
+        sg.Input(key="-LNAME-", size=(20, 1), font=font, background_color="white", text_color="black")
+    ]], pad=(0, 10))],
 
-        [sg.Column([[
-            sg.Text("Country of Birth:", size=(12, 1), font=font),
-            sg.Combo(list(country_options.keys()), key="-COB-", readonly=True, size=(30, 1), font=font),
-            sg.Text("Birthplace:", size=(12, 1), pad=((20, 0), 0), font=font),
-            sg.Input(key="-BIRTHPLACE-", size=(30, 1), font=font)
-        ]], pad=(0, 10))],
+    [sg.Column([[
+        sg.Text("Country of Birth:", size=(12, 1), font=font),
+        sg.Combo(list(country_options.keys()), key="-COB-", readonly=True, size=(30, 1), font=font),
+        sg.Text("Birthplace:", size=(12, 1), pad=((20, 0), 0), font=font),
+        sg.Input(key="-BIRTHPLACE-", size=(30, 1), font=font, background_color="white", text_color="black")
+    ]], pad=(0, 10))],
 
-        [sg.Column([[
-            sg.Push(),
-            sg.Button("Submit", size=(10, 1), font=font),
-            sg.Push()
-        ]], pad=(0, 10))]
+    [sg.Column([[
+        sg.Push(),
+        sg.Button("Submit", size=(10, 1), font=font),
+        sg.Push()
+    ]], pad=(0, 10))]
     ]
 
-    window = sg.Window("Study Selection", layout, size=(800, 500), resizable=True, finalize=True)
+
+    window = sg.Window("Study Selection", layout, size=(1200, 375), resizable=True, finalize=True)
 
     while True:
         event, values = window.read()

--- a/extras/add_subject.py
+++ b/extras/add_subject.py
@@ -5,7 +5,7 @@ from typing import Dict
 import os
 from datetime import datetime
 
-import neurobooth_os.config as config
+from neurobooth_os.config import load_config_by_service_name
 from neurobooth_os.config import ConfigException
 from neurobooth_os.iout import metadator
 
@@ -50,8 +50,8 @@ def launch_gui() -> None:
     sg.theme("Dark Grey 9")
     font = ("Arial", 12)
 
-    config.load_config_by_service_name("CTR")
-    conn = metadator.get_database_connection(config.database)
+    load_config_by_service_name("CTR")
+    conn = metadator.get_database_connection()
 
     options = load_add_subject_options()
     study_options = options.study_options

--- a/extras/add_subject.py
+++ b/extras/add_subject.py
@@ -1,0 +1,191 @@
+import FreeSimpleGUI as sg
+import yaml
+from pydantic import BaseModel
+from typing import Dict
+import os
+from datetime import datetime
+
+import neurobooth_os.config as config
+from neurobooth_os.config import ConfigException
+from neurobooth_os.iout import metadator
+
+
+class AddSubjectGuiOptions(BaseModel):
+    study_options: Dict[str, str]
+    gender_options: Dict[str, int]
+    country_options: Dict[str, int]
+
+
+def load_add_subject_options() -> AddSubjectGuiOptions:
+    config_file = os.path.join(os.environ.get("NB_CONFIG"), "add_subject_options.yml")
+    if not os.path.exists(config_file):
+        raise ConfigException(f"Required config file does not exist: {config_file}")
+
+    with open(config_file) as f:
+        return AddSubjectGuiOptions(**yaml.load(f, yaml.FullLoader))
+
+
+def get_next_subject_id(study_code, conn):
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT subject_id
+            FROM subject
+            WHERE subject_id LIKE %s
+            ORDER BY subject_id DESC
+            LIMIT 1
+        """, (f"{study_code}%",))
+        result = cur.fetchone()
+
+        if result:
+            last_id = result[0]
+            last_number = int(last_id[-4:])
+            new_number = last_number + 1
+        else:
+            new_number = 1
+
+        return f"{study_code}{str(new_number).zfill(4)}"
+
+
+def launch_gui():
+    sg.theme("LightBlue2")
+    font = ("Helvetica", 12)
+
+    config.load_config_by_service_name("CTR")
+    conn = metadator.get_database_connection(config.database)
+    options = load_add_subject_options()
+
+    study_options = options.study_options
+    gender_options = options.gender_options
+    country_options = options.country_options
+
+    layout = [
+        [sg.Column([[
+            sg.Text("Study:", size=(12, 1), font=font),
+            sg.Combo(list(study_options.keys()), key="-STUDY-", readonly=True, enable_events=True, size=(30, 1), font=font),
+            sg.Text("Subject ID:", size=(12, 1), font=font),
+            sg.Input(key="-SUBJECT_ID-", size=(30, 1), disabled=True, readonly=True, font=font)
+        ]], pad=(0, 10))],
+
+        [sg.Column([[
+            sg.Text("Gender:", size=(12, 1), font=font),
+            sg.Combo(list(gender_options.keys()), key="-GENDER-", readonly=True, size=(30, 1), font=font)
+        ]], pad=(0, 10))],
+
+        [sg.Column([[
+            sg.Text("Date of Birth:", size=(12, 1), font=font),
+            sg.Input(key="-DOB-", size=(20, 1), placeholder="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font),
+            sg.CalendarButton("Pick Date", target="-DOB-", format="%Y-%m-%d", size=(10, 1), font=font)
+        ]], pad=(0, 10))],
+
+        [sg.Column([[
+            sg.Text("First Name:", size=(12, 1), font=font),
+            sg.Input(key="-FNAME-", size=(20, 1), font=font),
+            sg.Text("Middle Name:", size=(12, 1), pad=((20, 0), 0), font=font),
+            sg.Input(key="-MNAME-", size=(20, 1), font=font),
+            sg.Text("Last Name:", size=(12, 1), pad=((20, 0), 0), font=font),
+            sg.Input(key="-LNAME-", size=(20, 1), font=font)
+        ]], pad=(0, 10))],
+
+        [sg.Column([[
+            sg.Text("Country of Birth:", size=(12, 1), font=font),
+            sg.Combo(list(country_options.keys()), key="-COB-", readonly=True, size=(30, 1), font=font),
+            sg.Text("Birthplace:", size=(12, 1), pad=((20, 0), 0), font=font),
+            sg.Input(key="-BIRTHPLACE-", size=(30, 1), font=font)
+        ]], pad=(0, 10))],
+
+        [sg.Column([[
+            sg.Push(),
+            sg.Button("Submit", size=(10, 1), font=font),
+            sg.Push()
+        ]], pad=(0, 10))]
+    ]
+
+    window = sg.Window("Study Selection", layout, size=(800, 500), resizable=True, finalize=True)
+
+    while True:
+        event, values = window.read()
+
+        if event == sg.WINDOW_CLOSED:
+            break
+
+        if event == "-STUDY-":
+            study_label = values["-STUDY-"]
+            study_code = study_options.get(study_label)
+            if study_code:
+                subject_id = get_next_subject_id(study_code, conn)
+                window["-SUBJECT_ID-"].update(subject_id)
+
+        if event == "Submit":
+            required_fields = {
+                "Study": values["-STUDY-"],
+                "First Name": values["-FNAME-"],
+                "Last Name": values["-LNAME-"],
+                "Date of Birth": values["-DOB-"]
+            }
+            missing = [label for label, val in required_fields.items() if not val]
+            if missing:
+                sg.popup_error(f"The following required fields are missing: {', '.join(missing)}")
+                continue
+
+            try:
+                datetime.strptime(values["-DOB-"], "%Y-%m-%d")
+            except ValueError:
+                sg.popup_error("Date must be in YYYY-MM-DD format.")
+                continue
+
+            data = {
+                "subject_id": values["-SUBJECT_ID-"],
+                "first_name_birth": values["-FNAME-"],
+                "middle_name_birth": values["-MNAME-"],
+                "last_name_birth": values["-LNAME-"],
+                "date_of_birth_subject": values["-DOB-"],
+                "country_of_birth": country_options.get(values["-COB-"], ""),
+                "gender_at_birth": gender_options.get(values["-GENDER-"], ""),
+                "birthplace": values["-BIRTHPLACE-"],
+                "redcap_event_name": "manual",
+                "guid": "",
+                "old_subject_id": ""
+            }
+
+            for key in data:
+                if data[key] is None:
+                    data[key] = ""
+
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("""
+                        INSERT INTO subject (
+                            subject_id, first_name_birth, middle_name_birth, last_name_birth,
+                            date_of_birth_subject, country_of_birth, gender_at_birth,
+                            birthplace, redcap_event_name, guid, old_subject_id
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """, (
+                        data["subject_id"],
+                        data["first_name_birth"],
+                        data["middle_name_birth"],
+                        data["last_name_birth"],
+                        data["date_of_birth_subject"],
+                        data["country_of_birth"],
+                        data["gender_at_birth"],
+                        data["birthplace"],
+                        data["redcap_event_name"],
+                        data["guid"],
+                        data["old_subject_id"]
+                    ))
+                    conn.commit()
+                    sg.popup("Submission successful!")
+
+                    # Clear fields after submission
+                    for key in ["-FNAME-", "-MNAME-", "-LNAME-", "-DOB-", "-GENDER-", "-COB-",
+                                "-BIRTHPLACE-", "-SUBJECT_ID-", "-STUDY-"]:
+                        window[key].update("")
+            except Exception as e:
+                sg.popup_error("Database insert failed:", str(e))
+
+    conn.close()
+    window.close()
+
+
+if __name__ == "__main__":
+    launch_gui()

--- a/extras/add_subject.py
+++ b/extras/add_subject.py
@@ -73,7 +73,7 @@ def launch_gui() -> None:
 
         [sg.Column([[
             sg.Text("Date of Birth:", size=(12, 1), font=font),
-            sg.Input(key="-DOB-", size=(20, 1), placeholder="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font),
+            sg.Input(key="-DOB-", size=(20, 1), default_text="YYYY-MM-DD", tooltip="Format: YYYY-MM-DD", font=font),
             sg.CalendarButton("Pick Date", target="-DOB-", format="%Y-%m-%d", size=(10, 1), font=font)
         ]], pad=(0, 10))],
 


### PR DESCRIPTION
A standalone GUI that adds a subject to the database and a bat file to start it up from a desktop shortcut. It has as an associated .yml configuration in the example configs for code mappings. (Not needed for MGH though.)

Note that each subject ID is assumed to start with a prefix (e.g., the first two digits) indicating the study. 

Primary author: @mehrab328