### PR TITLE
Move crash and startup logs to local_log_dir

### DIFF
--- a/extras/perf/task_manager.py
+++ b/extras/perf/task_manager.py
@@ -1,0 +1,148 @@
+"""Lightweight process monitor for neurobooth machines.
+
+Periodically snapshots the top processes by CPU usage and appends
+them to a log file with ISO timestamps. Useful for capturing system
+load on ACQ/STM during sessions.
+
+Disk IO columns are per-interval rates (MB/s), not cumulative totals.
+
+Usage:
+    python extras/perf/task_manager.py                     # default: process_log.csv, 3s interval
+    python extras/perf/task_manager.py -o session.csv      # custom output file
+    python extras/perf/task_manager.py --interval 5        # 5 second interval
+    python extras/perf/task_manager.py --top 10            # top 10 processes per snapshot
+"""
+
+import argparse
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import psutil
+
+
+# Track previous IO counters per PID to compute rates
+_prev_io = {}  # pid -> (read_bytes, write_bytes, timestamp)
+
+
+def get_processes():
+    """Sample all processes for CPU, memory, and IO usage.
+
+    Calls cpu_percent() twice with a 1s gap so the measurement
+    reflects actual utilization over that window. IO rates are
+    computed as deltas from the previous snapshot.
+    """
+    global _prev_io
+
+    procs = []
+    for proc in psutil.process_iter(['pid', 'name', 'status']):
+        if proc.pid == 0:  # System Idle Process reports bogus CPU on Windows
+            continue
+        try:
+            proc.cpu_percent()  # prime it
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        procs.append(proc)
+
+    time.sleep(1)
+
+    now = time.monotonic()
+    results = []
+    total_ram = psutil.virtual_memory().total
+    new_io = {}
+
+    for proc in procs:
+        try:
+            pid = proc.pid
+            cpu = proc.cpu_percent()
+            mem = proc.memory_info().rss
+
+            read_rate = 0.0
+            write_rate = 0.0
+            try:
+                io = proc.io_counters()
+                new_io[pid] = (io.read_bytes, io.write_bytes, now)
+                if pid in _prev_io:
+                    prev_r, prev_w, prev_t = _prev_io[pid]
+                    dt = now - prev_t
+                    if dt > 0:
+                        read_rate = (io.read_bytes - prev_r) / dt / 1024 / 1024
+                        write_rate = (io.write_bytes - prev_w) / dt / 1024 / 1024
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+            results.append({
+                'pid': pid,
+                'name': proc.name(),
+                'status': proc.status(),
+                'cpu_pct': cpu,
+                'mem_mb': mem / 1024 / 1024,
+                'mem_pct': mem / total_ram * 100,
+                'read_mbs': max(read_rate, 0.0),
+                'write_mbs': max(write_rate, 0.0),
+            })
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    _prev_io = new_io
+    return sorted(results, key=lambda x: x['cpu_pct'], reverse=True)
+
+
+HEADER = "timestamp,pid,name,status,cpu_pct,mem_mb,mem_pct,read_mbs,write_mbs,sys_cpu_pct,sys_ram_pct,n_processes\n"
+
+
+def write_snapshot(f, procs, top_n=30):
+    """Append one snapshot (top_n processes) to the open file handle."""
+    ts = datetime.now(timezone.utc).isoformat(timespec='milliseconds')
+    sys_cpu = psutil.cpu_percent()
+    sys_ram = psutil.virtual_memory().percent
+    n_procs = len(procs)
+
+    for p in procs[:top_n]:
+        name = p['name'].replace(',', ';')  # sanitize for CSV
+        f.write(
+            f"{ts},{p['pid']},{name},{p['status']},"
+            f"{p['cpu_pct']:.1f},{p['mem_mb']:.1f},{p['mem_pct']:.2f},"
+            f"{p['read_mbs']:.2f},{p['write_mbs']:.2f},"
+            f"{sys_cpu},{sys_ram},{n_procs}\n"
+        )
+    f.flush()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Log process snapshots to a CSV file.")
+    parser.add_argument("-o", "--output", default="process_log.csv",
+                        help="Output CSV file (default: process_log.csv)")
+    parser.add_argument("--interval", type=int, default=3,
+                        help="Seconds between snapshots (default: 3)")
+    parser.add_argument("--top", type=int, default=30,
+                        help="Number of top processes per snapshot (default: 30)")
+    args = parser.parse_args()
+
+    path = Path(args.output)
+    write_header = not path.exists() or path.stat().st_size == 0
+
+    print(f"Logging to {path.resolve()} every {args.interval}s (top {args.top} processes)")
+    print("Press Ctrl+C to stop.\n")
+
+    with open(path, "a") as f:
+        if write_header:
+            f.write(HEADER)
+
+        snapshot = 0
+        try:
+            while True:
+                procs = get_processes()
+                write_snapshot(f, procs, top_n=args.top)
+                snapshot += 1
+                ts = datetime.now().strftime("%H:%M:%S")
+                print(f"  [{ts}] Snapshot {snapshot}: {len(procs)} processes, "
+                      f"CPU {psutil.cpu_percent()}%, RAM {psutil.virtual_memory().percent}%",
+                      end="\r")
+                time.sleep(args.interval)
+        except KeyboardInterrupt:
+            print(f"\n\nSaved {snapshot} snapshots to {path.resolve()}")
+
+
+if __name__ == '__main__':
+    main()

--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -4,7 +4,7 @@ Ensures that the base neurobooth-os config file exists and makes config file ava
 """
 
 import logging
-from os import environ, path, getenv
+from os import environ, makedirs, path, getenv
 from typing import Dict, Optional, List
 
 import yaml
@@ -325,7 +325,7 @@ def validate_system_paths(server_name: str):
     if server.local_log_dir is not None:
         log_dir = server.local_log_dir
         if not path.exists(log_dir):
-            raise FileNotFoundError(f"The local_log_dir '{log_dir}' for server {server_name} does not exist.")
+            makedirs(log_dir, exist_ok=True)
         if not path.isdir(log_dir):
             raise ConfigException(f"The local_log_dir '{log_dir}' for server {server_name} is not a folder.")
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -436,6 +436,7 @@ def gui(logger):
 
             elif event == "Stop tasks":
                 controller.stop_session(resume_on_cancel=False)
+                _session_button_state(window, disabled=True)
 
             elif event == "Calibrate":
                 write_output(window, "Eyetracker recalibration scheduled. "

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -22,7 +22,7 @@ import neurobooth_os.current_config as current_config
 from neurobooth_os.realtime.lsl_plotter import stream_plotter
 
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes, PREVIEW_AREA
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, enable_crash_handler, relocate_crash_handler, SystemResourceLogger
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, enable_crash_handler, SystemResourceLogger
 from neurobooth_os.iout.metadator import LogSession
 import neurobooth_os.iout.metadator as meta
 import neurobooth_os.config as cfg
@@ -642,7 +642,6 @@ def main():
     exit_code = 0
     try:
         cfg.load_config_by_service_name("CTR")  # Load Neurobooth-OS configuration
-        relocate_crash_handler("CTR")
         logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
         logger.debug("Starting GUI")
         gui(logger)

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -22,7 +22,7 @@ import neurobooth_os.current_config as current_config
 from neurobooth_os.realtime.lsl_plotter import stream_plotter
 
 from neurobooth_os.layouts import _main_layout, _win_gen, _init_layout, write_task_notes, PREVIEW_AREA
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, enable_crash_handler, SystemResourceLogger
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, enable_crash_handler, relocate_crash_handler, SystemResourceLogger
 from neurobooth_os.iout.metadator import LogSession
 import neurobooth_os.iout.metadator as meta
 import neurobooth_os.config as cfg
@@ -642,6 +642,7 @@ def main():
     exit_code = 0
     try:
         cfg.load_config_by_service_name("CTR")  # Load Neurobooth-OS configuration
+        relocate_crash_handler("CTR")
         logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
         logger.debug("Starting GUI")
         gui(logger)

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -637,11 +637,11 @@ def get_popup_location(window):
 
 def main():
     """The starting point of Neurobooth"""
-    enable_crash_handler("CTR")
     logger = None
     exit_code = 0
     try:
         cfg.load_config_by_service_name("CTR")  # Load Neurobooth-OS configuration
+        enable_crash_handler("CTR")
         logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
         logger.debug("Starting GUI")
         gui(logger)

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -71,35 +71,6 @@ def enable_crash_handler(server_name: str) -> None:
     faulthandler.enable(file=_crash_log_file)
 
 
-def relocate_crash_handler(server_name: str) -> None:
-    """Reopen the crash log at the configured local_log_dir.
-
-    Called after config is loaded to move the crash log from the initial
-    fallback location to the configured directory.
-
-    Args:
-        server_name: Identifier for the process (e.g. ``"STM"``, ``"ACQ_0"``).
-    """
-    global _crash_log_file
-    log_dir = _get_log_dir()
-    log_path = os.path.join(log_dir, "neurobooth_crash.log")
-
-    # If already writing to the correct path, nothing to do
-    if _crash_log_file is not None and hasattr(_crash_log_file, 'name') and _crash_log_file.name == log_path:
-        return
-
-    old_file = _crash_log_file
-    _crash_log_file = open(log_path, "a")
-    _crash_log_file.write(
-        f"\n--- {server_name} crash log relocated at {datetime.now().isoformat()} (PID {os.getpid()}) ---\n"
-    )
-    _crash_log_file.flush()
-    faulthandler.enable(file=_crash_log_file)
-
-    if old_file is not None:
-        old_file.close()
-
-
 def make_fallback_logger() -> logging.Logger:
     """Create a file-based logger for use when the database logger is unavailable.
 

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -31,7 +31,13 @@ APP_LOG_NAME = "app"
 
 
 def _get_log_dir() -> str:
-    """Return the log directory from NB_INSTALL, falling back to the user's home directory."""
+    """Return the configured log directory, falling back to NB_INSTALL or the user's home directory."""
+    try:
+        server = config.neurobooth_config.current_server()
+        if server.local_log_dir is not None:
+            return server.local_log_dir
+    except Exception:
+        pass  # Config not loaded yet; use fallback
     return os.environ.get("NB_INSTALL", os.path.expanduser("~"))
 
 
@@ -63,6 +69,35 @@ def enable_crash_handler(server_name: str) -> None:
     )
     _crash_log_file.flush()
     faulthandler.enable(file=_crash_log_file)
+
+
+def relocate_crash_handler(server_name: str) -> None:
+    """Reopen the crash log at the configured local_log_dir.
+
+    Called after config is loaded to move the crash log from the initial
+    fallback location to the configured directory.
+
+    Args:
+        server_name: Identifier for the process (e.g. ``"STM"``, ``"ACQ_0"``).
+    """
+    global _crash_log_file
+    log_dir = _get_log_dir()
+    log_path = os.path.join(log_dir, "neurobooth_crash.log")
+
+    # If already writing to the correct path, nothing to do
+    if _crash_log_file is not None and hasattr(_crash_log_file, 'name') and _crash_log_file.name == log_path:
+        return
+
+    old_file = _crash_log_file
+    _crash_log_file = open(log_path, "a")
+    _crash_log_file.write(
+        f"\n--- {server_name} crash log relocated at {datetime.now().isoformat()} (PID {os.getpid()}) ---\n"
+    )
+    _crash_log_file.flush()
+    faulthandler.enable(file=_crash_log_file)
+
+    if old_file is not None:
+        old_file.close()
 
 
 def make_fallback_logger() -> logging.Logger:

--- a/neurobooth_os/perf_monitor.py
+++ b/neurobooth_os/perf_monitor.py
@@ -3,6 +3,11 @@
 Runs in a daemon thread, writing CSV snapshots at a configurable interval.
 Designed to run for the lifetime of a session on ACQ and STM machines.
 
+Enabled via the NB_ENABLE_PROCESS_LOG environment variable:
+  P — log top processes by CPU
+  M — log top processes by memory
+  A — log both (union of top CPU and top memory)
+
 Columns: timestamp, pid, name, status, cpu_pct, mem_mb, mem_pct,
          read_mbs, write_mbs, sys_cpu_pct, sys_ram_pct, n_processes
 """
@@ -22,20 +27,23 @@ HEADER = "timestamp,pid,name,status,cpu_pct,mem_mb,mem_pct,read_mbs,write_mbs,sy
 
 
 class ProcessMonitor:
-    """Periodically snapshots top processes by CPU and writes to a CSV file.
+    """Periodically snapshots top processes by CPU and/or memory and writes to a CSV file.
 
     Parameters
     ----------
     output_path : str or Path
         CSV file to append to.
+    mode : str
+        ``"P"`` for top-CPU, ``"M"`` for top-memory, ``"A"`` for both.
     interval_sec : int
         Seconds between snapshots (excluding the 1s CPU measurement window).
     top_n : int
-        Number of top-CPU processes to record per snapshot.
+        Number of top processes to record per ranking.
     """
 
-    def __init__(self, output_path: str, interval_sec: int = 3, top_n: int = 30):
+    def __init__(self, output_path: str, mode: str = "A", interval_sec: int = 3, top_n: int = 30):
         self._path = Path(output_path)
+        self._mode = mode.upper()
         self._interval = interval_sec
         self._top_n = top_n
         self._stop_event = threading.Event()
@@ -128,15 +136,34 @@ class ProcessMonitor:
                 pass
 
         self._prev_io = new_io
-        return sorted(results, key=lambda x: x['cpu_pct'], reverse=True)
+        return results
+
+    def _select(self, procs: list) -> list:
+        """Select the top-N processes according to the configured mode."""
+        if self._mode == "P":
+            return sorted(procs, key=lambda x: x['cpu_pct'], reverse=True)[:self._top_n]
+        if self._mode == "M":
+            return sorted(procs, key=lambda x: x['mem_mb'], reverse=True)[:self._top_n]
+
+        # "A" — union of top-N by CPU and top-N by memory
+        by_cpu = sorted(procs, key=lambda x: x['cpu_pct'], reverse=True)[:self._top_n]
+        by_mem = sorted(procs, key=lambda x: x['mem_mb'], reverse=True)[:self._top_n]
+        seen = set()
+        combined = []
+        for p in by_cpu + by_mem:
+            if p['pid'] not in seen:
+                seen.add(p['pid'])
+                combined.append(p)
+        return sorted(combined, key=lambda x: x['cpu_pct'], reverse=True)
 
     def _write_snapshot(self, f, procs: list) -> None:
         ts = datetime.now(timezone.utc).isoformat(timespec='milliseconds')
         sys_cpu = psutil.cpu_percent()
         sys_ram = psutil.virtual_memory().percent
         n_procs = len(procs)
+        selected = self._select(procs)
 
-        for p in procs[:self._top_n]:
+        for p in selected:
             name = p['name'].replace(',', ';')
             f.write(
                 f"{ts},{p['pid']},{name},{p['status']},"

--- a/neurobooth_os/perf_monitor.py
+++ b/neurobooth_os/perf_monitor.py
@@ -1,0 +1,147 @@
+"""Background process monitor that logs CPU, memory, and disk IO per process.
+
+Runs in a daemon thread, writing CSV snapshots at a configurable interval.
+Designed to run for the lifetime of a session on ACQ and STM machines.
+
+Columns: timestamp, pid, name, status, cpu_pct, mem_mb, mem_pct,
+         read_mbs, write_mbs, sys_cpu_pct, sys_ram_pct, n_processes
+"""
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import psutil
+
+logger = logging.getLogger(__name__)
+
+HEADER = "timestamp,pid,name,status,cpu_pct,mem_mb,mem_pct,read_mbs,write_mbs,sys_cpu_pct,sys_ram_pct,n_processes\n"
+
+
+class ProcessMonitor:
+    """Periodically snapshots top processes by CPU and writes to a CSV file.
+
+    Parameters
+    ----------
+    output_path : str or Path
+        CSV file to append to.
+    interval_sec : int
+        Seconds between snapshots (excluding the 1s CPU measurement window).
+    top_n : int
+        Number of top-CPU processes to record per snapshot.
+    """
+
+    def __init__(self, output_path: str, interval_sec: int = 3, top_n: int = 30):
+        self._path = Path(output_path)
+        self._interval = interval_sec
+        self._top_n = top_n
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._prev_io: dict = {}
+
+    def start(self) -> None:
+        """Start the monitor in a background daemon thread."""
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning("ProcessMonitor already running")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="ProcessMonitor")
+        self._thread.start()
+        logger.info(f"ProcessMonitor started: {self._path}")
+
+    def stop(self) -> None:
+        """Signal the monitor to stop and wait for it to finish."""
+        if self._thread is None or not self._thread.is_alive():
+            return
+        self._stop_event.set()
+        self._thread.join(timeout=10)
+        logger.info("ProcessMonitor stopped")
+
+    def _run(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        write_header = not self._path.exists() or self._path.stat().st_size == 0
+
+        try:
+            with open(self._path, "a") as f:
+                if write_header:
+                    f.write(HEADER)
+                while not self._stop_event.is_set():
+                    procs = self._sample()
+                    self._write_snapshot(f, procs)
+                    self._stop_event.wait(timeout=self._interval)
+        except Exception:
+            logger.exception("ProcessMonitor crashed")
+
+    def _sample(self) -> list:
+        """Sample all processes for CPU, memory, and IO."""
+        procs = []
+        for proc in psutil.process_iter(['pid', 'name', 'status']):
+            if proc.pid == 0:
+                continue
+            try:
+                proc.cpu_percent()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+            procs.append(proc)
+
+        time.sleep(1)
+
+        now = time.monotonic()
+        results = []
+        total_ram = psutil.virtual_memory().total
+        new_io = {}
+
+        for proc in procs:
+            try:
+                pid = proc.pid
+                cpu = proc.cpu_percent()
+                mem = proc.memory_info().rss
+
+                read_rate = 0.0
+                write_rate = 0.0
+                try:
+                    io = proc.io_counters()
+                    new_io[pid] = (io.read_bytes, io.write_bytes, now)
+                    if pid in self._prev_io:
+                        prev_r, prev_w, prev_t = self._prev_io[pid]
+                        dt = now - prev_t
+                        if dt > 0:
+                            read_rate = max((io.read_bytes - prev_r) / dt / 1024 / 1024, 0.0)
+                            write_rate = max((io.write_bytes - prev_w) / dt / 1024 / 1024, 0.0)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+
+                results.append({
+                    'pid': pid,
+                    'name': proc.name(),
+                    'status': proc.status(),
+                    'cpu_pct': cpu,
+                    'mem_mb': mem / 1024 / 1024,
+                    'mem_pct': mem / total_ram * 100,
+                    'read_mbs': read_rate,
+                    'write_mbs': write_rate,
+                })
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+        self._prev_io = new_io
+        return sorted(results, key=lambda x: x['cpu_pct'], reverse=True)
+
+    def _write_snapshot(self, f, procs: list) -> None:
+        ts = datetime.now(timezone.utc).isoformat(timespec='milliseconds')
+        sys_cpu = psutil.cpu_percent()
+        sys_ram = psutil.virtual_memory().percent
+        n_procs = len(procs)
+
+        for p in procs[:self._top_n]:
+            name = p['name'].replace(',', ';')
+            f.write(
+                f"{ts},{p['pid']},{name},{p['status']},"
+                f"{p['cpu_pct']:.1f},{p['mem_mb']:.1f},{p['mem_pct']:.2f},"
+                f"{p['read_mbs']:.2f},{p['write_mbs']:.2f},"
+                f"{sys_cpu},{sys_ram},{n_procs}\n"
+            )
+        f.flush()

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -34,11 +34,11 @@ def countdown(period):
 
 def main():
     acq_index = int(sys.argv[1]) if len(sys.argv) > 1 else 0
-    enable_crash_handler(f"ACQ_{acq_index}")
     logger = None
     exit_code = 0
     try:
         config.load_config_by_service_name("ACQ", acq_index=acq_index)
+        enable_crash_handler(f"ACQ_{acq_index}")
         logger = make_db_logger()  # Initialize default logger
         logger.debug(f"Starting ACQ (index={acq_index})")
         os.chdir(neurobooth_os.__path__[0])

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -98,13 +98,14 @@ def run_acq(logger, acq_index: int = 0):
                     system_resource_logger = SystemResourceLogger(machine_name=service_id)
                     system_resource_logger.start()
 
-                if os.environ.get("NB_ENABLE_PROCESS_LOG", "").lower() in ("1", "true", "yes"):
+                perf_mode = os.environ.get("NB_ENABLE_PROCESS_LOG", "").upper()
+                if perf_mode in ("P", "M", "A"):
                     log_dir = acq_config.local_log_dir
                     if log_dir is not None:
                         session_log_dir = os.path.join(log_dir, session_name)
                         os.makedirs(session_log_dir, exist_ok=True)
                         perf_path = os.path.join(session_log_dir, f"process_log_{service_id}.csv")
-                        process_monitor = ProcessMonitor(perf_path)
+                        process_monitor = ProcessMonitor(perf_path, mode=perf_mode)
                         process_monitor.start()
 
                 task_args = meta.build_tasks_for_collection(collection_id, selected_tasks)

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -15,6 +15,7 @@ import neurobooth_os.current_config as current_config
 from neurobooth_os import config
 from neurobooth_os.iout.stim_param_reader import TaskArgs, DeviceArgs
 from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
+from neurobooth_os.perf_monitor import ProcessMonitor
 from neurobooth_os.iout.device import CameraPreviewException
 from neurobooth_os.iout.lsl_streamer import DeviceManager
 import neurobooth_os.iout.metadator as meta
@@ -62,6 +63,7 @@ def run_acq(logger, acq_index: int = 0):
     device_manager = None
     recording = False
     system_resource_logger = None
+    process_monitor: Optional[ProcessMonitor] = None
     task_args: Dict[str, TaskArgs] = {}
     init_servers = Request(source=service_id, destination="CTR",
                            body=ServerStarted(neurobooth_version=release.version,
@@ -95,6 +97,10 @@ def run_acq(logger, acq_index: int = 0):
                 if system_resource_logger is None:
                     system_resource_logger = SystemResourceLogger(machine_name=service_id)
                     system_resource_logger.start()
+
+                perf_path = os.path.join(ses_folder, f"process_log_{service_id}.csv")
+                process_monitor = ProcessMonitor(perf_path)
+                process_monitor.start()
 
                 task_args = meta.build_tasks_for_collection(collection_id, selected_tasks)
 
@@ -174,6 +180,8 @@ def run_acq(logger, acq_index: int = 0):
                     logger.info('StopRecording received but not recording; ignored')
 
             elif "TerminateServerRequest" == current_msg_type:
+                if process_monitor is not None:
+                    process_monitor.stop()
                 if recording:
                     elapsed_time = stop_recording(device_manager, task_args[task].device_args)
                     logger.info(f'Device stop took {elapsed_time:.2f}')

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -14,7 +14,7 @@ import neurobooth_os.current_config as current_config
 
 from neurobooth_os import config
 from neurobooth_os.iout.stim_param_reader import TaskArgs, DeviceArgs
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler, relocate_crash_handler
 from neurobooth_os.iout.device import CameraPreviewException
 from neurobooth_os.iout.lsl_streamer import DeviceManager
 import neurobooth_os.iout.metadator as meta
@@ -39,6 +39,7 @@ def main():
     exit_code = 0
     try:
         config.load_config_by_service_name("ACQ", acq_index=acq_index)
+        relocate_crash_handler(f"ACQ_{acq_index}")
         logger = make_db_logger()  # Initialize default logger
         logger.debug(f"Starting ACQ (index={acq_index})")
         os.chdir(neurobooth_os.__path__[0])

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -98,9 +98,14 @@ def run_acq(logger, acq_index: int = 0):
                     system_resource_logger = SystemResourceLogger(machine_name=service_id)
                     system_resource_logger.start()
 
-                perf_path = os.path.join(ses_folder, f"process_log_{service_id}.csv")
-                process_monitor = ProcessMonitor(perf_path)
-                process_monitor.start()
+                if os.environ.get("NB_ENABLE_PROCESS_LOG", "").lower() in ("1", "true", "yes"):
+                    log_dir = acq_config.local_log_dir
+                    if log_dir is not None:
+                        session_log_dir = os.path.join(log_dir, session_name)
+                        os.makedirs(session_log_dir, exist_ok=True)
+                        perf_path = os.path.join(session_log_dir, f"process_log_{service_id}.csv")
+                        process_monitor = ProcessMonitor(perf_path)
+                        process_monitor.start()
 
                 task_args = meta.build_tasks_for_collection(collection_id, selected_tasks)
 

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -14,7 +14,7 @@ import neurobooth_os.current_config as current_config
 
 from neurobooth_os import config
 from neurobooth_os.iout.stim_param_reader import TaskArgs, DeviceArgs
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler, relocate_crash_handler
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
 from neurobooth_os.iout.device import CameraPreviewException
 from neurobooth_os.iout.lsl_streamer import DeviceManager
 import neurobooth_os.iout.metadator as meta
@@ -39,7 +39,6 @@ def main():
     exit_code = 0
     try:
         config.load_config_by_service_name("ACQ", acq_index=acq_index)
-        relocate_crash_handler(f"ACQ_{acq_index}")
         logger = make_db_logger()  # Initialize default logger
         logger.debug(f"Starting ACQ (index={acq_index})")
         os.chdir(neurobooth_os.__path__[0])

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -36,11 +36,11 @@ calib_instructions: bool = True  # True if we have not yet performed an eyetrack
 
 
 def main():
-    enable_crash_handler("STM")
     logger = None
     exit_code = 0
     try:
         config.load_config_by_service_name("STM")  # Load Neurobooth-OS configuration
+        enable_crash_handler("STM")
         logger = make_db_logger()  # Initialize logging to default
         logger.debug("Starting STM")
         os.chdir(neurobooth_os.__path__[0])

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -153,13 +153,14 @@ def run_stm(logger):
                     if "PrepareRequest" == current_msg_type:
                         request: PrepareRequest = message.body
                         session, task_log_entry = prepare_session(request, logger)
-                        if os.environ.get("NB_ENABLE_PROCESS_LOG", "").lower() in ("1", "true", "yes"):
+                        perf_mode = os.environ.get("NB_ENABLE_PROCESS_LOG", "").upper()
+                        if perf_mode in ("P", "M", "A"):
                             log_dir = config.neurobooth_config.presentation.local_log_dir
                             if log_dir is not None:
                                 session_log_dir = os.path.join(log_dir, session.session_name)
                                 os.makedirs(session_log_dir, exist_ok=True)
                                 perf_path = os.path.join(session_log_dir, "process_log_stm.csv")
-                                process_monitor = ProcessMonitor(perf_path)
+                                process_monitor = ProcessMonitor(perf_path, mode=perf_mode)
                                 process_monitor.start()
 
                     elif 'CreateTasksRequest' == current_msg_type:

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -28,7 +28,7 @@ from neurobooth_os.iout import metadator as meta
 
 from neurobooth_os.tasks.welcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler, relocate_crash_handler
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
 
 prefs.hardware["audioLib"] = ["PTB"]
 prefs.hardware["audioLatencyMode"] = 3
@@ -41,7 +41,6 @@ def main():
     exit_code = 0
     try:
         config.load_config_by_service_name("STM")  # Load Neurobooth-OS configuration
-        relocate_crash_handler("STM")
         logger = make_db_logger()  # Initialize logging to default
         logger.debug("Starting STM")
         os.chdir(neurobooth_os.__path__[0])

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -29,6 +29,7 @@ from neurobooth_os.iout import metadator as meta
 from neurobooth_os.tasks.welcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
 from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
+from neurobooth_os.perf_monitor import ProcessMonitor
 
 prefs.hardware["audioLib"] = ["PTB"]
 prefs.hardware["audioLatencyMode"] = 3
@@ -73,6 +74,7 @@ def run_stm(logger):
     finished: bool = False  # True if the "Thank you" screen has been displayed
     shutdown: bool = False  # True if message received that this server should be terminated
     last_task_finished_time: Optional[float] = None  # For inter-task timing
+    process_monitor: Optional[ProcessMonitor] = None
     init_servers = Request(source="STM", destination="CTR", body=ServerStarted(neurobooth_version=release.version,
                                                                                config_version=current_config.version))
     meta.post_message(init_servers)
@@ -134,6 +136,8 @@ def run_stm(logger):
                 current_msg_type: str = message.msg_type
 
                 if "TerminateServerRequest" == current_msg_type:
+                    if process_monitor is not None:
+                        process_monitor.stop()
                     if session is not None:
                         session.shutdown()
                     shutdown = True
@@ -144,6 +148,10 @@ def run_stm(logger):
                     if "PrepareRequest" == current_msg_type:
                         request: PrepareRequest = message.body
                         session, task_log_entry = prepare_session(request, logger)
+                        stm_data_dir = config.neurobooth_config.presentation.local_data_dir
+                        perf_path = os.path.join(stm_data_dir, session.session_name, "process_log_stm.csv")
+                        process_monitor = ProcessMonitor(perf_path)
+                        process_monitor.start()
 
                     elif 'CreateTasksRequest' == current_msg_type:
                         device_log_entry_dict, subj_id = _create_tasks(message, session, task_log_entry)

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -28,7 +28,7 @@ from neurobooth_os.iout import metadator as meta
 
 from neurobooth_os.tasks.welcome_finish_screens import welcome_screen, finish_screen
 import neurobooth_os.tasks.utils as utl
-from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler
+from neurobooth_os.log_manager import make_db_logger, make_fallback_logger, log_message_received, enable_crash_handler, relocate_crash_handler
 
 prefs.hardware["audioLib"] = ["PTB"]
 prefs.hardware["audioLatencyMode"] = 3
@@ -41,6 +41,7 @@ def main():
     exit_code = 0
     try:
         config.load_config_by_service_name("STM")  # Load Neurobooth-OS configuration
+        relocate_crash_handler("STM")
         logger = make_db_logger()  # Initialize logging to default
         logger.debug("Starting STM")
         os.chdir(neurobooth_os.__path__[0])

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -153,10 +153,14 @@ def run_stm(logger):
                     if "PrepareRequest" == current_msg_type:
                         request: PrepareRequest = message.body
                         session, task_log_entry = prepare_session(request, logger)
-                        stm_data_dir = config.neurobooth_config.presentation.local_data_dir
-                        perf_path = os.path.join(stm_data_dir, session.session_name, "process_log_stm.csv")
-                        process_monitor = ProcessMonitor(perf_path)
-                        process_monitor.start()
+                        if os.environ.get("NB_ENABLE_PROCESS_LOG", "").lower() in ("1", "true", "yes"):
+                            log_dir = config.neurobooth_config.presentation.local_log_dir
+                            if log_dir is not None:
+                                session_log_dir = os.path.join(log_dir, session.session_name)
+                                os.makedirs(session_log_dir, exist_ok=True)
+                                perf_path = os.path.join(session_log_dir, "process_log_stm.csv")
+                                process_monitor = ProcessMonitor(perf_path)
+                                process_monitor.start()
 
                     elif 'CreateTasksRequest' == current_msg_type:
                         device_log_entry_dict, subj_id = _create_tasks(message, session, task_log_entry)

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -194,7 +194,7 @@ def run_stm(logger):
                         logger.error(unex_msg)
                         raise RuntimeError(unex_msg)
 
-                if session_canceled and not finished:
+                if session_canceled and not finished and session is not None:
                     finished = _finish_tasks(session)
             except Exception as argument:
                 with meta.get_database_connection() as db_conn:


### PR DESCRIPTION
## Summary

- After config loads, relocate the crash log (faulthandler) and startup/fallback log to the configured `local_log_dir`
- Create `local_log_dir` automatically if it doesn't exist (instead of raising)
- Crash handler still starts at the fallback path before config is available, then is relocated via `relocate_crash_handler()`

## Files changed

- `config.py` — `validate_system_paths` creates `local_log_dir` with `makedirs` instead of raising
- `log_manager.py` — `_get_log_dir()` checks config for `local_log_dir`; new `relocate_crash_handler()` reopens crash log at configured path
- `server_stm.py`, `server_acq.py`, `gui.py` — call `relocate_crash_handler()` after config loads

## Depends on

- neurobooth/configs#103 — adds `local_log_dir` values to all environment configs

## Test plan

- [ ] Verify crash log is written to `local_log_dir` after startup
- [ ] Verify startup/fallback log is written to `local_log_dir` when DB connection fails
- [ ] Verify log directory is created if it doesn't exist
- [ ] Verify crash handler works at fallback path if config fails to load

Closes #667