### PR TITLE
Remove edf2asc conversion from inter-task transitions

### DIFF
--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -1,7 +1,6 @@
 import os.path as op
 import uuid
 import threading
-import subprocess
 import logging
 from typing import Tuple
 
@@ -173,19 +172,6 @@ class EyeTracker:
         prompt_msg.draw()
         self.win.flip()
 
-    def edf_to_ascii(self):
-        fname_asc = self.filename.replace(".edf", ".asc")
-        if not op.exists(fname_asc):
-            pout = subprocess.run(["edf2asc.exe", self.filename], shell=True)
-            if not pout.stderr:
-                body = NewVideoFile(stream_name=self.streamName, filename=op.split(fname_asc)[-1])
-                msg = Request(source="EyeTracker", destination="CTR", body=body)
-                post_message(msg)
-
-        else:
-            print(f"FILE {fname_asc} already exists")
-        return
-
     def start(self, filename="TEST.edf"):
         self.filename = filename
         body = NewVideoFile(stream_name=self.streamName, filename=op.split(filename)[-1])
@@ -270,7 +256,6 @@ class EyeTracker:
         if self.streaming:
             self.stream_thread.join()
             self.tk.receiveDataFile(self.fname_temp, self.filename)
-            self.edf_to_ascii()
             self.streaming = False
 
     def close(self):


### PR DESCRIPTION
## Summary

- Remove the `edf_to_ascii()` call from `EyeTracker.stop()`, eliminating the blocking `edf2asc.exe` subprocess that runs between every task
- Remove the `edf_to_ascii()` method and unused `subprocess` import

## Motivation

Performance analysis of inter-task gap durations identified `edf2asc.exe` as the single largest bottleneck in task transitions. The Eyelink's `stop()` method calls `receiveDataFile()` (transfers .edf from Eyelink hardware to STM disk, ~0.3s) followed by `edf_to_ascii()` (runs `edf2asc.exe` to convert binary EDF to ASCII text, **~16.5s median, up to 119s at p95**).

This conversion blocks the `RecordingStopped` message, preventing the next task from starting. Removing it eliminates ~16s from every inter-task transition.

The .edf file is already transferred and safely stored on the STM disk. The ASCII conversion is a convenience for downstream analysis and can be performed offline if needed.

## Test plan

- [ ] Verify Eyelink recording and .edf file transfer still work correctly
- [ ] Confirm inter-task transitions are faster (expect ~16s improvement per transition)
- [ ] Verify downstream analysis pipelines that consume .asc files are updated or can use .edf directly