### PR TITLE
Task rework

### DIFF
--- a/neurobooth_os/tasks/DSC.py
+++ b/neurobooth_os/tasks/DSC.py
@@ -11,7 +11,7 @@ import time
 import numpy as np
 import pandas as pd
 
-from psychopy import visual, iohub
+from psychopy import core, visual, event, iohub
 from psychopy.iohub import launchHubServer
 from psychopy.visual.textbox2 import TextBox2
 

--- a/neurobooth_os/tasks/DSC.py
+++ b/neurobooth_os/tasks/DSC.py
@@ -11,13 +11,12 @@ import time
 import numpy as np
 import pandas as pd
 
-from psychopy import core, visual, event, iohub
+from psychopy import visual, iohub
 from psychopy.iohub import launchHubServer
 from psychopy.visual.textbox2 import TextBox2
 
 import neurobooth_os
-from neurobooth_os.tasks import utils
-from neurobooth_os.tasks import Task_Eyetracker
+from neurobooth_os.tasks import utils, Task_Eyetracker
 from neurobooth_os.iout.stim_param_reader import get_cfg_path
 
 
@@ -200,40 +199,40 @@ class DSC(Task_Eyetracker):
             )
         self.io.quit()
 
-    def _run(self, prompt=True, subj_id="test", **kwarg):
-
-        self.results = []  # array to store trials details and responses
-        self.outcomes = {}  # object containing outcome variables
-        self.test_start_time = 0
-
-        # Check if run previously, create framesequence again
-        if len(self.frameSequence) == 0:
-            self.setFrameSequence()
-
-        self.subj_id = subj_id
-        self.present_instructions(prompt)
-
-        self.win.color = "white"
-        self.win.flip()
-
-        self.sendMessage(self.marker_task_start, to_marker=True, add_event=True)
-        self.nextTrial()
-        self.sendMessage(self.marker_task_end, to_marker=True, add_event=True)
-
-        if prompt:
-            func_kwargs_func = {"prompt": prompt}
-            self.rep += "_I"
-            self.show_text(
-                screen=self.press_task_screen,
-                msg="Task-continue-repeat",
-                func=self.run,
-                func_kwargs=func_kwargs_func,
-                waitKeys=False,
-            )
-
-        self.io.quit()
-        self.present_complete()
-        return self.events
+    # def _run(self, prompt=True, subj_id="test", **kwarg):
+    #
+    #     self.results = []  # array to store trials details and responses
+    #     self.outcomes = {}  # object containing outcome variables
+    #     self.test_start_time = 0
+    #
+    #     # Check if run previously, create framesequence again
+    #     if len(self.frameSequence) == 0:
+    #         self.setFrameSequence()
+    #
+    #     self.subj_id = subj_id
+    #     self.present_instructions(prompt)
+    #
+    #     self.win.color = "white"
+    #     self.win.flip()
+    #
+    #     self.sendMessage(self.marker_task_start, to_marker=True, add_event=True)
+    #     self.nextTrial()
+    #     self.sendMessage(self.marker_task_end, to_marker=True, add_event=True)
+    #
+    #     if prompt:
+    #         func_kwargs_func = {"prompt": prompt}
+    #         self.rep += "_I"
+    #         self.show_text(
+    #             screen=self.press_task_screen,
+    #             msg="Task-continue-repeat",
+    #             func=self.run,
+    #             func_kwargs=func_kwargs_func,
+    #             waitKeys=False,
+    #         )
+    #
+    #     self.io.quit()
+    #     self.present_complete()
+    #     return self.events
 
     def wait_release(self, keys=None):
         while True:
@@ -479,7 +478,7 @@ class DSC(Task_Eyetracker):
 
 
 if __name__ == "__main__":
-    from psychopy import sound, core, event, monitors, visual, monitors
+    from psychopy import core, event, monitors, visual, monitors
 
     monitor_width = 55
     monitor_distance = 60

--- a/neurobooth_os/tasks/MOT/task.py
+++ b/neurobooth_os/tasks/MOT/task.py
@@ -188,47 +188,47 @@ class MOT(Task_Eyetracker):
                 waitKeys=False,
             )
     
-    def _run(self, prompt=True, subj_id=None, **kwargs):
-        if subj_id is not None:  # The provided argument contains the full session timestamp...
-            self.subject_id = subj_id
-
-        if self.n_repetitions > 0:
-            self._init_frame_sequence(*self.stimulus_params)  # Create new frames for repeats to flush old data
-
-        self.score = 0
-        self.present_instructions(prompt)
-        self.win.color = "white"
-        self.win.flip()
-        self.sendMessage(self.marker_task_start, to_marker=True, add_event=True)
-        try:
-            for chunk in self.practice_chunks:
-                self.run_chunk(chunk)
-            for chunk in self.test_chunks:
-                self.run_chunk(chunk)
-                # Check early stopping criterion and stop if met
-                total_click_duration = MOT.chunk_click_duration(chunk)
-                if total_click_duration > self.chunk_timeout_sec:
-                    print(f'MOT timed out: total_click_duration={total_click_duration} s')
-                    break
-        except TaskAborted:
-            print('MOT aborted')
-        self.sendMessage(self.marker_task_end, to_marker=True, add_event=True)
-
-        self.save_results()
-
-        if prompt:  # Check if task should be repeated
-            func_kwargs_func = {"prompt": prompt}
-            self.n_repetitions += 1
-            self.show_text(
-                screen=self.press_task_screen,
-                msg="Task-continue-repeat",
-                func=self.run,
-                func_kwargs=func_kwargs_func,
-                waitKeys=False,
-            )
-
-        self.present_complete()
-        return self.events
+    # def _run(self, prompt=True, subj_id=None, **kwargs):
+    #     if subj_id is not None:  # The provided argument contains the full session timestamp...
+    #         self.subject_id = subj_id
+    #
+    #     if self.n_repetitions > 0:
+    #         self._init_frame_sequence(*self.stimulus_params)  # Create new frames for repeats to flush old data
+    #
+    #     self.score = 0
+    #     self.present_instructions(prompt)
+    #     self.win.color = "white"
+    #     self.win.flip()
+    #     self.sendMessage(self.marker_task_start, to_marker=True, add_event=True)
+    #     try:
+    #         for chunk in self.practice_chunks:
+    #             self.run_chunk(chunk)
+    #         for chunk in self.test_chunks:
+    #             self.run_chunk(chunk)
+    #             # Check early stopping criterion and stop if met
+    #             total_click_duration = MOT.chunk_click_duration(chunk)
+    #             if total_click_duration > self.chunk_timeout_sec:
+    #                 print(f'MOT timed out: total_click_duration={total_click_duration} s')
+    #                 break
+    #     except TaskAborted:
+    #         print('MOT aborted')
+    #     self.sendMessage(self.marker_task_end, to_marker=True, add_event=True)
+    #
+    #     self.save_results()
+    #
+    #     if prompt:  # Check if task should be repeated
+    #         func_kwargs_func = {"prompt": prompt}
+    #         self.n_repetitions += 1
+    #         self.show_text(
+    #             screen=self.press_task_screen,
+    #             msg="Task-continue-repeat",
+    #             func=self.run,
+    #             func_kwargs=func_kwargs_func,
+    #             waitKeys=False,
+    #         )
+    #
+    #     self.present_complete()
+    #     return self.events
 
     def run_chunk(self, chunk: List[MOTFrame]) -> None:
         for frame in chunk:

--- a/neurobooth_os/tasks/__init__.py
+++ b/neurobooth_os/tasks/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
-from neurobooth_os.tasks.task import Task, Task_Eyetracker
+from neurobooth_os.tasks.task import Task
+from neurobooth_os.tasks.task_eyetracker import Task_Eyetracker

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -6,7 +6,6 @@ import os.path as op
 
 from neurobooth_os.iout.metadator import post_message, get_database_connection
 from neurobooth_os.msg.messages import NewVideoFile, Request
-from neurobooth_os.tasks.task import Task_Eyetracker
 from neurobooth_os import config
 
 
@@ -43,7 +42,7 @@ class Calibrate(Task_Eyetracker):
 
 if __name__ == "__main__":
     from neurobooth_os.iout.eyelink_tracker import EyeTracker
-    from neurobooth_os.tasks import utils
+    from neurobooth_os.tasks import utils, Task_Eyetracker
 
     win = utils.make_win(False)
     eye_tracker = EyeTracker(win=win, ip="192.168.100.15")

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -4,6 +4,7 @@ A task that is run to calibrate the eyetracker
 """
 import os.path as op
 
+from neurobooth_os.tasks import Task_Eyetracker
 from neurobooth_os.iout.metadator import post_message, get_database_connection
 from neurobooth_os.msg.messages import NewVideoFile, Request
 from neurobooth_os import config

--- a/neurobooth_os/tasks/fixations.py
+++ b/neurobooth_os/tasks/fixations.py
@@ -3,12 +3,14 @@
 
 """
 
-from neurobooth_os.tasks.task import Task_Eyetracker
-from neurobooth_os.tasks.task import Eyelink_HostPC
-from neurobooth_os.tasks import utils
+from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC
+from neurobooth_os.tasks import utils, Task_Eyetracker
 
 
 class Fixation_Target(Task_Eyetracker):
+    """
+    Fixation tasks with zero or one visible target
+    """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -45,6 +47,10 @@ class Fixation_Target(Task_Eyetracker):
 
 
 class Fixation_Target_Multiple(Eyelink_HostPC):
+    """
+    Fixation task with multiple targets. Each target is presented alone, sequentially and each is
+    treated as an individual trial
+    """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -62,9 +68,7 @@ class Fixation_Target_Multiple(Eyelink_HostPC):
 
         for pos in trial_pos:
             self.target.pos = [self.deg_2_pix(pos[0]), self.deg_2_pix(pos[1])]
-            self.target.size = self.deg_2_pix(
-                target_size
-            )  # target_size from deg to cms
+            self.target.size = self.deg_2_pix(target_size)  # target_size from deg to cms
             if sum(self.target.size):
                 self.send_target_loc(self.target.pos)
 
@@ -93,80 +97,6 @@ class Fixation_Target_Multiple(Eyelink_HostPC):
                 func_kwargs=func_kwargs,
                 waitKeys=False,
             )
-
-
-class Fixation_Target_sidetrials(Task_Eyetracker):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def present_task(
-        self,
-        prompt=True,
-        duration=3,
-        target_pos=(-10, 10),
-        target_size=0.7,
-        trial_intruct=["trial 1", "trial 2"],
-        **kwargs
-    ):
-
-        self.sendMessage(self.marker_task_start)
-
-        for nth, trl in enumerate(trial_intruct):
-            self.display_trial_instructions(trl)
-            self.countdown_to_stimulus()
-            self.perform_trial(duration, target_pos, target_size)
-            self.present_trial_ended_msg()
-
-        self.sendMessage(self.marker_task_end)
-
-        if prompt:
-            func_kwargs = locals()
-            del func_kwargs["self"]
-            self.show_text(
-                screen=self.press_task_screen,
-                msg="Task-continue-repeat",
-                func=self.present_task,
-                func_kwargs=func_kwargs,
-                waitKeys=False,
-            )
-
-    def perform_trial(self, duration, target_pos, target_size):
-        self.calc_target_position_and_size(target_pos, target_size)
-        # Send event to eyetracker and to LSL separately
-        self.sendMessage(self.marker_trial_start, False)
-        self.show_text(
-            screen=self.target,
-            msg="Trial",
-            wait_time=duration,
-            abort_keys=self.abort_keys,
-            waitKeys=False
-        )
-        self.sendMessage(self.marker_trial_end, False)
-
-    def present_trial_ended_msg(self):
-        msg = utils.create_text_screen(self.win, "Task on one side ended")
-        utils.present(self.win, msg, wait_time=2, waitKeys=False)
-
-    def calc_target_position_and_size(self, target_pos, target_size):
-        self.target.pos = [
-            self.deg_2_pix(target_pos[0]),
-            self.deg_2_pix(target_pos[1]),
-        ]
-        self.target.size = self.deg_2_pix(
-            target_size
-        )  # target_size from deg to cms
-        if sum(self.target.size):
-            self.send_target_loc(self.target.pos)
-
-    def display_trial_instructions(self, trl_instructions) -> None:
-        """
-        Display the instructions for the current trial
-        Parameters
-        ----------
-        trl_instructions str: The instructions for the current trial
-        """
-        msg = utils.create_text_screen(self.win, trl_instructions + "\n\n\nPress CONTINUE")
-        utils.present(self.win, msg)
 
 
 if __name__ == "__main__":

--- a/neurobooth_os/tasks/hevelius/hevelius_task.py
+++ b/neurobooth_os/tasks/hevelius/hevelius_task.py
@@ -10,8 +10,7 @@ from typing import Union
 from psychopy import visual, core, data, event
 from psychopy.constants import NOT_STARTED, STARTED, FINISHED
 
-from neurobooth_os.tasks import utils
-from neurobooth_os.tasks.task import Task_Eyetracker
+from neurobooth_os.tasks import utils, Task_Eyetracker
 from neurobooth_os.iout.stim_param_reader import get_cfg_path
 import neurobooth_os
 

--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pylink
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix
-from neurobooth_os.tasks.task import Eyelink_HostPC
+from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC
 import numpy as np
 from pylsl import local_clock
 

--- a/neurobooth_os/tasks/sdmt.py
+++ b/neurobooth_os/tasks/sdmt.py
@@ -8,7 +8,8 @@ from psychopy.core import CountdownTimer
 from psychopy.visual import TextStim, ImageStim
 from psychopy.visual.rect import Rect
 
-from neurobooth_os.tasks.task import Eyelink_HostPC, TaskAborted, EyelinkColor
+from neurobooth_os.tasks.task import TaskAborted
+from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC, EyelinkColor
 from neurobooth_os.iout.stim_param_reader import get_cfg_path
 
 

--- a/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
+++ b/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
@@ -4,7 +4,7 @@ from math import sin, pi
 from psychopy import core
 import pylink
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix, peak_vel2freq, deg2rad
-from neurobooth_os.tasks.task import Eyelink_HostPC
+from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC
 
 
 class Pursuit(Eyelink_HostPC):

--- a/neurobooth_os/tasks/task.py
+++ b/neurobooth_os/tasks/task.py
@@ -2,35 +2,29 @@
 """
  A task is an operation or sequence of steps performed presented to a subject via Psychopy.
 """
-
 from __future__ import absolute_import, division
 
-from typing import List, Union, Optional
-from enum import Enum
+import logging
+import os.path as op
+import time
+
+import neurobooth_os
+import neurobooth_os.config as cfg
+import neurobooth_os.iout.metadator as meta
+
+from typing import List, Optional
 
 from psychopy import logging as psychopy_logging
 
 from neurobooth_os.msg.messages import StatusMessage, Request
+from neurobooth_os.tasks import utils
+from neurobooth_os.log_manager import APP_LOG_NAME
+
+from datetime import datetime
+from psychopy import visual, event
+
 
 psychopy_logging.console.setLevel(psychopy_logging.CRITICAL)
-
-import logging
-import os
-import os.path as op
-from datetime import datetime
-import time
-import pylink
-
-from psychopy import visual, monitors, sound, event
-
-import neurobooth_os
-from neurobooth_os.tasks import utils
-from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix
-from neurobooth_os.log_manager import APP_LOG_NAME
-import neurobooth_os.config as cfg
-import neurobooth_os.iout.metadator as meta
-
-from pylsl import local_clock
 
 
 class TaskAborted(Exception):
@@ -56,7 +50,6 @@ class Task:
             text_continue=utils.text_continue,
             text_practice_screen=utils.text_practice_screen,
             text_task=utils.text_task,
-            text_end=utils.text_end,
             countdown=None,
             task_repeatable_by_subject: bool = True,
             **kwargs,
@@ -106,7 +99,6 @@ class Task:
             self.win_temp = False
 
         self.instruction_file = instruction_file
-        # self.load_instruction_video()
 
         # Create mouse and set not visible
         self.Mouse = event.Mouse(visible=False, win=self.win)
@@ -126,7 +118,7 @@ class Task:
         self.task_screen = utils.create_text_screen(self.win, text_task)
         self.end_screen = utils.get_end_screen(self.win)
 
-    def load_instruction_video(self):
+    def _load_instruction_video(self):
         """
         Loads instruction video if not previously loaded or if previously loaded but currently stopped.
         Returns
@@ -178,9 +170,9 @@ class Task:
         if self.with_lsl:
             self.marker.push_sample([f"{msg}_{time.time()}"])
         if add_event:
-            self.add_event(msg)
+            self._add_event(msg)
 
-    def add_event(self, event_name):
+    def _add_event(self, event_name):
         self.events.append(f"{event_name}:{datetime.now().strftime('%H:%M:%S')}")
 
     def show_text(
@@ -215,7 +207,7 @@ class Task:
             if self.repeat_advance():
                 func(**func_kwargs)
 
-    def show_video(self, video, msg, stop=False):
+    def _show_video(self, video, msg, stop=False):
         self.send_marker(f"{msg}_start", True)
         if video is not None:
             utils.play_video(self.win, video, stop=stop)
@@ -229,8 +221,8 @@ class Task:
         utils.play_tone()
 
     def present_instructions(self, prompt=True):
-        self.load_instruction_video()
-        self.show_video(video=self.instruction_video, msg="Intructions")
+        self._load_instruction_video()
+        self._show_video(video=self.instruction_video, msg="Intructions")
         if prompt:
             self.show_text(
                 screen=self.press_inst_screen,
@@ -288,319 +280,3 @@ class Task:
                 req = Request(source="STM", destination="CTR", body=msg)
                 meta.post_message(req, db_conn)
             raise TaskAborted()
-
-
-class Task_countdown(Task):
-    """
-        Task whose instances are experiments that run for a fixed amount of time (counting down in seconds).
-        It's used by speech tasks like 'La-La-La'
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def present_task(self, prompt, duration, **kwargs):
-        self.countdown_to_stimulus()
-
-        self.send_marker(self.marker_task_start, True)
-        utils.present(self.win, self.task_screen, waitKeys=False)
-
-        duration += 2  # No idea why, but the original code was like this...
-        try:  # Keep presenting the screen until the task is over or the task is aborted.
-            start_time = local_clock()
-            while (local_clock() - start_time) < duration:
-                self.check_if_aborted()
-        except TaskAborted:
-            self.logger.info('Task aborted.')
-
-        self.win.flip()
-        self.send_marker(self.marker_task_end, True)
-
-        if prompt:
-            func_kwargs = locals()
-            del func_kwargs["self"]
-            self.show_text(
-                screen=self.press_task_screen,
-                msg="Task-continue-repeat",
-                func=self.present_task,
-                func_kwargs=func_kwargs,
-                waitKeys=False,
-            )
-
-
-class Task_pause(Task):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.screen = None
-
-    def run(self, slide_image="end_slide_01_23_25.jpg", wait_key="return", **kwarg):
-        self.screen = utils.load_slide(self.win, slide_image)
-        self.screen.draw()
-        self.win.flip()
-        utils.get_keys(keyList=[wait_key])
-        self.win.flip()
-
-
-class Task_Eyetracker(Task):
-    def __init__(self, eye_tracker=None, target_size=7, **kwargs):
-        super().__init__(**kwargs)
-
-        self.eye_tracker = eye_tracker
-
-        self.mon_size = self.win.monitor.getSizePix()
-        self.SCN_W, self.SCN_H = self.mon_size
-        self.monitor_width = self.win.monitor.getWidth()
-        self.pixpercm = self.mon_size[0] / self.monitor_width
-        self.subj_screendist_cm = self.win.monitor.getDistance()
-
-        self.target_size_pix = self.deg_2_pix(target_size)
-
-        # prepare the pursuit target, the clock and the movement parameters
-        self.win.color = [0, 0, 0]
-        self.win.flip()
-        self.target = visual.GratingStim(
-            self.win, tex=None, mask="circle", size=self.target_size_pix
-        )
-
-    def pos_psych2pix(self, locs: list):
-        """compute location x, y from 0 centered psychopy to top-left centered pixels"""
-        x = int(locs[0] + self.win.size[0] / 2.0)
-        y = int(self.win.size[1] / 2.0 - locs[1])
-        return [x, y]
-
-    def send_target_loc(
-            self, loc: list, target_name="target", to_marker=True, no_interpolation=0
-    ):
-        """send target loc(ation) 0 centered to eyetracker after converting to top-left centered pixels.
-        no_interpolation: 0 or 1
-            0 interpolates, 1 doesn't"""
-        loc = self.pos_psych2pix(loc)
-        self.sendMessage(
-            f"!V TARGET_POS {target_name} {loc[0]}, {loc[1]} 1 {no_interpolation}",
-            to_marker,
-        )  # 1 0  eyetracker code x, y, draw (1 yes), interpolation (0 == yes)
-
-    def deg_2_pix(self, deg):
-        return deg2pix(deg, self.subj_screendist_cm, self.pixpercm)
-
-    def sendMessage(self, msg, to_marker=True, add_event=False):
-        if self.eye_tracker is not None:
-            self.eye_tracker.tk.sendMessage(msg)
-            if to_marker:
-                self.send_marker(msg, add_event)
-
-    def setOfflineMode(self):
-        if self.eye_tracker is not None:
-            self.eye_tracker.paused = True
-            self.eye_tracker.tk.setOfflineMode()
-
-    def startRecording(self):
-        if self.eye_tracker is not None:
-            self.eye_tracker.tk.startRecording(1, 1, 1, 1)
-            self.eye_tracker.paused = False
-
-    def sendCommand(self, msg):
-        if self.eye_tracker is not None:
-            self.eye_tracker.tk.sendCommand(msg)
-
-    def doDriftCorrect(self, vals):
-        # vals : int, position target in screen
-        if self.eye_tracker is not None:
-            self.eye_tracker.tk.doDriftCorrect(*vals)
-
-    def gaze_contingency(self):
-        # move task
-        pass
-
-
-class EyelinkColor(Enum):
-    '''
-       Color codes accepted by the Eyetracker.
-       The source of these codes is from the comments in the examples
-       provided by SR Research - specifically saccade.py
-       Example script can be found in:
-       C:\Program Files (x86)\SR Research\EyeLink\SampleExperiments\Python\examples\Psychopy_examples
-    '''
-    BLACK = 0
-    BLUE = 1
-    GREEN = 2
-    CYAN = 3
-    RED = 4
-    MAGENTA = 5
-    BROWN = 6
-    LIGHTGRAY = 7
-    DARKGRAY = 8
-    LIGHTBLUE = 9
-    LIGHTGREEN = 10
-    LIGHTCYAN = 11
-    LIGHTRED = 12
-    BRIGHTMAGENTA = 13
-    YELLOW = 14
-    BRIGHTWHITE = 15
-
-
-class Eyelink_HostPC(Task_Eyetracker):
-    '''
-       Class containing methods that interact with the HostPC display.
-       HostPC is the computer that controls the eye tracker camera. Tasks
-       can interact with the display that is attached to this computer. In
-       our set up, the display is an Android tablet running the Eyelink app.
-
-       The commands that are sent to the HostPC are in the form of strings,
-       the list of commands and documentation is available in the
-       "COMMANDS.INI" file inside the HostPC (i.e. NUC) - this can be found
-       via the WebUI or by browsing the filesystem in the NUC and looking in
-       /elcl/exe directory. Additional documentation is in the SR Research
-       forums.
-    '''
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def draw_cross(self, x: int, y: int, colour: EyelinkColor) -> None:
-        '''Draw a cross at the x,y position on the screen of the specified colour
-           x, y must be in the top-left centered coordinate space
-        '''
-        self.sendCommand('draw_cross %d %d %d' % (x, y, colour.value))
-
-    def draw_box(self, x: int, y: int, width: int, height: int, colour: EyelinkColor, filled: bool = False) -> None:
-        '''
-           Draw a rectangle of size width by height (in pixels) around a point
-           x,y on the screen. x, y must be in the top-left centered coordinate
-           space.
-
-           'draw_box' command for the HostPC takes in the diagonal coordinates and
-           a color integer
-        '''
-        half_box_wid_in_pix = int(width/2)
-        half_box_hei_in_pix = int(height/2)
-
-        box_coords_top_x = x-half_box_wid_in_pix
-        box_coords_top_y = y-half_box_hei_in_pix
-        box_coords_bot_x = x+half_box_wid_in_pix
-        box_coords_bot_y = y+half_box_hei_in_pix
-
-        if not filled:
-            self.sendCommand('draw_box %d %d %d %d %d' % (box_coords_top_x, box_coords_top_y,
-                                                               box_coords_bot_x, box_coords_bot_y,
-                                                               colour.value))
-        else:
-            self.sendCommand('draw_filled_box %d %d %d %d %d' % (box_coords_top_x, box_coords_top_y,
-                                                               box_coords_bot_x, box_coords_bot_y,
-                                                               colour.value))
-            pass
-
-    def update_screen(self, x: float, y: float) -> None:
-        '''
-           Draw a cross and a box on the eyelink tablet.
-           x and y are positions in 0 centered psychopy coordinate space.
-           x and y can be int or float
-           See pos_psych2pix above
-        '''
-
-        # First clear tablet screen
-        self.clear_screen()
-
-        # convert from 0 centered to top-left centered coordinate space
-        xy = self.pos_psych2pix([x, y])
-        top_left_x = xy[0]
-        top_left_y = xy[1]
-
-        # draw cross at top_left centered x,y position
-        self.draw_cross(top_left_x, top_left_y, EyelinkColor.LIGHTGREEN)
-
-        # draw box around cross
-        box_len_in_pix = 100
-        self.draw_box(top_left_x, top_left_y, box_len_in_pix, box_len_in_pix, EyelinkColor.LIGHTRED)
-
-    def clear_screen(self, colour: EyelinkColor = EyelinkColor.BLACK) -> None:
-        '''Clear the HostPC screen and leave a Black background by default'''
-        self.sendCommand('clear_screen %d' % colour.value)
-
-    def _render_image(self, path_to_image: Union[str, os.PathLike],
-                     crop_x: int, crop_y: int, crop_width: int, crop_height: int,
-                     host_x: int, host_y: int,
-                     drawing_options: any = pylink.BX_MAXCONTRAST) -> None:
-        '''
-           Employs the imageBackdrop method of eyetracker to display an image on
-           HostPC screen. Documentation available as comments in (and code adapted
-           from) picture.py example provided in SR Research software located at:
-           C:\Program Files (x86)\SR Research\EyeLink\SampleExperiments\Python\examples\Psychopy_examples
-
-           This method:
-           ** DOES NOT SUPPORT IMAGE RESIZING **
-           ** ONLY WORKS WHEN EYETRACKER IS IN OFFLINE MODE **
-
-           Therefore this method needs to be executed before eyetracker starts
-           recording
-
-           :param path_to_image: complete file path to the image file
-           :param crop_x/crop_y: x,y coordinate in pixels for cropping the image
-           :param crop_width/crop_height: width and height in pixels  for cropping
-                                          the image
-           :param host_x/host_y: x,y position in pixels on the HostPC screen where
-                                 the image needs to be rendered
-           :param drawing_options: drawing options from SR Research's pylink package
-
-           Example usage:
-           If you want to render a 1920 by 1080 image on a 1920x1080 screen,
-           crop_x/crop_y would be 0,0, since you do not want to crop anything
-           crop_width/crop_height would be 1920/1080 since you want the full image
-           host_x/host_y would be 0,0 since you want the full image displayed on
-           screen
-
-           For Bamboo Passage the image size is 1536 by 864 which we want to render
-           on a 1920x1080 screen. We do not want to crop the image, but we want to
-           center the image on screen. Therefore the params would be:
-           crop_x/crop_y = 0,0
-           crop_width/crop_height = 1536, 864
-           host_x/host_y = 192, 108 {i.e. (self.SCN_W-1536)/2 & (self.SCN_H-864)/2}
-
-           This method ** DOES NOT SUPPORT ** image resizing. For resizing options
-           follow the el_tracker.bitmapBackdrop() method provided in picture.py
-           example script.
-
-           This method starts with an '_'(underscore) because it is not meant to be
-           called directly, and must be wrapped in a wrapper called 'render_image'
-           within the task script for the image to be rendered when called within
-           server_stm script.
-        '''
-        self.clear_screen()
-
-        if self.eye_tracker is not None:
-            self.eye_tracker.tk.imageBackdrop(path_to_image,
-                                           crop_x, crop_y, crop_width, crop_height,
-                                           host_x, host_y,
-                                           drawing_options)
-
-
-class Task_ShowProgressBar(Task):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.screen = None
-
-    def run(self, **kwargs) -> None:
-        self.screen = utils.load_slide(self.win, kwargs['slide_image'])
-        self.show_text(screen=self.screen, msg="Task", audio=None, wait_time=kwargs['duration'], waitKeys=kwargs['wait_keys'])
-        self.present_complete()
-
-
-class Introduction_Task(Task):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def run(self, **kwargs):
-        self.present_instructions(prompt=False)
-
-
-if __name__ == "__main__":
-
-    instruction_file = op.join(neurobooth_os.__path__[0], "tasks", "assets", "test.mp4")
-    if not op.isfile(instruction_file):
-        raise IOError(f'Required instruction file {instruction_file} does not exist.')
-
-    task = Task_countdown(
-        instruction_file=instruction_file
-    )
-
-    task.run(prompt=True, duration=3)

--- a/neurobooth_os/tasks/task_countdown.py
+++ b/neurobooth_os/tasks/task_countdown.py
@@ -1,0 +1,60 @@
+from __future__ import division, absolute_import
+
+from pylsl import local_clock
+
+import neurobooth_os
+from neurobooth_os.tasks import Task, utils
+from neurobooth_os.tasks.task import TaskAborted
+
+import os.path as op
+
+
+class Task_countdown(Task):
+    """
+        Task whose instances are experiments that run for a fixed amount of time (counting down in seconds).
+        It's used by speech tasks like 'La-La-La'
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def present_task(self, prompt, duration, **kwargs):
+        self.countdown_to_stimulus()
+
+        self.send_marker(self.marker_task_start, True)
+        utils.present(self.win, self.task_screen, waitKeys=False)
+
+        duration += 2  # No idea why, but the original code was like this...
+        try:  # Keep presenting the screen until the task is over or the task is aborted.
+            start_time = local_clock()
+            while (local_clock() - start_time) < duration:
+                self.check_if_aborted()
+        except TaskAborted:
+            self.logger.info('Task aborted.')
+
+        self.win.flip()
+        self.send_marker(self.marker_task_end, True)
+
+        if prompt:
+            func_kwargs = locals()
+            del func_kwargs["self"]
+            self.show_text(
+                screen=self.press_task_screen,
+                msg="Task-continue-repeat",
+                func=self.present_task,
+                func_kwargs=func_kwargs,
+                waitKeys=False,
+            )
+
+
+if __name__ == "__main__":
+
+    instruction_file = op.join(neurobooth_os.__path__[0], "tasks", "assets", "test.mp4")
+    if not op.isfile(instruction_file):
+        raise IOError(f'Required instruction file {instruction_file} does not exist.')
+
+    task = Task_countdown(
+        instruction_file=instruction_file
+    )
+
+    task.run(prompt=True, duration=3)

--- a/neurobooth_os/tasks/task_eyetracker.py
+++ b/neurobooth_os/tasks/task_eyetracker.py
@@ -1,0 +1,247 @@
+from __future__ import division, absolute_import
+
+import os
+from typing import Union
+
+import pylink
+from psychopy import visual
+from enum import Enum
+
+from neurobooth_os.tasks import Task
+from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix
+
+
+class EyelinkColor(Enum):
+    """
+       Color codes accepted by the Eyetracker.
+       The source of these codes is from the comments in the examples
+       provided by SR Research - specifically saccade.py
+       Example script can be found in:
+       C:\Program Files (x86)\SR Research\EyeLink\SampleExperiments\Python\examples\Psychopy_examples
+    """
+    BLACK = 0
+    BLUE = 1
+    GREEN = 2
+    CYAN = 3
+    RED = 4
+    MAGENTA = 5
+    BROWN = 6
+    LIGHTGRAY = 7
+    DARKGRAY = 8
+    LIGHTBLUE = 9
+    LIGHTGREEN = 10
+    LIGHTCYAN = 11
+    LIGHTRED = 12
+    BRIGHTMAGENTA = 13
+    YELLOW = 14
+    BRIGHTWHITE = 15
+
+
+class Task_Eyetracker(Task):
+    """
+    Task that uses an Eyetracker from SR Research for target-directed gaze routines where the subject's eyes
+    are presented with a fixed or moving target.
+    """
+    def __init__(self, eye_tracker=None, target_size=7, **kwargs):
+        super().__init__(**kwargs)
+
+        self.eye_tracker = eye_tracker
+        self.mon_size = self.win.monitor.getSizePix()
+        self.SCN_W, self.SCN_H = self.mon_size
+        self.monitor_width = self.win.monitor.getWidth()
+        self.pixpercm = self.mon_size[0] / self.monitor_width
+        self.subj_screendist_cm = self.win.monitor.getDistance()
+
+        self.target_size_pix = self.deg_2_pix(target_size)
+
+        # prepare the pursuit target, the clock and the movement parameters
+        self.win.color = [0, 0, 0]
+        self.win.flip()
+        self.target = visual.GratingStim(
+            self.win, tex=None, mask="circle", size=self.target_size_pix
+        )
+
+    def pos_psych2pix(self, locs: list):
+        """compute location x, y from 0 centered psychopy to top-left centered pixels"""
+        x = int(locs[0] + self.win.size[0] / 2.0)
+        y = int(self.win.size[1] / 2.0 - locs[1])
+        return [x, y]
+
+    def send_target_loc(
+            self, loc: list, target_name="target", to_marker=True, no_interpolation=0
+    ):
+        """send target loc(ation) 0 centered to eyetracker after converting to top-left centered pixels.
+        no_interpolation: 0 or 1
+            0 interpolates, 1 doesn't"""
+        loc = self.pos_psych2pix(loc)
+        self.sendMessage(
+            f"!V TARGET_POS {target_name} {loc[0]}, {loc[1]} 1 {no_interpolation}",
+            to_marker,
+        )  # 1 0  eyetracker code x, y, draw (1 yes), interpolation (0 == yes)
+
+    def deg_2_pix(self, deg):
+        return deg2pix(deg, self.subj_screendist_cm, self.pixpercm)
+
+    def sendMessage(self, msg, to_marker=True, add_event=False):
+        if self.eye_tracker is not None:
+            self.eye_tracker.tk.sendMessage(msg)
+            if to_marker:
+                self.send_marker(msg, add_event)
+
+    def setOfflineMode(self):
+        if self.eye_tracker is not None:
+            self.eye_tracker.paused = True
+            self.eye_tracker.tk.setOfflineMode()
+
+    def startRecording(self):
+        if self.eye_tracker is not None:
+            self.eye_tracker.tk.startRecording(1, 1, 1, 1)
+            self.eye_tracker.paused = False
+
+    def sendCommand(self, msg):
+        if self.eye_tracker is not None:
+            self.eye_tracker.tk.sendCommand(msg)
+
+    def doDriftCorrect(self, vals):
+        # vals : int, position target in screen
+        if self.eye_tracker is not None:
+            self.eye_tracker.tk.doDriftCorrect(*vals)
+
+    def gaze_contingency(self):
+        # move task
+        pass
+
+
+class Eyelink_HostPC(Task_Eyetracker):
+    '''
+       Class containing methods that interact with the HostPC display.
+       HostPC is the computer that controls the eye tracker camera. Tasks
+       can interact with the display that is attached to this computer. In
+       our set up, the display is an Android tablet running the Eyelink app.
+
+       The commands that are sent to the HostPC are in the form of strings,
+       the list of commands and documentation is available in the
+       "COMMANDS.INI" file inside the HostPC (i.e. NUC) - this can be found
+       via the WebUI or by browsing the filesystem in the NUC and looking in
+       /elcl/exe directory. Additional documentation is in the SR Research
+       forums.
+    '''
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def draw_cross(self, x: int, y: int, colour: EyelinkColor) -> None:
+        '''Draw a cross at the x,y position on the screen of the specified colour
+           x, y must be in the top-left centered coordinate space
+        '''
+        self.sendCommand('draw_cross %d %d %d' % (x, y, colour.value))
+
+    def draw_box(self, x: int, y: int, width: int, height: int, colour: EyelinkColor, filled: bool = False) -> None:
+        '''
+           Draw a rectangle of size width by height (in pixels) around a point
+           x,y on the screen. x, y must be in the top-left centered coordinate
+           space.
+
+           'draw_box' command for the HostPC takes in the diagonal coordinates and
+           a color integer
+        '''
+        half_box_wid_in_pix = int(width/2)
+        half_box_hei_in_pix = int(height/2)
+
+        box_coords_top_x = x-half_box_wid_in_pix
+        box_coords_top_y = y-half_box_hei_in_pix
+        box_coords_bot_x = x+half_box_wid_in_pix
+        box_coords_bot_y = y+half_box_hei_in_pix
+
+        if not filled:
+            self.sendCommand('draw_box %d %d %d %d %d' % (box_coords_top_x, box_coords_top_y,
+                                                               box_coords_bot_x, box_coords_bot_y,
+                                                               colour.value))
+        else:
+            self.sendCommand('draw_filled_box %d %d %d %d %d' % (box_coords_top_x, box_coords_top_y,
+                                                               box_coords_bot_x, box_coords_bot_y,
+                                                               colour.value))
+            pass
+
+    def update_screen(self, x: float, y: float) -> None:
+        '''
+           Draw a cross and a box on the eyelink tablet.
+           x and y are positions in 0 centered psychopy coordinate space.
+           x and y can be int or float
+           See pos_psych2pix above
+        '''
+
+        # First clear tablet screen
+        self.clear_screen()
+
+        # convert from 0 centered to top-left centered coordinate space
+        xy = self.pos_psych2pix([x, y])
+        top_left_x = xy[0]
+        top_left_y = xy[1]
+
+        # draw cross at top_left centered x,y position
+        self.draw_cross(top_left_x, top_left_y, EyelinkColor.LIGHTGREEN)
+
+        # draw box around cross
+        box_len_in_pix = 100
+        self.draw_box(top_left_x, top_left_y, box_len_in_pix, box_len_in_pix, EyelinkColor.LIGHTRED)
+
+    def clear_screen(self, colour: EyelinkColor = EyelinkColor.BLACK) -> None:
+        """Clear the HostPC screen and leave a Black background by default"""
+        self.sendCommand('clear_screen %d' % colour.value)
+
+    def _render_image(self, path_to_image: Union[str, os.PathLike],
+                     crop_x: int, crop_y: int, crop_width: int, crop_height: int,
+                     host_x: int, host_y: int,
+                     drawing_options: any = pylink.BX_MAXCONTRAST) -> None:
+        """
+           Employs the imageBackdrop method of eyetracker to display an image on
+           HostPC screen. Documentation available as comments in (and code adapted
+           from) picture.py example provided in SR Research software located at:
+           C:\Program Files (x86)\SR Research\EyeLink\SampleExperiments\Python\examples\Psychopy_examples
+
+           This method:
+           ** DOES NOT SUPPORT IMAGE RESIZING **
+           ** ONLY WORKS WHEN EYETRACKER IS IN OFFLINE MODE **
+
+           Therefore this method needs to be executed before eyetracker starts
+           recording
+
+           :param path_to_image: complete file path to the image file
+           :param crop_x/crop_y: x,y coordinate in pixels for cropping the image
+           :param crop_width/crop_height: width and height in pixels  for cropping
+                                          the image
+           :param host_x/host_y: x,y position in pixels on the HostPC screen where
+                                 the image needs to be rendered
+           :param drawing_options: drawing options from SR Research's pylink package
+
+           Example usage:
+           If you want to render a 1920 by 1080 image on a 1920x1080 screen,
+           crop_x/crop_y would be 0,0, since you do not want to crop anything
+           crop_width/crop_height would be 1920/1080 since you want the full image
+           host_x/host_y would be 0,0 since you want the full image displayed on
+           screen
+
+           For Bamboo Passage the image size is 1536 by 864 which we want to render
+           on a 1920x1080 screen. We do not want to crop the image, but we want to
+           center the image on screen. Therefore, the params would be:
+           crop_x/crop_y = 0,0
+           crop_width/crop_height = 1536, 864
+           host_x/host_y = 192, 108 {i.e. (self.SCN_W-1536)/2 & (self.SCN_H-864)/2}
+
+           This method ** DOES NOT SUPPORT ** image resizing. For resizing options
+           follow the el_tracker.bitmapBackdrop() method provided in picture.py
+           example script.
+
+           This method starts with an '_'(underscore) because it is not meant to be
+           called directly, and must be wrapped in a wrapper called 'render_image'
+           within the task script for the image to be rendered when called within
+           server_stm script.
+        """
+        self.clear_screen()
+
+        if self.eye_tracker is not None:
+            self.eye_tracker.tk.imageBackdrop(path_to_image,
+                                           crop_x, crop_y, crop_width, crop_height,
+                                           host_x, host_y,
+                                           drawing_options)

--- a/neurobooth_os/tasks/task_introduction.py
+++ b/neurobooth_os/tasks/task_introduction.py
@@ -1,0 +1,9 @@
+from neurobooth_os.tasks import Task
+
+
+class Introduction_Task(Task):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def run(self, **kwargs):
+        self.present_instructions(prompt=False)

--- a/neurobooth_os/tasks/task_passage_reading.py
+++ b/neurobooth_os/tasks/task_passage_reading.py
@@ -7,7 +7,7 @@ import os
 import os.path as op
 from typing import Union
 
-from neurobooth_os.tasks.task import Eyelink_HostPC
+from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC
 from neurobooth_os.tasks import utils
 from neurobooth_os.iout.stim_param_reader import get_cfg_path
 

--- a/neurobooth_os/tasks/task_pause.py
+++ b/neurobooth_os/tasks/task_pause.py
@@ -1,0 +1,16 @@
+from __future__ import division, absolute_import
+
+from neurobooth_os.tasks import Task, utils
+
+
+class Task_pause(Task):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.screen = None
+
+    def run(self, slide_image="end_slide_01_23_25.jpg", wait_key="return", **kwarg):
+        self.screen = utils.load_slide(self.win, slide_image)
+        self.screen.draw()
+        self.win.flip()
+        utils.get_keys(keyList=[wait_key])
+        self.win.flip()

--- a/neurobooth_os/tasks/task_show_progress_bar.py
+++ b/neurobooth_os/tasks/task_show_progress_bar.py
@@ -1,0 +1,14 @@
+from __future__ import division, absolute_import
+
+from neurobooth_os.tasks import Task, utils
+
+
+class Task_ShowProgressBar(Task):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.screen = None
+
+    def run(self, **kwargs) -> None:
+        self.screen = utils.load_slide(self.win, kwargs['slide_image'])
+        self.show_text(screen=self.screen, msg="Task", audio=None, wait_time=kwargs['duration'], waitKeys=kwargs['wait_keys'])
+        self.present_complete()

--- a/neurobooth_os/tasks/task_sidetrials.py
+++ b/neurobooth_os/tasks/task_sidetrials.py
@@ -1,0 +1,79 @@
+from neurobooth_os.tasks import Task_Eyetracker, utils
+
+
+class Task_sidetrials(Task_Eyetracker):
+    """
+    Tasks with two trials, one for each 'side', dominant or not dominant. It supports fixation tasks with side-trials,
+    such as finger-nose
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def present_task(
+        self,
+        prompt=True,
+        duration=3,
+        target_pos=(-10, 10),
+        target_size=0.7,
+        trial_intruct=["trial 1", "trial 2"],
+        **kwargs
+    ):
+
+        self.sendMessage(self.marker_task_start)
+
+        for nth, trl in enumerate(trial_intruct):
+            self.display_trial_instructions(trl)
+            self.countdown_to_stimulus()
+            self.perform_trial(duration, target_pos, target_size)
+            self.present_trial_ended_msg()
+
+        self.sendMessage(self.marker_task_end)
+
+        if prompt:
+            func_kwargs = locals()
+            del func_kwargs["self"]
+            self.show_text(
+                screen=self.press_task_screen,
+                msg="Task-continue-repeat",
+                func=self.present_task,
+                func_kwargs=func_kwargs,
+                waitKeys=False,
+            )
+
+    def perform_trial(self, duration, target_pos, target_size):
+        self.calc_target_position_and_size(target_pos, target_size)
+        # Send event to eyetracker and to LSL separately
+        self.sendMessage(self.marker_trial_start, False)
+        self.show_text(
+            screen=self.target,
+            msg="Trial",
+            wait_time=duration,
+            abort_keys=self.abort_keys,
+            waitKeys=False
+        )
+        self.sendMessage(self.marker_trial_end, False)
+
+    def present_trial_ended_msg(self):
+        msg = utils.create_text_screen(self.win, "Task on one side ended")
+        utils.present(self.win, msg, wait_time=2, waitKeys=False)
+
+    def calc_target_position_and_size(self, target_pos, target_size):
+        self.target.pos = [
+            self.deg_2_pix(target_pos[0]),
+            self.deg_2_pix(target_pos[1]),
+        ]
+        self.target.size = self.deg_2_pix(
+            target_size
+        )  # target_size from deg to cms
+        if sum(self.target.size):
+            self.send_target_loc(self.target.pos)
+
+    def display_trial_instructions(self, trl_instructions) -> None:
+        """
+        Display the instructions for the current trial
+        Parameters
+        ----------
+        trl_instructions str: The instructions for the current trial
+        """
+        msg = utils.create_text_screen(self.win, trl_instructions + "\n\n\nPress CONTINUE")
+        utils.present(self.win, msg)

--- a/neurobooth_os/tasks/test_timing/saccades_sounds.py
+++ b/neurobooth_os/tasks/test_timing/saccades_sounds.py
@@ -8,7 +8,7 @@ from pylsl import local_clock
 from psychopy import sound
 
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix
-from neurobooth_os.tasks.task import Task_Eyetracker
+from neurobooth_os.tasks import Task_Eyetracker
 
 
 def countdown(period):


### PR DESCRIPTION
More cleanup and reorganization of Task code to make the structure of tasks easier to understand.  This is intended ultimately to facilitate restructuring and standardization of task behavior.

Changes:

- Moving Task subclasses out of task.py, and moving and renaming one of the fixation tasks, because the code it encapsulates isn't really about fixation. It's about tasks with "sidetrials" 
- Deleting unused functions "_run()" in the MOT and DSC classes
- More minor cleanup of imports and 