### PR TITLE
Updated postprocess_split_xdf.bat to use environment variables

### DIFF
--- a/extras/postprocess_split_xdf.bat
+++ b/extras/postprocess_split_xdf.bat
@@ -1,2 +1,2 @@
-call  C:\Users\CTR\anaconda3\Scripts\activate.bat C:\Users\CTR\anaconda3\envs\neurobooth-staging
+call  %NB_CONDA_INSTALL%\Scripts\activate.bat %NB_CONDA_ENV%
 call start /W ipython C:\neurobooth-os\extras\run_xdf_split_postproces.py


### PR DESCRIPTION
Found a bug on Merrimac where ipython was not found when running postprocess_split_xdf.bat at the end of the day. Reason was hardcoded address for environment which does not exist. Changed it out to environment variables as in transfer_data.bat