### PR TITLE
Expanded functionality for frame preview

### DIFF
--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -76,6 +76,7 @@ class NeuroboothConfig(BaseModel):
     video_task_dir: str
     split_xdf_backlog: str
     cam_inx_lowfeed: int
+    default_preview_stream: str
     acquisition: ServerSpec
     presentation: ServerSpec
     control: ServerSpec

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -719,7 +719,7 @@ def gui(logger):
                             preview_default = list(frame_preview_devices.keys())[0]
 
                         window["-frame_preview-"].update(visible=True)
-                        window["-frame_preview_opts-"].update(visible=True, default_value=preview_default)
+                        window["-frame_preview_opts-"].update(visible=True, value=preview_default)
                     if not start_pressed:
                         window['Start'].update(disabled=False)
                         write_output(window, "Device connection complete. OK to start session")

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -433,7 +433,7 @@ def _plot_realtime(window, plttr, inlets):
 
 def handle_frame_preview_reply(window, frame_reply: FramePreviewReply):
     if not frame_reply.image_available or len(frame_reply.image) < 100:
-        write_output(window, "ERROR: no iphone in LSL streams", text_color="red")
+        write_output(window, f"ERROR: Unable to preview ({frame_reply.unavailable_message})", text_color="red")
         return
     frame = base64.b64decode(frame_reply.image)
     nparr = np.frombuffer(frame, dtype=np.uint8)

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -714,8 +714,12 @@ def gui(logger):
                 if session_prepared_count == len(_get_nodes()):
                     session = _start_lsl_session(window, inlets, sess_info["subject_id_date"])
                     if len(frame_preview_devices) > 0:
+                        preview_default = cfg.neurobooth_config.default_preview_stream
+                        if preview_default not in frame_preview_devices:
+                            preview_default = list(frame_preview_devices.keys())[0]
+
                         window["-frame_preview-"].update(visible=True)
-                        window["-frame_preview_opts-"].update(visible=True)
+                        window["-frame_preview_opts-"].update(visible=True, default_value=preview_default)
                     if not start_pressed:
                         window['Start'].update(disabled=False)
                         write_output(window, "Device connection complete. OK to start session")

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -444,7 +444,7 @@ def handle_frame_preview_reply(window, frame_reply: FramePreviewReply):
 
 
 def _request_frame_preview(conn):
-    msg = FramePreviewRequest()
+    msg = FramePreviewRequest(device_id='IPhone_dev_1')  # TODO: Make this selectable or customizable from ACQ devices
     req = Request(source="CTR", destination="ACQ", body=msg)
     meta.post_message(req, conn)
 

--- a/neurobooth_os/iout/device.py
+++ b/neurobooth_os/iout/device.py
@@ -1,0 +1,14 @@
+# This file should eventually contain common device types, such as base class defining the lifecycle.
+# For now, it is just the frame preview interface.
+
+from typing import ByteString
+
+
+class CameraPreviewer:
+    def frame_preview(self) -> ByteString:
+        """
+        Retrieve a single frame from a camera.
+
+        :returns: The raw data of the image/frame, or an empty byte string if an error occurs.
+        """
+        raise NotImplementedError()

--- a/neurobooth_os/iout/device.py
+++ b/neurobooth_os/iout/device.py
@@ -4,6 +4,11 @@
 from typing import ByteString
 
 
+class CameraPreviewException(Exception):
+    """An exception raised when unable to capture a preview image/frame from a camera stream."""
+    pass
+
+
 class CameraPreviewer:
     def frame_preview(self) -> ByteString:
         """

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -150,7 +150,11 @@ class EyeTracker:
         self.tk.sendCommand("calibration_area_proportion = 0.80 0.78")
         self.tk.sendCommand("validation_area_proportion = 0.80 0.78")
 
-        body = DeviceInitialization(stream_name=self.streamName, outlet_id=self.oulet_id)
+        body = DeviceInitialization(
+            stream_name=self.streamName,
+            outlet_id=self.oulet_id,
+            device_id=self.device_id,
+        )
         msg = Request(source="EyeTracker", destination="CTR", body=body)
         with get_database_connection() as conn:
             post_message(msg, conn)

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -246,6 +246,9 @@ class VidRec_Flir(CameraPreviewer):
         img, _ = self.imgage_proc()
         self.cam.EndAcquisition()
 
+        # Open question: why is the image not flipped during active recording?
+        img = cv2.rotate(img, cv2.ROTATE_180)
+
         rc, img = cv2.imencode('.png', img)
         return img.tobytes() if rc else b""
 

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -143,7 +143,11 @@ class VidRec_Flir:
             gamma=str(self.gamma),
             # device_model_id=self.cam.get_device_name().decode(),
         )
-        msg_body = DeviceInitialization(stream_name=self.streamName, outlet_id=self.oulet_id)
+        msg_body = DeviceInitialization(
+            stream_name=self.streamName,
+            outlet_id=self.oulet_id,
+            device_id=self.device_id,
+        )
         with meta.get_database_connection() as db_conn:
             meta.post_message(Request(source='Flir', destination='CTR', body=msg_body), conn=db_conn)
         return StreamOutlet(info)

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -21,6 +21,7 @@ from neurobooth_os.iout.stim_param_reader import FlirDeviceArgs
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.log_manager import APP_LOG_NAME
 from neurobooth_os.msg.messages import DeviceInitialization, Request, NewVideoFile
+from neurobooth_os.iout.device import CameraPreviewer
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 
@@ -30,7 +31,7 @@ class FlirException(Exception):
         super().__init__(*args, **kwargs)
 
 
-class VidRec_Flir:
+class VidRec_Flir(CameraPreviewer):
     # def __init__(self,
     #              sizex=round(1936 / 2), sizey=round(1216 / 2), fps=196,
     #              camSN="20522874", exposure=4500, gain=20, gamma=.6,

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -630,7 +630,7 @@ class IPhone(CameraPreviewer):
                 'Time_ACQ': 'Local machine timestamp (s)',
             }
         )
-        body = DeviceInitialization(stream_name=self.streamName, outlet_id=self.outlet_id)
+        body = DeviceInitialization(stream_name=self.streamName, outlet_id=self.outlet_id, camera_preview=True)
         msg = Request(source="IPhone", destination="CTR", body=body)
         with get_database_connection() as conn:
             post_message(msg, conn)

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -16,6 +16,7 @@ from enum import IntEnum
 from hashlib import md5
 from base64 import b64decode
 
+from neurobooth_os.iout.device import CameraPreviewer
 from neurobooth_os.iout.metadator import post_message, get_database_connection
 from neurobooth_os.iout.stim_param_reader import DeviceArgs
 from neurobooth_os.iout.usbmux import USBMux
@@ -93,7 +94,7 @@ def _handle_panic(func):
     return wrapper_panic
 
 
-class IPhone:
+class IPhone(CameraPreviewer):
     """
     Handles interactions with an iPhone device running the Neurobooth app.
     Intended Lifecycle:

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -630,7 +630,12 @@ class IPhone(CameraPreviewer):
                 'Time_ACQ': 'Local machine timestamp (s)',
             }
         )
-        body = DeviceInitialization(stream_name=self.streamName, outlet_id=self.outlet_id, camera_preview=True)
+        body = DeviceInitialization(
+            stream_name=self.streamName,
+            outlet_id=self.outlet_id,
+            device_id=self.device_id,
+            camera_preview=True,
+        )
         msg = Request(source="IPhone", destination="CTR", body=body)
         with get_database_connection() as conn:
             post_message(msg, conn)

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -72,9 +72,6 @@ SERVER_ASSIGNMENTS: Dict[str, List[str]] = {
 }
 
 
-CAMERA_PREVIEW_DEVICE = 'IPhone_dev_1'
-
-
 N_ASYNC_THREADS: int = 3  # The maximum number of mbients on one machine
 ASYNC_STARTUP: List[str] = [
     'Mbient_BK_1',
@@ -250,13 +247,13 @@ class DeviceManager:
             wait(reset_results.values())
             return {stream_name: result.result() for stream_name, result in reset_results.items()}
 
-    def camera_frame_preview(self) -> ByteString:
-        if CAMERA_PREVIEW_DEVICE not in self.streams:
-            raise CameraPreviewException(f'Device {CAMERA_PREVIEW_DEVICE} unavailable.')
+    def camera_frame_preview(self, device_id: str) -> ByteString:
+        if device_id not in self.streams:
+            raise CameraPreviewException(f'Device {device_id} unavailable.')
 
-        camera = self.streams[CAMERA_PREVIEW_DEVICE]
+        camera = self.streams[device_id]
         if not isinstance(camera, CameraPreviewer):
-            raise CameraPreviewException(f'Device {CAMERA_PREVIEW_DEVICE} is not a valid preview device.')
+            raise CameraPreviewException(f'Device {device_id} is not a valid preview device.')
 
         return camera.frame_preview()
 

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -689,7 +689,11 @@ class Mbient:
                 self.outlet = self._create_outlet()
             self.setup()
             if not DISABLE_LSL:
-                body = DeviceInitialization(stream_name=self.dev_name, outlet_id=self.outlet_id)
+                body = DeviceInitialization(
+                    stream_name=self.dev_name,
+                    outlet_id=self.outlet_id,
+                    device_id=self.device_id,
+                )
                 msg = Request(source="Mbient", destination="CTR", body=body)
                 post_message(msg, get_database_connection())
 

--- a/neurobooth_os/iout/microphone.py
+++ b/neurobooth_os/iout/microphone.py
@@ -84,7 +84,11 @@ class MicStream:
             fps=str(self.fps),
             device_name=device_args.device_name,
         )
-        body = DeviceInitialization(stream_name='Audio', outlet_id=self.oulet_id)
+        body = DeviceInitialization(
+            stream_name='Audio',
+            outlet_id=self.oulet_id,
+            device_id=device_args.device_id,
+        )
         msg = Request(source="Audio", destination="CTR", body=body)
         with get_database_connection() as conn:
             post_message(msg, conn)

--- a/neurobooth_os/iout/mouse_tracker.py
+++ b/neurobooth_os/iout/mouse_tracker.py
@@ -34,7 +34,11 @@ class MouseStream:
             }
         )
         self.outlet = StreamOutlet(self.info_stream)
-        body = DeviceInitialization(stream_name='Mouse', outlet_id=self.oulet_id)
+        body = DeviceInitialization(
+            stream_name='Mouse',
+            outlet_id=self.oulet_id,
+            device_id=device_args.device_id,
+        )
         msg = Request(source="MouseStream", destination="CTR", body=body)
         with get_database_connection() as conn:
             post_message(msg, conn)

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -231,6 +231,7 @@ class WebcamDeviceArgs(DeviceArgs):
     """
     camera_idx: int
     fourcc: str  # Video codec to use
+    n_frames_to_flush: int  # Number of frames to discard before recording
     sensor_array: List[StandardSensorArgs] = []
 
     def __init__(self, **kwargs):

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -88,6 +88,11 @@ class VidRec_Webcam(CameraPreviewer):
             self.logger.error('Webcam: Could not open stream')
             raise WebcamException('Webcam: Could not open stream')
         self.open = True
+        self.flush_video_buffer()
+
+    def flush_video_buffer(self) -> None:
+        for _ in range(cv2.CAP_PROP_BUFFERSIZE):
+            self.camera.grab()
 
     def close_stream(self) -> None:
         self.camera.release()

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -87,16 +87,18 @@ class VidRec_Webcam(CameraPreviewer):
         if not self.camera.isOpened():
             self.logger.error('Webcam: Could not open stream')
             raise WebcamException('Webcam: Could not open stream')
-        self.open = True
         self.flush_video_buffer()
+        self.open = True
 
     def flush_video_buffer(self) -> None:
-        for _ in range(cv2.CAP_PROP_BUFFERSIZE):
-            self.camera.grab()
+        # Retrieve/flush old frames from the buffer before recording.
+        for _ in range(120):  # TODO: Configs
+            self.camera.retrieve()
 
     def close_stream(self) -> None:
         self.camera.release()
         self.camera = None
+        cv2.destroyAllWindows()
         self.open = False
 
     def save_to_disk(self) -> None:

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -91,6 +91,7 @@ class VidRec_Webcam(CameraPreviewer):
 
     def close_stream(self) -> None:
         self.camera.release()
+        self.camera = None
         self.open = False
 
     def save_to_disk(self) -> None:

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -72,7 +72,7 @@ class VidRec_Webcam(CameraPreviewer):
             fps_rgb=str(self.device_args.sample_rate()),
             size_rgb=str((self.device_args.width_px(), self.device_args.height_px())),
         )
-        msg_body = DeviceInitialization(stream_name=self.stream_name, outlet_id=self.outlet_id)
+        msg_body = DeviceInitialization(stream_name=self.stream_name, outlet_id=self.outlet_id, camera_preview=True)
         with meta.get_database_connection() as db_conn:
             meta.post_message(Request(source='Webcam', destination='CTR', body=msg_body), conn=db_conn)
         return StreamOutlet(info)

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -184,9 +184,10 @@ class VidRec_Webcam(CameraPreviewer):
         :returns: The raw data of the image/frame, or an empty byte string if an error occurs.
         """
         self.open_stream()
-        rc, img = self.camera.read()
+        rc1, img = self.camera.read()
         self.close_stream()
-        return img.tobytes() if rc else b""
+        rc2, img = cv2.imencode('.png', img)
+        return img.tobytes() if (rc1 and rc2) else b""
 
 
 def test_script() -> None:

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -191,10 +191,13 @@ class VidRec_Webcam(CameraPreviewer):
         :returns: The raw data of the image/frame, or an empty byte string if an error occurs.
         """
         self.open_stream()
-        rc1, img = self.camera.read()
+        rc, img = self.camera.read()
         self.close_stream()
-        rc2, img = cv2.imencode('.png', img)
-        return img.tobytes() if (rc1 and rc2) else b""
+        if not rc:
+            return b""
+
+        rc, img = cv2.imencode('.png', img)
+        return img.tobytes() if rc else b""
 
 
 def test_script() -> None:

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -91,14 +91,13 @@ class VidRec_Webcam(CameraPreviewer):
         self.open = True
 
     def flush_video_buffer(self) -> None:
-        # Retrieve/flush old frames from the buffer before recording.
-        for _ in range(120):  # TODO: Configs
+        # Retrieve/flush old frames from the buffer before recording
+        for _ in range(self.device_args.n_frames_to_flush):
             self.camera.retrieve()
 
     def close_stream(self) -> None:
         self.camera.release()
         self.camera = None
-        cv2.destroyAllWindows()
         self.open = False
 
     def save_to_disk(self) -> None:

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -181,7 +181,7 @@ class VidRec_Webcam(CameraPreviewer):
         self.open_stream()
         rc, img = self.camera.read()
         self.close_stream()
-        return cv2.imencode('.jpg', img)[1].tobytes() if rc else b""
+        return img.tobytes() if rc else b""
 
 
 def test_script() -> None:

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -11,6 +11,7 @@ from pylsl import StreamInfo, StreamOutlet
 
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 import neurobooth_os.iout.metadator as meta
+from neurobooth_os.iout.device import CameraPreviewer
 from neurobooth_os.iout.stim_param_reader import WebcamDeviceArgs
 
 from neurobooth_os.log_manager import APP_LOG_NAME
@@ -22,7 +23,7 @@ class WebcamException(Exception):
         super().__init__(*args, **kwargs)
 
 
-class VidRec_Webcam:
+class VidRec_Webcam(CameraPreviewer):
     def __init__(
         self,
         device_args: WebcamDeviceArgs,
@@ -175,7 +176,7 @@ class VidRec_Webcam:
         """
         Retrieve a frame preview from the webcam.
 
-        :returns: The raw data of the image, or an empty byte string if the condition times out.
+        :returns: The raw data of the image/frame, or an empty byte string if an error occurs.
         """
         self.open_stream()
         rc, img = self.camera.read()

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -72,7 +72,12 @@ class VidRec_Webcam(CameraPreviewer):
             fps_rgb=str(self.device_args.sample_rate()),
             size_rgb=str((self.device_args.width_px(), self.device_args.height_px())),
         )
-        msg_body = DeviceInitialization(stream_name=self.stream_name, outlet_id=self.outlet_id, camera_preview=True)
+        msg_body = DeviceInitialization(
+            stream_name=self.stream_name,
+            outlet_id=self.outlet_id,
+            device_id=self.device_args.device_id,
+            camera_preview=True,
+        )
         with meta.get_database_connection() as db_conn:
             meta.post_message(Request(source='Webcam', destination='CTR', body=msg_body), conn=db_conn)
         return StreamOutlet(info)

--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -269,6 +269,7 @@ def _main_layout(sess_info, frame_sz=(270, 480)):
                 size=(40, 1),
                 readonly=True,
                 key="-frame_preview_opts-",
+                visible=False,
             ),
         ],
         [_space()],

--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -12,6 +12,10 @@ import cv2
 import neurobooth_os.iout.metadator as meta
 import neurobooth_os.config as cfg
 
+
+PREVIEW_AREA = (1080 // 4, 1920 // 4)
+
+
 def _lay_butt(name, key=None, tooltip=None, pad=None):
     if key is None:
         key = name
@@ -24,7 +28,7 @@ def _space(n=10):
     return sg.Text(" " * n)
 
 
-def _init_layout(conn, exclusion=None, frame_sz=(320, 240)):
+def _init_layout(conn, exclusion=None):
     sg.theme("Dark Grey 9")
     sg.set_options(
         element_padding=(0, 0),
@@ -144,8 +148,8 @@ def _make_tasks_checkbox(task_list):
     return field_tasks
 
 
-def _main_layout(sess_info, frame_sz=(270, 480)):
-    frame_cam = np.ones(frame_sz)
+def _main_layout(sess_info):
+    frame_cam = np.ones(PREVIEW_AREA)
     imgbytes = cv2.imencode(".png", frame_cam)[1].tobytes()
     sg.theme("Dark Grey 9")
     sg.set_options(element_padding=(0, 0))
@@ -254,7 +258,7 @@ def _main_layout(sess_info, frame_sz=(270, 480)):
     )
 
     layout_col2 = [
-        [sg.Image(data=imgbytes, key="iphone", size=frame_sz)],
+        [sg.Image(data=imgbytes, key="iphone", size=PREVIEW_AREA)],
         [
             sg.Button(
                 "Preview Camera",

--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -257,13 +257,20 @@ def _main_layout(sess_info, frame_sz=(270, 480)):
         [sg.Image(data=imgbytes, key="iphone", size=frame_sz)],
         [
             sg.Button(
-                "IPhone preview",
+                "Preview Camera",
                 button_color=("white", "black"),
                 key="-frame_preview-",
                 visible=False,
             )
         ],
-        [_space()],
+        [
+            sg.Combo(
+                values=[],
+                size=(40, 1),
+                readonly=True,
+                key="-frame_preview_opts-",
+            ),
+        ],
         [_space()],
         [_space()],
         [sg.Text("", justification="left", k="task_title")],

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -229,6 +229,7 @@ class DeviceInitialization(MsgBody):
     """
     stream_name: str
     outlet_id: str
+    device_id: str = ''
     camera_preview: bool = False
 
     def __init__(self, **data):

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -388,8 +388,10 @@ class MbientResetResults(MsgBody):
 
 class FramePreviewRequest(MsgBody):
     """
-    Message from controller to ACQ asking for an iPhone frame preview image
+    Message from controller to ACQ asking for a frame preview image from the specified device
     """
+    device_id: str
+
     def __init__(self, **data):
         data['priority'] = HIGH_PRIORITY
         super().__init__(**data)

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -229,6 +229,7 @@ class DeviceInitialization(MsgBody):
     """
     stream_name: str
     outlet_id: str
+    camera_preview: bool = False
 
     def __init__(self, **data):
         data['priority'] = MEDIUM_PRIORITY

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -397,10 +397,11 @@ class FramePreviewRequest(MsgBody):
 
 class FramePreviewReply(MsgBody):
     f"""
-    Message from ACQ to controller/gui in response to {FramePreviewRequest} containing an iPhone frame preview image
+    Message from ACQ to controller/gui in response to {FramePreviewRequest} containing an camera frame preview image
     """
-    image: Optional[str]=None
+    image: Optional[str] = None
     image_available: bool
+    unavailable_message: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -12,6 +12,7 @@ import neurobooth_os
 from neurobooth_os import config
 from neurobooth_os.iout.stim_param_reader import TaskArgs, DeviceArgs
 from neurobooth_os.log_manager import make_db_logger, log_message_received
+from neurobooth_os.iout.device import CameraPreviewException
 from neurobooth_os.iout.lsl_streamer import DeviceManager
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.log_manager import SystemResourceLogger
@@ -97,7 +98,7 @@ def run_acq(logger):
                 meta.post_message(updator, db_conn)
 
             elif "FramePreviewRequest" == current_msg_type and not recording:
-                iphone_frame_preview(db_conn, device_manager, logger)
+                camera_frame_preview(db_conn, device_manager, logger)
 
             # TODO: Both reset_mbients and frame_preview should be reworked as dynamic hooks that register a callback
             elif "ResetMbients" == current_msg_type:
@@ -156,19 +157,20 @@ def run_acq(logger):
             raise argument
 
 
-def iphone_frame_preview(db_conn, device_manager, logger):
-    frame = device_manager.iphone_frame_preview()
-    if frame is None:
-        body = FramePreviewReply(image=None, image_available=False)
-    else:
+def camera_frame_preview(db_conn, device_manager, logger):
+    try:
+        frame = device_manager.camera_frame_preview()
         b64_frame = base64.b64encode(frame).decode('utf-8')
-        body = FramePreviewReply(image=b64_frame, image_available=True)
+        body = FramePreviewReply(image=b64_frame, image_available=True, unavailable_message=None)
+    except CameraPreviewException as e:
+        body = FramePreviewReply(image=None, image_available=False, unavailable_message=str(e))
+
     reply = Request(source="ACQ", destination="CTR", body=body)
     meta.post_message(reply, db_conn)
     if body.image_available:
         logger.debug('Frame preview sent')
     else:
-        logger.debug('Frame preview unavailable')
+        logger.debug(f'Frame preview unavailable: {body.unavailable_message}')
 
 
 def start_recording(device_manager: DeviceManager, fname: str, task_devices: List[DeviceArgs]) -> float:


### PR DESCRIPTION
This PR adds an auto-populated drop-down to the GUI that allows selection of different camera sources for the frame preview. This also enables previews for systems with a different "primary camera" than the iPhone. A default stream is specified in the configs so that one-click functionality still exists for the "primary camera".

Device changes:
- Previews implemented for webcam and FLIR. **The FLIR preview should be tested at MGH.**
- It seems that OpenCV was buffering frames for the webcam that messed with previews and the beginnings of recorded videos. Therefore, there is now logic to flush some number of frames (specified via the config) from the buffer when starting up the camera. 120 frames (2 seconds) seemed to be the sweet spot for the Elgato Facecam Mk2. This change should not impact MGH.
- There is a new `iout/device.py` file that defines an interface for devices that implement a preview. The assumption is that this file will eventually also contain a Device interface that defines the lifecycle of a device.

Messaging Changes:
- Device Initialization messages now contain the device ID and whether the device is capable of a preview (defaulting to False). The GUI needs to keep track of both these things to enable the new functionality.
- Preview Request messages now contain the device ID to preview. ACQ passes this along to LSL streamer to select the correct device.
- Preview Reply messages now pass along an optional error message to give more specificity as to why a preview may have failed.

Caveat: Only devices connected to ACQ can be previewed. There does not seem to be a reason to extend this functionality to STM, which would introduce extra complexity. Any requests for devices not available on ACQ should gracefully fail.

Config changes: https://github.com/neurobooth/configs/pull/45