### PR TITLE
Fix thread-unsafe GUI writes and silent message reader death

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -99,10 +99,13 @@ class GuiEventListener(SessionEventListener):
             self.window.write_event_value('-config_version_error-', [error.other_version, error.server])
 
     def on_error(self, message, text_color=None):
-        write_output(self.window, message, text_color)
+        self.window.write_event_value('-status_message-', (message, text_color))
 
     def on_frame_preview(self, frame_reply):
-        handle_frame_preview_reply(self.window, frame_reply)
+        self.window.write_event_value('-frame_preview_reply-', frame_reply)
+
+    def on_message_reader_died(self, error_msg):
+        self.window.write_event_value('-message_reader_died-', error_msg)
 
     def on_new_preview_device(self, stream_name, device_id):
         self.window.write_event_value("-new_preview_device-", [stream_name, device_id])
@@ -566,6 +569,30 @@ def gui(logger):
                 if check:
                     write_output(window, "Servers initiated. OK to connect devices.")
                     window["-Connect-"].Update(disabled=False)
+
+            elif event == '-status_message-':
+                message, text_color = values[event]
+                write_output(window, message, text_color)
+
+            elif event == '-frame_preview_reply-':
+                handle_frame_preview_reply(window, values[event])
+
+            elif event == '-message_reader_died-':
+                error_msg = values[event]
+                write_output(
+                    window,
+                    f"\nCRITICAL: Message reader thread has crashed. "
+                    f"The system can no longer receive messages from servers.\n"
+                    f"Please terminate and restart.\nError: {error_msg}",
+                    text_color="red",
+                )
+                sg.PopupError(
+                    "The message reader thread has crashed.\n\n"
+                    "The system can no longer communicate with ACQ/STM servers.\n"
+                    "Please terminate the system and restart.",
+                    title="Critical System Error",
+                    location=get_popup_location(window),
+                )
 
             elif event == "no_eyetracker":
                 result = sg.PopupError(values[event], location=get_popup_location(window))

--- a/neurobooth_os/headless_listener.py
+++ b/neurobooth_os/headless_listener.py
@@ -106,6 +106,9 @@ class HeadlessListener(SessionEventListener):
     def on_mbient_disconnected(self, warning: str) -> None:
         logger.warning(f"Mbient disconnected: {warning}")
 
+    def on_message_reader_died(self, error_msg: str) -> None:
+        logger.critical(f"Message reader thread died: {error_msg}")
+
     def on_new_video_file(self, stream_name: str, filename: str, event: str) -> None:
         logger.debug(f"New video file: {stream_name}/{filename}")
 

--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -132,6 +132,10 @@ class SessionEventListener(ABC):
         """An Mbient device disconnected during a task."""
 
     @abstractmethod
+    def on_message_reader_died(self, error_msg: str) -> None:
+        """The background message reader thread has crashed."""
+
+    @abstractmethod
     def prompt_pause_decision(self) -> str:
         """Ask the user whether to continue or stop after a pause.
 
@@ -549,6 +553,17 @@ class SessionController:
         """Poll the database for messages and dispatch to the listener."""
         from neurobooth_os.log_manager import log_message_received
 
+        try:
+            self._message_reader_loop(log_message_received)
+        except Exception as e:
+            self.logger.critical(f"Message reader thread died: {e}", exc_info=True)
+            try:
+                self.listener.on_message_reader_died(str(e))
+            except Exception:
+                pass  # If even notification fails, at least we logged it
+
+    def _message_reader_loop(self, log_message_received) -> None:
+        """Inner loop for _message_reader, separated to allow top-level exception handling."""
         with meta.get_database_connection() as db_conn:
             while True:
                 message: Message = meta.read_next_message("CTR", conn=db_conn)


### PR DESCRIPTION
## Summary
- Route `on_error()` and `on_frame_preview()` through `window.write_event_value()` (thread-safe) instead of calling `write_output()` directly from the background `_message_reader` thread, which crashed tkinter with `RuntimeError: main thread is not in main loop`
- Wrap `_message_reader` in try/except so thread death is logged at CRITICAL and surfaced to the operator via a popup, instead of failing silently and leaving the system unable to receive messages
- Add `on_message_reader_died` to `SessionEventListener` ABC, `GuiEventListener`, and `HeadlessListener`

Closes #640

## Test plan
- [x] Trigger a `StatusMessage` from a device (e.g. Mbient disconnect) and confirm the message appears in the GUI without crashing
- [x] Verify frame preview still works after routing through event queue
- [x] Confirm "OK to terminate" appears at end of session
- [x] All existing tests pass (33 passed, 5 pre-existing failures unchanged)