### PR TITLE
Fix SCHTASKS /TR quoting that drops acq_index argument

### DIFF
--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -205,7 +205,13 @@ def start_server(node_name, acq_index=None, save_pid_txt=True):
 
     if task_name not in scheduled_tasks:
         print(f"Windows task: {task_name} was not found. Attempting to create")
-        tr_cmd = f'{s.bat} {acq_index}' if acq_index is not None else s.bat
+        # Inner quotes around the bat path ensure subprocess quoting
+        # produces \"path\" arg on the command line, so SCHTASKS stores
+        # the bat as the executable and the index as a separate argument.
+        # Without inner quotes, the space-containing value gets wrapped
+        # as "path arg" — SCHTASKS treats the whole thing as the program
+        # path and the argument is lost.
+        tr_cmd = f'"{s.bat}" {acq_index}' if acq_index is not None else s.bat
         cmd_1 = cmd_schtasks_base + [
             "/Create", "/TN", task_name, "/TR", tr_cmd, "/SC", "ONEVENT", "/EC", "Application", "/MO", "*[System/EventID=777]", "/f"
         ]


### PR DESCRIPTION
## Summary

The /TR value passed to SCHTASKS was built as `path/server_acq.bat 2` (space-separated). Python's subprocess quotes space-containing values, producing `"path/server_acq.bat 2"` on the command line. SCHTASKS interprets the entire quoted string as the executable path and silently drops the argument. The bat runs without it, defaulting to `acq_index=0`.

Fix adds inner quotes around only the bat path: `"path/server_acq.bat" 2`, so SCHTASKS correctly separates program from argument.

Previously invisible because `acq_index=0` is the default — only surfaced when adding a third acquisition service at index 2 in the wang environment.

## After deploying

Delete the broken task on ACQ so the code recreates it with the fixed /TR:
```
SCHTASKS /S acq /U ACQ /P <password> /Delete /TN acq-hands-wang0 /f
```

## Test plan

- [ ] Verify `SCHTASKS /query /TN acq-hands-wang0 /V /FO LIST` shows the bat path AND argument `2` in "Task To Run"
- [ ] Verify GUI shows `ACQ_0`, `ACQ_1`, `ACQ_2`, `STM` (no duplicate IDs)