### PR TITLE
Add faulthandler crash logging for silent process deaths

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -22,7 +22,7 @@ import neurobooth_os.current_config as current_config
 from neurobooth_os.realtime.lsl_plotter import stream_plotter
 
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes, PREVIEW_AREA
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, enable_crash_handler
 from neurobooth_os.iout.metadator import LogSession
 import neurobooth_os.iout.metadator as meta
 import neurobooth_os.config as cfg
@@ -613,6 +613,7 @@ def get_popup_location(window):
 
 def main():
     """The starting point of Neurobooth"""
+    enable_crash_handler("CTR")
     logger = None
     exit_code = 0
     try:

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -1,8 +1,10 @@
+import faulthandler
 import json
 import logging
+import os
 import sys
 from datetime import datetime
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, IO
 import psutil
 from threading import Thread, Event
 import platform
@@ -28,16 +30,50 @@ APP_LOGGER: Optional[logging.Logger] = None
 APP_LOG_NAME = "app"
 
 
+def _get_log_dir() -> str:
+    """Return the log directory from NB_INSTALL, falling back to the user's home directory."""
+    return os.environ.get("NB_INSTALL", os.path.expanduser("~"))
+
+
+# Keep a module-level reference so the file stays open for the lifetime of the process.
+_crash_log_file: Optional[IO] = None
+
+
+def enable_crash_handler(server_name: str) -> None:
+    """Enable faulthandler to capture fatal C-level crashes (e.g. segfaults).
+
+    Writes to ``neurobooth_crash.log`` in the NB_INSTALL directory (or the
+    user's home directory if NB_INSTALL is not set). The file is opened in
+    append mode so traces from successive runs accumulate. A timestamped
+    header is written on each call so crashes can be correlated with a
+    specific process launch.
+
+    This should be called as early as possible in each server's ``main()``
+    — before config loading, database connections, or any imports that
+    pull in C extensions.
+
+    Args:
+        server_name: Identifier for the process (e.g. ``"CTR"``, ``"STM"``, ``"ACQ_0"``).
+    """
+    global _crash_log_file
+    log_path = os.path.join(_get_log_dir(), "neurobooth_crash.log")
+    _crash_log_file = open(log_path, "a")
+    _crash_log_file.write(
+        f"\n--- {server_name} started at {datetime.now().isoformat()} (PID {os.getpid()}) ---\n"
+    )
+    _crash_log_file.flush()
+    faulthandler.enable(file=_crash_log_file)
+
+
 def make_fallback_logger() -> logging.Logger:
     """Create a file-based logger for use when the database logger is unavailable.
 
-    Writes to ``neurobooth_startup.log`` in the NB_CONFIG directory (or the
-    user's home directory if NB_CONFIG is not set). This is intended as a
+    Writes to ``neurobooth_startup.log`` in the NB_INSTALL directory (or the
+    user's home directory if NB_INSTALL is not set). This is intended as a
     last-resort logger for capturing errors that occur before the database
     connection is established.
     """
-    import os
-    log_dir = os.environ.get("NB_INSTALL", os.path.expanduser("~"))
+    log_dir = _get_log_dir()
     log_path = os.path.join(log_dir, "neurobooth_startup.log")
     logger = logging.getLogger("startup_fallback")
     if not logger.handlers:  # Avoid adding duplicate handlers

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -14,7 +14,7 @@ import neurobooth_os.current_config as current_config
 
 from neurobooth_os import config
 from neurobooth_os.iout.stim_param_reader import TaskArgs, DeviceArgs
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
 from neurobooth_os.iout.device import CameraPreviewException
 from neurobooth_os.iout.lsl_streamer import DeviceManager
 import neurobooth_os.iout.metadator as meta
@@ -33,10 +33,11 @@ def countdown(period):
 
 
 def main():
+    acq_index = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    enable_crash_handler(f"ACQ_{acq_index}")
     logger = None
     exit_code = 0
     try:
-        acq_index = int(sys.argv[1]) if len(sys.argv) > 1 else 0
         config.load_config_by_service_name("ACQ", acq_index=acq_index)
         logger = make_db_logger()  # Initialize default logger
         logger.debug(f"Starting ACQ (index={acq_index})")

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -28,7 +28,7 @@ from neurobooth_os.iout import metadator as meta
 
 from neurobooth_os.tasks.welcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
 
 prefs.hardware["audioLib"] = ["PTB"]
 prefs.hardware["audioLatencyMode"] = 3
@@ -37,6 +37,7 @@ frame_preview_device_id: Optional[str] = None
 
 
 def main():
+    enable_crash_handler("STM")
     logger = None
     exit_code = 0
     try:


### PR DESCRIPTION
## Summary
- Enable `faulthandler` at the start of each server's `main()` (CTR, STM, ACQ) to capture C-level crashes (segfaults from PsychoPy, OpenCV, pylsl, etc.) that bypass Python's exception handling
- Crash tracebacks are appended to `neurobooth_crash.log` in the `NB_INSTALL` directory, with timestamped headers per process launch so crashes can be correlated with specific runs
- Fix `make_fallback_logger` docstring that incorrectly referenced `NB_CONFIG` instead of `NB_INSTALL`

## Test plan
- [ ] Verify all three servers start normally with faulthandler enabled
- [ ] Confirm `neurobooth_crash.log` is created in `NB_INSTALL` with startup markers
- [ ] Verify crash log accumulates across restarts (append mode)