### PR TITLE
Load passwords from secrets.yaml at config startup

### DIFF
--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -3,10 +3,13 @@
 Ensures that the base neurobooth-os config file exists and makes config file available as neurobooth_config
 """
 
+import json
+import logging
 from os import environ, path, getenv
 from typing import Optional, List
+
+import yaml
 from pydantic import BaseModel, conlist
-import json
 
 
 class ConfigException(Exception):
@@ -72,6 +75,7 @@ class ServerSpec(BaseModel):
 
 
 class NeuroboothConfig(BaseModel):
+    environment: str
     remote_data_dir: str
     video_task_dir: str
     split_xdf_backlog: str
@@ -121,6 +125,82 @@ class NeuroboothConfig(BaseModel):
 
 neurobooth_config: Optional[NeuroboothConfig] = None
 
+logger = logging.getLogger(__name__)
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge *override* into *base*, returning a new dict.
+
+    Lists are merged element-wise so that, e.g., acquisition server entries
+    line up by index.  Scalar values in *override* replace those in *base*.
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        elif (
+            key in result
+            and isinstance(result[key], list)
+            and isinstance(value, list)
+        ):
+            merged = []
+            for i in range(max(len(result[key]), len(value))):
+                base_item = result[key][i] if i < len(result[key]) else None
+                over_item = value[i] if i < len(value) else None
+                if (
+                    isinstance(base_item, dict)
+                    and isinstance(over_item, dict)
+                ):
+                    merged.append(_deep_merge(base_item, over_item))
+                elif over_item is not None:
+                    merged.append(over_item)
+                else:
+                    merged.append(base_item)
+            result[key] = merged
+        else:
+            result[key] = value
+    return result
+
+
+def _load_secrets(config_dir: str, env_name: str) -> Optional[dict]:
+    """Load environment-specific secrets from ``secrets.yaml``.
+
+    Resolution order for the secrets file path:
+      1. The ``NB_SECRETS`` environment variable, if set.
+      2. ``secrets.yaml`` in the same directory as the config file.
+
+    Args:
+        config_dir: Directory containing the loaded config file.
+        env_name: Value of the ``environment`` field from the config JSON,
+            used to select the correct section in ``secrets.yaml``.
+
+    Returns:
+        A dict of secret overrides for this environment, or ``None`` if the
+        secrets file does not exist or contains no section for the environment.
+    """
+    secrets_path = getenv("NB_SECRETS")
+    if secrets_path is None:
+        secrets_path = path.join(config_dir, "secrets.yaml")
+
+    if not path.exists(secrets_path):
+        logger.debug("No secrets file found at %s; skipping.", secrets_path)
+        return None
+
+    with open(secrets_path, "r") as f:
+        all_secrets = yaml.safe_load(f)
+
+    if not isinstance(all_secrets, dict) or env_name not in all_secrets:
+        logger.warning(
+            "secrets.yaml found but contains no section for environment '%s'.",
+            env_name,
+        )
+        return None
+
+    logger.info(
+        "Loaded secrets for environment '%s' from %s", env_name, secrets_path
+    )
+    return all_secrets[env_name]
+
 
 def validate_system_paths(server_name: str):
     if server_name == "presentation":
@@ -136,14 +216,29 @@ def validate_system_paths(server_name: str):
 
 def load_neurobooth_config(fname: Optional[str] = None):
     if fname is None:
-        fname = path.join(environ.get("NB_CONFIG"), "neurobooth_os_config.json")
+        config_dir = environ.get("NB_CONFIG")
+        if config_dir is None:
+            raise ConfigException(
+                "NB_CONFIG environment variable is not set and no file path was provided."
+            )
+        fname = path.join(config_dir, "neurobooth_os_config.json")
+    else:
+        config_dir = path.dirname(path.abspath(fname))
 
     if not path.exists(fname):
         raise ConfigException(f'Required config file does not exist: {fname}')
 
     with open(fname, "r") as f:
-        global neurobooth_config
-        neurobooth_config = NeuroboothConfig(**json.load(f))
+        config_data = json.load(f)
+
+    env_name = config_data.get("environment")
+    if env_name is not None:
+        secrets = _load_secrets(config_dir, env_name)
+        if secrets is not None:
+            config_data = _deep_merge(config_data, secrets)
+
+    global neurobooth_config
+    neurobooth_config = NeuroboothConfig(**config_data)
 
 
 def load_config_by_service_name(service_abbr: str, acq_index: int = 0, fname: Optional[str] = None,


### PR DESCRIPTION
## Summary
- Add `_load_secrets` and `_deep_merge` helpers to `config.py` so that `load_neurobooth_config` merges credentials from a `secrets.yaml` file before building the Pydantic model
- Secrets file is located in the same directory as the config JSON, or via `NB_SECRETS` env var
- The correct section is selected using the new `environment` field in the config JSON
- Add `environment` as a required field on `NeuroboothConfig`

Companion PR in configs repo removes passwords from JSON files and adds the example template.

## Test plan
- [ ] Place a `secrets.yaml` alongside a config file and verify passwords are merged into the loaded `NeuroboothConfig`
- [ ] Verify loading works without a `secrets.yaml` when passwords are still in the JSON (backward compat)
- [ ] Verify a clear error is raised when passwords are missing from both sources