### PR TITLE
Moving LSL streamer device imports into start functions

### DIFF
--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -6,36 +6,27 @@ from neurobooth_os import config
 from typing import Any, Dict, List, Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 
-# --------------------------------------------------------------------------------
-# Device class imports
-# TODO: These need to be handled in a more flexible/extensible yet thread-safe way during device rework
-# --------------------------------------------------------------------------------
 import neurobooth_os.iout.metadator as meta
-from neurobooth_os.iout.eyelink_tracker import EyeTracker
-from neurobooth_os.iout.mouse_tracker import MouseStream
-from neurobooth_os.iout.microphone import MicStream
-from neurobooth_os.iout.mbient import Mbient
-from neurobooth_os.iout.camera_intel import VidRec_Intel
-from neurobooth_os.iout.flir_cam import VidRec_Flir
-from neurobooth_os.iout.iphone import IPhone
 from neurobooth_os.msg.messages import DeviceInitialization, Request
-
 
 # --------------------------------------------------------------------------------
 # Wrappers for device setup procedures.
 # TODO: Handle device setup calls and imports in a more standardized/extensible fashion!!!
 # --------------------------------------------------------------------------------
 def start_eyelink_stream(win, device_args):
+    from neurobooth_os.iout.eyelink_tracker import EyeTracker
     return EyeTracker(win=win, device_args=device_args)
 
 
 def start_mouse_stream(_, device_args):
+    from neurobooth_os.iout.mouse_tracker import MouseStream
     device = MouseStream(device_args)
     device.start()
     return device
 
 
 def start_mbient_stream(_, device_args):
+    from neurobooth_os.iout.mbient import Mbient
     device = Mbient(device_args)
     if not device.prepare():
         return None
@@ -44,19 +35,28 @@ def start_mbient_stream(_, device_args):
 
 
 def start_intel_stream(_, device_args):
+    from neurobooth_os.iout.camera_intel import VidRec_Intel
     return VidRec_Intel(device_args)
 
 
 def start_flir_stream(_, device_args):
+    from neurobooth_os.iout.flir_cam import VidRec_Flir
     return VidRec_Flir(device_args)
 
 
+def start_webcam_stream(_, device_args):
+    from neurobooth_os.iout.webcam import VidRec_Webcam
+    return VidRec_Webcam(device_args)
+
+
 def start_iphone_stream(_, device_args):
+    from neurobooth_os.iout.iphone import IPhone
     device = IPhone(name="IPhoneFrameIndex", device_args=device_args)
     return device if device.prepare() else None
 
 
 def start_yeti_stream(_, device_args):
+    from neurobooth_os.iout.microphone import MicStream
     device = MicStream(device_args)
     device.start()
     return device


### PR DESCRIPTION
This is a follow-up to Sid's work parameterizing the device start-up functions. The imports were still all included, which would force installation of libraries/dependencies for devices not active in the current system. By moving the imports inside the startup calls, only the necessary ones are executed.

Also: Adding in the start-up function for the webcam.