### PR TITLE
Reduce STM polling intervals for faster task transitions

### DIFF
--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -123,7 +123,7 @@ def run_stm(logger):
 
             message: Message = meta.read_next_message("STM", conn=read_msg_conn)
             if message is None:
-                sleep(1)
+                sleep(.25)
                 continue
 
             log_message_received(message, logger)
@@ -339,9 +339,9 @@ def _wait_for_lsl_recording_to_start(session):
     ctr_msg_found: bool = False
     attempt = 0
     with meta.get_database_connection() as db_conn:
-        while not ctr_msg_found and attempt < 30:
+        while not ctr_msg_found and attempt < 300:
             ctr_msg_found = meta.read_next_message("STM", db_conn, 'LslRecording') is not None
-            sleep(1)
+            sleep(.1)
             attempt = attempt + 1
     if not ctr_msg_found:
         session.logger.warning("Message LsLRecording not received in STM")
@@ -377,12 +377,12 @@ def stop_acq(session: StmSession, task_args: TaskArgs):
     replies = 0
     attempts = 0
     with meta.get_database_connection() as poll_conn:
-        while replies < len(acq_ids) and attempts < 30:
+        while replies < len(acq_ids) and attempts < 300:
             reply = meta.read_next_message("STM", poll_conn, msg_type="RecordingStopped")
             if reply is not None:
                 replies += 1
             else:
-                sleep(1)
+                sleep(.1)
                 attempts += 1
 
 
@@ -424,7 +424,7 @@ def _start_acq(session: StmSession, task_id: str, tsk_start_time, frame_preview_
             if reply is not None:
                 replies += 1
             else:
-                sleep(1)
+                sleep(.1)
     elapsed_time = time() - t1
     session.logger.info(f'Waiting for ACQ to start took: {elapsed_time:.2f}')
 


### PR DESCRIPTION
## Summary

- Reduce STM message polling from 1.0s to 0.1s for time-critical waits (RecordingStarted, RecordingStopped, LslRecording)
- Reduce STM main idle loop polling from 1.0s to 0.25s (matches ACQ)
- Increase max attempt counts proportionally to preserve the same 30-second timeout windows

## Motivation

The STM server sleeps 1 second between database polls when waiting for ACQ responses during task transitions. Each start/stop cycle involves at least 2 wait loops, adding an average of ~1 second of pure polling latency per transition. With 25+ tasks per session, this accumulates to significant wasted time.

The database load increase is negligible — one lightweight SELECT every 0.1s instead of every 1s, on an already-open connection.

## Changes

| Wait location | Before | After | Total timeout |
|---|---|---|---|
| Main idle loop | 1.0s | 0.25s | n/a |
| Wait for LslRecording | 1.0s x 30 | 0.1s x 300 | 30s (unchanged) |
| Wait for RecordingStopped | 1.0s x 30 | 0.1s x 300 | 30s (unchanged) |
| Wait for RecordingStarted | 1.0s | 0.1s | no limit (unchanged) |

## Test plan

- [ ] Verify task transitions complete successfully on staging
- [ ] Confirm no increase in database errors or connection issues
- [ ] Measure inter-task gap improvement (expect ~1-2s reduction per transition)