### PR TITLE
moved mbient import from inside start stream to the top

### DIFF
--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 
 import neurobooth_os.iout.metadator as meta
+from neurobooth_os.iout.mbient import Mbient
 from neurobooth_os.msg.messages import DeviceInitialization, Request
 
 # --------------------------------------------------------------------------------
@@ -26,7 +27,6 @@ def start_mouse_stream(_, device_args):
 
 
 def start_mbient_stream(_, device_args):
-    from neurobooth_os.iout.mbient import Mbient
     device = Mbient(device_args)
     if not device.prepare():
         return None


### PR DESCRIPTION
Moving the mbient import to the top of lsl streamer fixes the RF/LF not connecting (and throwing Windows Error) issue. Second option was to remove RF/LF from ASYNC list.

This is a temporary fix till we figure out the root of the problem.