### PR TITLE
Add timing instrumentation to inter-task critical path

### DIFF
--- a/docs/inter_task_message_flow.md
+++ b/docs/inter_task_message_flow.md
@@ -40,7 +40,7 @@ sequenceDiagram
     Note over CTR,GUI: PHASE 2b: CTR handles TaskCompletion<br/>(parallel, no one waits on this)
     CTR-->>DB: (polls 250ms) reads TaskCompletion
     CTR->>GUI: write_event_value("task_finished")
-    GUI-->>GUI: (polls 500ms) window.read() picks up event
+    Note over GUI: window.read() wakes immediately
     Note over GUI: liesl session.stop_recording() — UNKNOWN DURATION
     Note over GUI: starts XDF split thread (non-blocking)
     end
@@ -56,7 +56,7 @@ sequenceDiagram
     par Wait for CTR LSL start
         CTR-->>DB: (polls 250ms) reads TaskInitialization
         CTR->>GUI: write_event_value("task_initiated")
-        GUI-->>GUI: (polls 500ms) window.read() picks up event
+        Note over GUI: window.read() wakes immediately
         Note over GUI: liesl session.start_recording() — UNKNOWN DURATION
         GUI->>DB: LslRecording (to STM)
         STM-->>DB: (polls 100ms) reads LslRecording
@@ -97,7 +97,7 @@ so average pickup latency = interval / 2.
 | STM task-critical waits | any -> STM | 100ms | ~50ms |
 | ACQ main loop | any -> ACQ | 250ms | ~125ms |
 | CTR message reader | any -> CTR | 250ms | ~125ms |
-| GUI event loop | CTR thread -> GUI | 500ms | ~250ms |
+| GUI event loop | CTR thread -> GUI | wakes immediately | ~0ms |
 
 ## Critical Path (Minimum Latency)
 
@@ -122,12 +122,12 @@ STM post-task:
 start next task (parallel, take the max):
   Path A — CTR LSL start:
     CTR reader polls                avg  125ms
-    GUI event loop polls            avg  250ms
+    GUI event loop wakes             ~0ms  (write_event_value wakes window.read)
     liesl start_recording                ???
     CTR posts LslRecording           ~0ms
     STM polls and picks up          avg   50ms
                                     ───────────
-                                    min  425ms + liesl start time
+                                    min  175ms + liesl start time
 
   Path B — ACQ recording start:
     ACQ polls and picks up          avg  125ms
@@ -139,8 +139,8 @@ start next task (parallel, take the max):
 
   task instance creation                 ???
 
-TOTAL MINIMUM (polls only):         ~725ms
-TOTAL WITH UNKNOWNS:                ~725ms + device stop + device start
+TOTAL MINIMUM (polls only):         ~475ms
+TOTAL WITH UNKNOWNS:                ~475ms + device stop + device start
                                           + liesl stop/start + log_task
                                           + task instance creation
 ```

--- a/docs/inter_task_message_flow.md
+++ b/docs/inter_task_message_flow.md
@@ -1,0 +1,148 @@
+# Inter-Task Message Flow
+
+Messages and processing between the end of task N and the start of task N+1.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant ACQ as ACQ (x3)
+    participant STM
+    participant DB as Message Queue (DB)
+    participant CTR as CTR (message reader)
+    participant GUI as CTR (GUI event loop)
+
+    Note over STM: task.run() returns
+
+    rect rgb(255, 230, 230)
+    Note over STM: PHASE 1: Stop ACQ recording<br/>(STM blocked)
+
+    STM->>DB: StopRecording (to each ACQ)
+    ACQ-->>DB: (polls 250ms) reads StopRecording
+    Note over ACQ: stops recording devices
+    ACQ->>DB: RecordingStopped
+    STM-->>DB: (polls 100ms) reads RecordingStopped x3
+    Note over STM: stop_acq unblocks
+    end
+
+    Note over STM: eyetracker.stop() if applicable
+
+    STM->>DB: TaskCompletion (to CTR, fire-and-forget)
+
+    rect rgb(230, 255, 230)
+    Note over STM: PHASE 2: STM post-task work<br/>(no blocking dependency)
+    Note over STM: log_task() — DB write
+    Note over STM: returns to main loop
+    STM-->>DB: (polls 250ms) reads next PerformTaskRequest
+    end
+
+    rect rgb(230, 230, 255)
+    Note over CTR,GUI: PHASE 2b: CTR handles TaskCompletion<br/>(parallel, no one waits on this)
+    CTR-->>DB: (polls 250ms) reads TaskCompletion
+    CTR->>GUI: write_event_value("task_finished")
+    GUI-->>GUI: (polls 500ms) window.read() picks up event
+    Note over GUI: liesl session.stop_recording() — UNKNOWN DURATION
+    Note over GUI: starts XDF split thread (non-blocking)
+    end
+
+    Note over STM: _perform_task() begins for task N+1
+    Note over STM: _get_task_args(), DB logging
+
+    STM->>DB: TaskInitialization (to CTR)
+
+    rect rgb(255, 240, 220)
+    Note over STM: PHASE 3: STM blocked on parallel waits
+
+    par Wait for CTR LSL start
+        CTR-->>DB: (polls 250ms) reads TaskInitialization
+        CTR->>GUI: write_event_value("task_initiated")
+        GUI-->>GUI: (polls 500ms) window.read() picks up event
+        Note over GUI: liesl session.start_recording() — UNKNOWN DURATION
+        GUI->>DB: LslRecording (to STM)
+        STM-->>DB: (polls 100ms) reads LslRecording
+    and Wait for ACQ recording start
+        STM->>DB: StartRecording (to each ACQ)
+        ACQ-->>DB: (polls 250ms) reads StartRecording
+        Note over ACQ: starts recording devices
+        ACQ->>DB: RecordingStarted
+        STM-->>DB: (polls 100ms) reads RecordingStarted x3
+    end
+
+    Note over STM: Both futures complete, unblocks
+    end
+
+    Note over STM: _get_task_instance() — create task, start eyetracker
+    Note over STM: task.run() begins for task N+1
+```
+
+## Blocking Dependencies
+
+| Blocker | Blocked Service | What It Waits For | Poll Interval | Timeout |
+|---------|----------------|-------------------|---------------|---------|
+| ACQ stop | **STM** | `RecordingStopped` from each ACQ | 100ms | 30s |
+| CTR LSL start | **STM** | `LslRecording` from CTR | 100ms | 30s |
+| ACQ start | **STM** | `RecordingStarted` from each ACQ | 100ms | **none** |
+
+STM is the only service that blocks on messages. CTR/GUI processes `TaskCompletion`
+asynchronously — nobody waits on it.
+
+## Poll Latencies per Hop
+
+Each message goes through the DB queue. The receiver polls at a fixed interval,
+so average pickup latency = interval / 2.
+
+| Hop | Direction | Poll Interval | Avg Latency |
+|-----|-----------|---------------|-------------|
+| STM main loop | any -> STM | 250ms | ~125ms |
+| STM task-critical waits | any -> STM | 100ms | ~50ms |
+| ACQ main loop | any -> ACQ | 250ms | ~125ms |
+| CTR message reader | any -> CTR | 250ms | ~125ms |
+| GUI event loop | CTR thread -> GUI | 500ms | ~250ms |
+
+## Critical Path (Minimum Latency)
+
+The shortest possible inter-task time, assuming zero processing:
+
+```
+stop_acq:
+  STM posts StopRecording                          ~0ms
+  ACQ polls and picks up             avg  125ms
+  ACQ stops devices                       ???
+  ACQ posts RecordingStopped               ~0ms
+  STM polls and picks up (x3)       avg   50ms
+                                    ───────────
+                                    min  175ms + device stop time (x3 ACQs)
+
+STM post-task:
+  log_task DB write                       ???
+  main loop poll for next msg       avg  125ms
+                                    ───────────
+                                    min  125ms + DB write
+
+start next task (parallel, take the max):
+  Path A — CTR LSL start:
+    CTR reader polls                avg  125ms
+    GUI event loop polls            avg  250ms
+    liesl start_recording                ???
+    CTR posts LslRecording           ~0ms
+    STM polls and picks up          avg   50ms
+                                    ───────────
+                                    min  425ms + liesl start time
+
+  Path B — ACQ recording start:
+    ACQ polls and picks up          avg  125ms
+    ACQ starts devices                   ???
+    ACQ posts RecordingStarted       ~0ms
+    STM polls and picks up (x3)     avg   50ms
+                                    ───────────
+                                    min  175ms + device start time (x3 ACQs)
+
+  task instance creation                 ???
+
+TOTAL MINIMUM (polls only):         ~725ms
+TOTAL WITH UNKNOWNS:                ~725ms + device stop + device start
+                                          + liesl stop/start + log_task
+                                          + task instance creation
+```
+
+The "???" items are what the new timing instrumentation will measure.

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -7,6 +7,7 @@ import os
 import os.path as op
 import logging
 import sys
+import time as time_mod
 from typing import Dict, Optional, List
 
 import cv2
@@ -484,6 +485,7 @@ def gui(logger):
 
             # Signal a task started: record LSL data and update gui
             elif event == "task_initiated":
+                t_evt = time_mod.time()
                 # event values -> f"['{task_id}', '{t_obs_id}', '{log_task_id}, '{tsk_strt_time}']
                 window["-frame_preview-"].update(disabled=True)
                 task_id, t_obs_id, state.obs_log_id, tsk_strt_time = eval(values[event])
@@ -497,6 +499,7 @@ def gui(logger):
                     state.sess_info["subject_id_date"],
                     task_id, t_obs_id, state.obs_log_id, tsk_strt_time,
                 )
+                logger.info(f"CTR task_initiated handler took: {time_mod.time() - t_evt:.2f}")
                 window["task_title"].update("Running Task:")
                 window["task_running"].update(task_id, background_color="red")
                 if "calibration" in task_id.lower():
@@ -504,6 +507,7 @@ def gui(logger):
 
             # Signal a task ended: stop LSL recording and update gui
             elif event == "task_finished":
+                t_evt = time_mod.time()
                 task_id, has_lsl_stream = eval(values['task_finished'])
                 boolean_value = has_lsl_stream.lower() == 'true'
                 if boolean_value:
@@ -511,6 +515,7 @@ def gui(logger):
                     elapsed = controller.stop_lsl_recording(
                         task_id, task_id, state.obs_log_id,
                         state.sess_info["subject_id_date"])
+                    logger.info(f"CTR task_finished handler took: {time_mod.time() - t_evt:.2f}")
                     write_output(window, f"SPLIT XDF {task_id} took: {elapsed:.1f}")
                     window["task_running"].update(task_id, background_color="green")
                     write_task_notes(state.sess_info["subject_id_date"],

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -70,6 +70,7 @@ def run_stm(logger):
     session_canceled: bool = False  # True if message received that RC requests that the session be canceled
     finished: bool = False  # True if the "Thank you" screen has been displayed
     shutdown: bool = False  # True if message received that this server should be terminated
+    last_task_finished_time: Optional[float] = None  # For inter-task timing
     init_servers = Request(source="STM", destination="CTR", body=ServerStarted(neurobooth_version=release.version,
                                                                                config_version=current_config.version))
     meta.post_message(init_servers)
@@ -147,7 +148,10 @@ def run_stm(logger):
                     frame_preview_device_id = msg_body.frame_preview_device_id
 
                 elif "PerformTaskRequest" == current_msg_type:
+                    if last_task_finished_time is not None:
+                        logger.info(f"Inter-task gap (STM idle): {time() - last_task_finished_time:.2f}")
                     _perform_task(device_log_entry_dict, message, session, subj_id, task_log_entry)
+                    last_task_finished_time = time()
 
                 elif "PauseSessionRequest" == current_msg_type:
                     paused = _pause(session)
@@ -240,12 +244,16 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
             events = task_args.task_instance.run(**this_task_kwargs)
             elapsed_time = time() - t01
             session.logger.info(f"Total task RUN took: {elapsed_time:.2f}")
+            t_stop = time()
             stop_acq(session, task_args)
+            session.logger.info(f"stop_acq took: {time() - t_stop:.2f}")
 
             # Signal CTR to stop LSL rec
             meta.post_message(Request(source='STM', destination='CTR', body=TaskCompletion(task_id=task_id)))
             session.logger.info(f'FINISHED TASK: {task_id}')
+            t_log = time()
             log_task(events, session, task_id, task_id, task_log_entry, task_args.task_instance)
+            session.logger.info(f"log_task took: {time() - t_log:.2f}")
 
             elapsed_time = time() - t00
             session.logger.info(f"Total TASK took: {elapsed_time:.2f}")
@@ -359,6 +367,7 @@ def _get_task_args(session: StmSession, task_id: str):
 
 def stop_acq(session: StmSession, task_args: TaskArgs):
     """ Stop recording on all ACQ servers in parallel to stopping on STM """
+    t0 = time()
     session.logger.info(f'SENDING record_stop TO ACQ')
     stimulus_id = task_args.stim_args.stimulus_id
 
@@ -367,13 +376,17 @@ def stop_acq(session: StmSession, task_args: TaskArgs):
         body = StopRecording()
         sr_msg = Request(source="STM", destination=acq_id, body=body)
         meta.post_message(sr_msg)
+    session.logger.info(f"stop_acq: posted StopRecording to {len(acq_ids)} ACQs in {time() - t0:.2f}")
 
     # Stop eyetracker
+    t_eye = time()
     device_ids = [x.device_id for x in task_args.device_args]
     if session.eye_tracker is not None and any("Eyelink" in d for d in device_ids):
         if "calibration_task" not in stimulus_id:
             session.eye_tracker.stop()
+            session.logger.info(f"stop_acq: eyetracker stop took: {time() - t_eye:.2f}")
 
+    t_poll = time()
     replies = 0
     attempts = 0
     with meta.get_database_connection() as poll_conn:
@@ -384,6 +397,8 @@ def stop_acq(session: StmSession, task_args: TaskArgs):
             else:
                 sleep(.1)
                 attempts += 1
+    session.logger.info(f"stop_acq: poll for {len(acq_ids)} RecordingStopped took: {time() - t_poll:.2f} "
+                        f"({replies}/{len(acq_ids)} replies, {attempts} poll attempts)")
 
 
 def _start_acq(session: StmSession, task_id: str, tsk_start_time, frame_preview_device_id):

--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -444,7 +444,9 @@ class SessionController:
                             tsk_strt_time: str) -> str:
         """Start recording LSL data for a task and notify STM."""
         rec_fname = f"{subject_id}_{tsk_strt_time}_{t_obs_id}"
+        t0 = time_mod.time()
         self.state.session.start_recording(rec_fname)
+        self.logger.info(f"liesl start_recording took: {time_mod.time() - t0:.2f}")
 
         msg = Request(source="CTR", destination='STM', body=LslRecording())
         meta.post_message(msg)
@@ -457,7 +459,9 @@ class SessionController:
                            obs_log_id: str, folder: str) -> float:
         """Stop LSL recording and trigger XDF split."""
         import threading as threading_mod
+        t_stop = time_mod.time()
         self.state.session.stop_recording()
+        self.logger.info(f"liesl stop_recording took: {time_mod.time() - t_stop:.2f}")
 
         xdf_fname = get_xdf_name(self.state.session, self.state.rec_fname)
         xdf_path = op.join(folder, xdf_fname)


### PR DESCRIPTION
## Summary

- Adds logging to every unmeasured segment of the inter-task critical path (stop_acq breakdown, log_task, STM idle gap, liesl start/stop_recording, CTR event handler totals)
- Adds a message-flow diagram documenting all messages, polling intervals, and blocking dependencies between task N ending and task N+1 starting

## Context

Inter-task times are 12-14 seconds. Polling overhead alone accounts for ~475ms minimum, so the bulk is in operations that were previously unmeasured. This PR adds the instrumentation needed to identify the actual bottleneck before making further changes.

## New log messages

| Log message | Server | What it measures |
|---|---|---|
| `Inter-task gap (STM idle)` | STM | Time from `_perform_task` return to next `PerformTaskRequest` pickup |
| `stop_acq took` | STM | Total `stop_acq()` call |
| `stop_acq: posted StopRecording to N ACQs` | STM | Time to post stop messages |
| `stop_acq: eyetracker stop took` | STM | Eyetracker `.stop()` call |
| `stop_acq: poll for N RecordingStopped took` | STM | Waiting for ACQ confirmations |
| `log_task took` | STM | DB logging after task |
| `liesl start_recording took` | CTR | `session.start_recording()` |
| `liesl stop_recording took` | CTR | `session.stop_recording()` |
| `CTR task_initiated handler took` | CTR | Full handler including LSL start |
| `CTR task_finished handler took` | CTR | Full handler including LSL stop |

## Test plan

- [ ] Deploy to staging, run a session with multiple tasks
- [ ] Query `log_application` for the new log messages
- [ ] Identify which segments account for the 12-14s inter-task gap