### PR TITLE
New task picture description

### DIFF
--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -409,7 +409,8 @@ class FixationTargetStimArgs(EyeTrackerStimArgs):
 
 class PassageReadingStimArgs(EyeTrackerStimArgs):
     countdown: str  # An mp4 filename
-
+    image_to_render_on_tablet: str
+    image_to_render_on_HostPC: str
 
 class SaccadesStimArgs(EyeTrackerStimArgs):
     direction: str

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -17,8 +17,10 @@ from neurobooth_os.iout.stim_param_reader import get_cfg_path
 
 
 class Passage_Reading(Eyelink_HostPC):
-    def __init__(self, **kwargs):
+    def __init__(self, image_to_render_on_tablet, image_to_render_on_HostPC, **kwargs):
         super().__init__(**kwargs)
+        self.image_to_render_on_tablet = image_to_render_on_tablet
+        self.image_to_render_on_HostPC = image_to_render_on_HostPC
 
     @classmethod
     def asset_path(cls, asset: Union[str, os.PathLike]) -> str:
@@ -31,13 +33,13 @@ class Passage_Reading(Eyelink_HostPC):
 
     def render_image(self):
         self._render_image(
-            Passage_Reading.asset_path('bamboo_screenshot.jpg'),
+            Passage_Reading.asset_path(self.image_to_render_on_tablet),
             0, 0, 1920, 1080, 0, 0
         )
 
     def present_task(self, prompt=True, duration=0, **kwargs):
         self.Mouse.setVisible(1)  # Allow participants to use the mouse to assist their reading
-        screen = utils.load_image(self.win, Passage_Reading.asset_path('passage_reading_1536x864.jpg'))
+        screen = utils.load_image(self.win, Passage_Reading.asset_path(self.image_to_render_on_HostPC))
         self.show_text(screen=screen, msg="Task", audio=None, wait_time=5)
 
         if prompt:

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -33,7 +33,7 @@ class Passage_Reading(Eyelink_HostPC):
 
     def render_image(self):
         self._render_image(
-            Passage_Reading.asset_path(self.image_to_render_on_tablet),
+            Passage_Reading.asset_path('bamboo_screenshot.jpg'),
             0, 0, 1920, 1080, 0, 0
         )
 

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -33,7 +33,7 @@ class Passage_Reading(Eyelink_HostPC):
 
     def render_image(self):
         self._render_image(
-            Passage_Reading.asset_path('bamboo_screenshot.jpg'),
+            Passage_Reading.asset_path(self.image_to_render_on_tablet),
             0, 0, 1920, 1080, 0, 0
         )
 


### PR DESCRIPTION
Added a new task for picture description, currently in the FA collections.

This PR includes new config files for the picture description task. 
Note that the picture description task inherits from the passage reading task class. 

The PassageReadingStimArgs() now have two new variables, namely image_to_render_on_tablet and image_to_render_on_HostPC, to allow the Passage_Reading() class to identify which images to render on tablet and hostPC.

This PR is linked to a PR in configs with a branch with the same name.

The image used here is from the Western Aphasia Battery - Revised. The use of the said image with the correct permissions for NeuroBooth is still being sorted out.