### PR TITLE
Read screen res from config

### DIFF
--- a/examples/environments/staging/neurobooth_os_config.json
+++ b/examples/environments/staging/neurobooth_os_config.json
@@ -8,7 +8,8 @@
         "width_cm": 55,
         "subject_distance_to_screen_cm": 60,
         "min_refresh_rate_hz": 230,
-        "max_refresh_rate_hz": 245
+        "max_refresh_rate_hz": 245,
+        "screen_resolution": [1920, 1080]
     },
     "acquisition": {
         "name": "acq-staging",

--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -5,7 +5,7 @@ Ensures that the base neurobooth-os config file exists and makes config file ava
 
 from os import environ, path, getenv
 from typing import Optional, List
-from pydantic import BaseModel
+from pydantic import BaseModel, conlist
 import json
 
 
@@ -47,6 +47,7 @@ class ScreenSpec(BaseModel):
     subject_distance_to_screen_cm: int
     min_refresh_rate_hz: float
     max_refresh_rate_hz: float
+    screen_resolution: conlist(int, min_length=2, max_length=2)
 
 
 class DatabaseSpec(BaseModel):

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -499,8 +499,6 @@ Calibration instructions:
     
     Press ESC to exit calibration or validation mode.
     Pressing ESC outside of these modes ends the calibration task
-    
-    Press ENTER outside of these modes to toggle between eyes
 """
     for line in instructions.splitlines():
         write_output(win, line)

--- a/neurobooth_os/stm_session.py
+++ b/neurobooth_os/stm_session.py
@@ -60,6 +60,7 @@ class StmSession(BaseModel):
             full_screen=screen_config.fullscreen,
             monitor_width=screen_config.width_cm,
             subj_screendist_cm=screen_config.subject_distance_to_screen_cm,
+            screen_resolution=screen_config.screen_resolution,
         )
         utl.check_window_refresh_rate(
             win, min_rate=screen_config.min_refresh_rate_hz, max_rate=screen_config.max_refresh_rate_hz

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -160,5 +160,7 @@ class Saccade(Eyelink_HostPC):
 
 
 if __name__ == "__main__":
+    from neurobooth_os import config
+    config.load_config()
     task = Saccade(direction="vertical", amplitude_deg=30)
     task.run(prompt=False)

--- a/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
+++ b/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
@@ -150,8 +150,15 @@ class Pursuit(Eyelink_HostPC):
 
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
+    from neurobooth_os import config
+    config.load_config()
 
-    task = Pursuit()
+    task = Pursuit(
+        amplitude_deg=30,
+        peak_velocity_deg=30,
+        start_phase_deg=0,
+        ntrials=5,
+        )
     task.run(prompt=True)
 
     tstmp = task.time_array

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -69,11 +69,9 @@ def make_win(
         subj_screendist_cm=60,  # Distance (cm) from subject head to middle of screen, used for psychopy sizing of UI
         screen_resolution=[1920,1080],  # Resolution of the screen in pixels, used for sizing the psychopy window
 ):
-    
     custom_mon = monitors.Monitor(
         "demoMon", width=monitor_width, distance=subj_screendist_cm
     )
-
     mon_size = screen_resolution
     custom_mon.setSizePix(mon_size)
     custom_mon.saveMon()

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -67,13 +67,14 @@ def make_win(
         full_screen=True,
         monitor_width=55,  # Width (cm) of viewable monitor area, used for psychopy sizing of UI
         subj_screendist_cm=60,  # Distance (cm) from subject head to middle of screen, used for psychopy sizing of UI
+        screen_resolution=[1920,1080],  # Resolution of the screen in pixels, used for sizing the psychopy window
 ):
-    mon = monitors.getAllMonitors()[0]
+    
     custom_mon = monitors.Monitor(
         "demoMon", width=monitor_width, distance=subj_screendist_cm
     )
 
-    mon_size = monitors.Monitor(mon).getSizePix()
+    mon_size = screen_resolution
     custom_mon.setSizePix(mon_size)
     custom_mon.saveMon()
     win = visual.Window(


### PR DESCRIPTION
In this PR there are 3 changes:

1. Removed one line from gui.py calibration task console text based on CRC feedback
        - affects gui.py
        - unrelated to other changes
2. saccades task and pursuit loads config when run stand alone on stm - is helpful for testing
        - affects saccades_task.py and pursuit_tas.py
        - unrelated to other changes
3. Changes related to reading screen resolution from config. This is the main purpose of this PR. Screen Resolution is read from config json. This will create demoMon more repeatably.

There is no error handling - seeking feedback: please let me know if I should wrap steps in make_win in a try/except block and raise an exception if any of the steps in make_win fail for some reason.