### PR TITLE
Fix KeyError in is_device_assigned for generic acquisition name

### DIFF
--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -101,11 +101,24 @@ def get_device_assignment(device_id: str) -> str:
 def is_device_assigned(device_id: str, server_name: str) -> bool:
     """
     Check whether a device is assigned to a particular server.
+
+    When *server_name* is ``'acquisition'`` (the generic role name returned by
+    :func:`get_server_name_from_env`), all indexed acquisition servers
+    (``acquisition_0``, ``acquisition_1``, ...) are checked.
+
     :param device_id: The ID of the device.
     :param server_name: The name of the server.
-    :return: True if the device is assigned to a server, False otherwise.
+    :return: True if the device is assigned to the server, False otherwise.
     """
-    return device_id in SERVER_ASSIGNMENTS[server_name]
+    if server_name in SERVER_ASSIGNMENTS:
+        return device_id in SERVER_ASSIGNMENTS[server_name]
+    if server_name == 'acquisition':
+        return any(
+            device_id in devices
+            for key, devices in SERVER_ASSIGNMENTS.items()
+            if key.startswith('acquisition_')
+        )
+    return False
 
 
 # --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `get_server_name_from_env()` returns `'acquisition'` but `SERVER_ASSIGNMENTS` uses indexed keys (`acquisition_0`, `acquisition_1`, etc.)
- This caused a `KeyError` in scripts like `dump_iphone_video.py` that call `is_device_assigned`
- Now checks all `acquisition_*` entries when given the generic `'acquisition'` name, and returns `False` for unknown server names instead of raising

## Test plan
- [ ] Run `dump_iphone_video.py` on an ACQ machine and verify it no longer crashes
- [ ] Verify `is_device_assigned` still works with indexed names (`acquisition_0`)