### PR TITLE
Tag RecordingFiles with fname to fix #659 regression

### DIFF
--- a/docs/arch/video_filename_tracking_current.md
+++ b/docs/arch/video_filename_tracking_current.md
@@ -1,0 +1,172 @@
+# Video Filename Tracking — Current Design (post #659 re-fix)
+
+This document describes the current mechanism for recording video filenames in
+`log_sensor_file` and compares the resulting data to the pre-#611 system.
+Intended audience: anyone touching `split_xdf`, `server_acq`, `server_stm`,
+`session_controller`, or downstream scripts that read `log_sensor_file`.
+
+For historical context on the bug that motivated the 2026-04 rewrite, see
+`video_filename_tracking.md` (describes the LSL marker-stream design and the
+gap bug introduced by `TransitionRecording`).
+
+## Mechanism
+
+Filenames travel from the producer (ACQ's DeviceManager or STM's task/eye
+tracker code) to CTR via the database `message_queue`, as a `RecordingFiles`
+message. CTR accumulates them in an in-memory buffer on the message reader
+thread, and passes the buffer contents to `split_xdf` when the matching
+`TaskCompletion` arrives.
+
+Each `RecordingFiles` message is **tagged with `fname`**, the unique per-run
+identifier:
+
+```
+fname = f"{session_name}_{tsk_start_time}_{task_id}"
+```
+
+`tsk_start_time` is generated when STM enters `_perform_task` for a given
+task and contains hour/minute/second resolution. Repeated runs of the same
+task (recalibration, session restart, subject repeats) produce different
+`tsk_start_time` values and therefore different fnames. The fname flows
+through the same code paths used for file naming, so the buffer key matches
+the filename prefix on disk.
+
+`TaskCompletion` carries the same `fname`. When CTR reads it, it pops only
+the bucket for that specific fname. Files for other task runs stay untouched.
+
+### Sequence (happy path)
+
+```
+STM                    ACQ                    CTR
+ │                      │                      │
+ ├─ post TransitionRecording(fname=F1) ──────► │
+ │                      │                      │
+ │                      ├─ start cameras       │
+ │                      ├─ post RecordingFiles(fname=F1, files=...) ─────►
+ │                      │                      │  buffer[F1] = {...}
+ ├─ task runs ...       │                      │
+ │                      │                      │
+ ├─ post TaskCompletion(fname=F1) ─────────────►
+ │                      │                      │  pop buffer[F1]
+ │                      │                      │  → split_xdf → log_sensor_file
+```
+
+### Sequence (out-of-order, the race #659 was fighting)
+
+```
+STM                    ACQ                    CTR
+ │                      │                      │
+ ├─ post TransitionRecording(fname=F2, task=next) ───►
+ │                      │                      │
+ │                      ├─ start cameras       │
+ │                      ├─ post RecordingFiles(fname=F2, files=...) ───► (inserted as id=N)
+ │                      │                      │  buffer[F2] = {...}
+ │                      │                      │
+ ├─ post TaskCompletion(fname=F1, task=current) ─────────────► (inserted as id=N+1)
+ │                      │                      │  pop buffer[F1]
+ │                      │                      │  → correctly empty
+ │                      │                      │  F2's bucket is still intact
+ │                      │                      │
+ ├─ post TaskCompletion(fname=F2, task=next) ─────────────►
+ │                      │                      │  pop buffer[F2]
+ │                      │                      │  → contains F2's files ✓
+```
+
+The key property: messages inserted into the DB out of order still get
+bucketed correctly because the bucket key is the task-run identifier, not
+arrival order or message type grouping.
+
+## Data comparison to pre-#611 system
+
+### `log_sensor_file.sensor_file_path`
+
+**Same data, same format.** The array still contains
+`[hdf5_path, video_path_1, video_path_2, ...]` in the same order as before.
+The mechanism for collecting the paths is different but the resulting column
+value is identical.
+
+Validated by the check script at `extras/sql/check_missing_video_files.sql` —
+for a correctly-functioning session, every camera row should contain its
+expected video file extension.
+
+### `log_sensor_file.file_start_time` / `file_end_time`
+
+**Same derivation, same values, same bug.** These are still computed by
+`compute_clocks_diff()` at XDF split time (see #671). The fname-keyed
+buffering change does not touch timestamp computation. If #671 is fixed, the
+values become correct; if not, they have the same clock-drift risk as before.
+
+### `log_sensor_file.true_temporal_resolution`
+
+**Same derivation, same values.** Computed from the XDF `time_stamps` array
+during split. Unchanged.
+
+### XDF file contents
+
+**One visible difference.** Pre-#611 XDF files contained a `videofiles` LSL
+marker stream with samples of the form `"FlirFrameIndex,task_flir.avi"`. The
+current XDF files do **not** contain this stream — it was removed in
+d0dfbf8 (the first #659 fix) when filename transport moved off LSL and onto
+the DB message queue.
+
+Consequences:
+- `parse_xdf()` no longer reads the `videofiles` stream. The branch that did
+  still exists in the pre-d0dfbf8 code paths but is dead.
+- Any external tool that re-opens old XDF files expecting `videofiles` will
+  still find it (old files are unchanged); any tool that expects it in
+  *new* XDF files will get nothing.
+- The `video_files` parameter now flows into `parse_xdf`/`split_sens_files`
+  from the CTR buffer, not from the XDF file itself.
+
+### `log_sensor_file` row cardinality
+
+**Same.** Still one row per `(log_task_id, device_id, sensor_id)`. The
+multi-sensor devices (Intel `rgb_1` + `depth_1`) still produce two rows per
+task, with identical `sensor_file_path` arrays. The FLIR still produces one
+row with one hdf5 and one avi. No new rows, no removed rows.
+
+### Failure modes
+
+**Different, and fewer.**
+
+| Failure mode | Pre-#611 | d0dfbf8 (first fix) | Current |
+|---|---|---|---|
+| LSL gap between recordings (markers lost) | Yes — #659 | No | No |
+| Message-order race (next task's files swept into current) | N/A | Yes — #659 regression | No |
+| Repeated tasks within a session mixing files | N/A | Yes (task_id collision) | No |
+| Downstream missing-video queries | Broken by LSL gap | Broken by order race | Should work |
+
+### Data timing
+
+**Slightly different but invisible.** In the pre-#611 system, filenames
+entered `log_sensor_file` during the XDF split, after LabRecorder finalized
+the XDF file. In the current system, filenames enter the CTR buffer as soon
+as the device's `start()` returns; they're still written to
+`log_sensor_file` during the XDF split on the same schedule. The timing of
+DB writes is unchanged from the reader's perspective.
+
+## What to look for when validating
+
+Run `extras/sql/check_missing_video_files.sql` (filtered to the target
+release) after each session and confirm zero rows. Any row returned means
+either:
+- A device failed to produce its video file (check device logs), or
+- A `RecordingFiles` message was lost or mistagged (check `body.fname`
+  values in the `message_queue` table for the session)
+
+## Files and line references
+
+- `neurobooth_os/msg/messages.py` — `RecordingFiles.fname`,
+  `TaskCompletion.fname`
+- `neurobooth_os/iout/lsl_streamer.py` — `start_recording_devices(filename, fname, task_devices)`
+- `neurobooth_os/server_acq.py` — extracts `fname` from
+  `StartRecording`/`TransitionRecording`, passes through to
+  `start_recording`
+- `neurobooth_os/server_stm.py` — constructs `fname` in `_perform_task`,
+  threads through to `_get_task_instance` and `TaskCompletion`
+- `neurobooth_os/tasks/eye_tracker_calibrate.py` — uses `kwargs["run_fname"]`
+  in its `RecordingFiles` message
+- `neurobooth_os/session_controller.py` — `task_video_files: Dict[fname, Dict[stream, files]]`;
+  message reader buckets by `body.fname`, pops by `TaskCompletion.fname`
+- `tests/pytest/test_video_files_race.py` — unit tests including the session
+  3185 message-order race and the repeated-task case

--- a/extras/sql/check_missing_video_files.sql
+++ b/extras/sql/check_missing_video_files.sql
@@ -1,0 +1,51 @@
+-- check_missing_video_files.sql
+--
+-- Finds log_sensor_file entries where a camera device recorded but its
+-- video file (.avi, .bag, .mov) is missing from the sensor_file_path array.
+--
+-- Background:
+--   Each camera device (FLIR, Intel, iPhone) produces both an LSL data
+--   stream (saved as .hdf5 via XDF split) and a video file (.avi/.bag/.mov).
+--   The split_sens_files() function writes both paths into sensor_file_path.
+--   If the video file path is missing, downstream scripts that look up
+--   files by extension will report "log_sensor_file_id not found".
+--
+-- Root cause (fixed in v0.81.0):
+--   A race condition between the message reader thread and the GUI thread
+--   allowed RecordingFiles for the next task (sent via TransitionRecording)
+--   to be buffered before stop_lsl_recording snapshotted task_video_files,
+--   causing the current task to capture both tasks' files and the next
+--   task to get none. See GitHub issue #659.
+--
+-- Usage:
+--   Run after deploying a new version to verify that video files are
+--   being registered correctly. Expect 0 rows on a healthy session.
+--
+--   Filter by version:  WHERE ls.application_version = 'v0.81.0'
+--   Filter by date:     WHERE ls.date >= '2026-04-10'
+--   Filter by session:  WHERE ls.log_session_id = 3180
+
+SELECT
+    ls.log_session_id,
+    ls.date,
+    ls.application_version,
+    lt.task_id,
+    lsf.device_id,
+    lsf.sensor_file_path
+FROM log_sensor_file lsf
+JOIN log_task lt ON lsf.log_task_id = lt.log_task_id
+JOIN log_session ls ON lt.log_session_id = ls.log_session_id
+WHERE lsf.device_id IN ('FLIR_blackfly_1', 'Intel_D455_1', 'Intel_D455_2',
+                         'Intel_D455_3', 'IPhone_dev_1')
+  AND NOT (
+      -- FLIR produces .avi
+      (lsf.device_id = 'FLIR_blackfly_1' AND lsf.sensor_file_path::text LIKE '%_flir.avi%')
+      -- Intel cameras produce .bag
+      OR (lsf.device_id LIKE 'Intel_D455_%' AND lsf.sensor_file_path::text LIKE '%_intel%.bag%')
+      -- iPhone produces .mov
+      OR (lsf.device_id = 'IPhone_dev_1' AND lsf.sensor_file_path::text LIKE '%_IPhone.mov%')
+  )
+  -- Uncomment one of these filters:
+  -- AND ls.application_version = 'v0.81.0'
+  -- AND ls.date >= '2026-04-10'
+ORDER BY ls.date, ls.log_session_id, lt.task_id, lsf.device_id;

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -253,7 +253,7 @@ class DeviceManager:
             if not device.has_capability(DeviceCapability.CALIBRATABLE)
         ]
 
-    def start_recording_devices(self, filename: str, task_devices: List[DeviceArgs]) -> Dict[str, List[str]]:
+    def start_recording_devices(self, filename: str, fname: str, task_devices: List[DeviceArgs]) -> Dict[str, List[str]]:
         """Start camera recording devices in parallel for the given task.
 
         Collects the filenames created by each device and sends a single
@@ -261,7 +261,9 @@ class DeviceManager:
         reliably without depending on the LSL marker stream.
 
         Args:
-            filename: Base path for output files, passed to each device's ``start()``.
+            filename: Full output path prefix, passed to each device's ``start()``.
+            fname: Unique per-run identifier (``{session_name}_{tsk_start_time}_{task_id}``),
+                used by CTR to bucket RecordingFiles against a specific task run.
             task_devices: Devices required by the current task.
 
         Returns:
@@ -283,7 +285,8 @@ class DeviceManager:
                 except Exception as e:
                     self.logger.exception(e)
         if all_files:
-            msg = Request(source="ACQ", destination="CTR", body=RecordingFiles(files=all_files))
+            msg = Request(source="ACQ", destination="CTR",
+                          body=RecordingFiles(fname=fname, files=all_files))
             meta.post_message(msg)
         return all_files
 

--- a/neurobooth_os/msg/messages.py
+++ b/neurobooth_os/msg/messages.py
@@ -289,6 +289,7 @@ class TaskCompletion(MsgBody):
     """
     task_id: str
     has_lsl_stream: bool = True  # True if the task has associated LSL streams (False for instructions, pauses)
+    fname: Optional[str] = None  # Unique per-run file name prefix (session_tsk_start_task). Used by CTR to look up buffered RecordingFiles for this specific task run.
 
     def __init__(self, **data):
         data['priority'] = HIGH_PRIORITY
@@ -459,9 +460,15 @@ class RecordingFiles(MsgBody):
     XDF post-processing, replacing the fragile ``videofiles`` LSL marker stream.
 
     Attributes:
+        fname: Unique per-run file name prefix (``{session_name}_{tsk_start_time}_{task_id}``),
+            matching the ``fname`` in ``StartRecording`` / ``TransitionRecording``. CTR buckets
+            RecordingFiles by this value so messages for different task runs cannot mix, even
+            when a task is repeated or a RecordingFiles for the next task arrives before the
+            current task's TaskCompletion.
         files: Mapping of LSL stream name to list of file basenames created by
             that device (e.g. ``{"FLIR": ["task_flir.avi"], "IPhone": ["task_IPhone.mov", "task_IPhone.json"]}``).
     """
+    fname: str
     files: Dict[str, List[str]]
 
     def __init__(self, **data):

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -143,11 +143,11 @@ def run_acq(logger, acq_index: int = 0):
                     camera_frame_preview(dev_id, device_manager, logger, service_id)
 
                 task = msg_body.task_id
-                fname = msg_body.fname
+                fname = msg_body.fname  # unique per-run identifier, preserved for RecordingFiles tag
                 session_name = msg_body.session_name
-                fname = os.path.join(acq_config.local_data_dir, session_name, fname)
+                filename = os.path.join(acq_config.local_data_dir, session_name, fname)
 
-                elapsed_time = start_recording(device_manager, fname, task_args[task].device_args)
+                elapsed_time = start_recording(device_manager, filename, fname, task_args[task].device_args)
                 logger.info(f'Device start took {elapsed_time:.2f} for {task}')
                 reply = Request(source=service_id, destination="STM", body=RecordingStarted())
                 meta.post_message(reply)
@@ -165,11 +165,11 @@ def run_acq(logger, acq_index: int = 0):
                     camera_frame_preview(dev_id, device_manager, logger, service_id)
 
                 task = msg_body.task_id
-                fname = msg_body.fname
+                fname = msg_body.fname  # unique per-run identifier, preserved for RecordingFiles tag
                 session_name = msg_body.session_name
-                fname = os.path.join(acq_config.local_data_dir, session_name, fname)
+                filename = os.path.join(acq_config.local_data_dir, session_name, fname)
 
-                elapsed_start = start_recording(device_manager, fname, task_args[task].device_args)
+                elapsed_start = start_recording(device_manager, filename, fname, task_args[task].device_args)
                 logger.info(f'Transition: device start took {elapsed_start:.2f} for {task}')
                 reply = Request(source=service_id, destination="STM", body=RecordingStarted())
                 meta.post_message(reply)
@@ -234,9 +234,18 @@ def camera_frame_preview(device_id: str, device_manager, logger, service_id: str
         logger.debug(f'Frame preview unavailable: {body.unavailable_message}')
 
 
-def start_recording(device_manager: DeviceManager, fname: str, task_devices: List[DeviceArgs]) -> float:
+def start_recording(device_manager: DeviceManager, filename: str, fname: str, task_devices: List[DeviceArgs]) -> float:
+    """Start recording all cameras for the current task.
+
+    Args:
+        device_manager: The device manager holding the running device instances.
+        filename: Full output path prefix (``local_data_dir/session/fname``).
+        fname: Unique per-run identifier, passed through to
+            :meth:`DeviceManager.start_recording_devices` for the RecordingFiles tag.
+        task_devices: Devices required by the current task.
+    """
     t0 = time()
-    device_manager.start_recording_devices(fname, task_devices)
+    device_manager.start_recording_devices(filename, fname, task_devices)
     device_manager.mbient_reconnect()  # Attempt to reconnect Mbients if disconnected
     elapsed_time = time() - t0
     return elapsed_time

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -231,7 +231,10 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
         session.next_task_start_time = None
     else:
         tsk_start_time = datetime.now().strftime("%Hh-%Mm-%Ss")
-    edf_fname = f"{session.path}/{session.session_name}_{tsk_start_time}_{task_id}.edf"
+    # Unique per-run identifier; matches the fname used in StartRecording / TransitionRecording
+    # messages to ACQ and serves as the task-run bucket key for RecordingFiles on CTR.
+    fname = f"{session.session_name}_{tsk_start_time}_{task_id}"
+    edf_fname = f"{session.path}/{fname}.edf"
 
     if task_id not in session.tasks():
         session.logger.warning(f'Task {task_id} not implemented')
@@ -251,7 +254,7 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
             load_task_media(session, task_args)
             task: Task = task_args.task_instance
             task.run(**this_task_kwargs)
-            # Signal CTR to stop LSL rec
+            # Signal CTR to stop LSL rec (no fname — non-recording tasks never post RecordingFiles)
             meta.post_message(Request(source='STM', destination='CTR',
                                       body=TaskCompletion(task_id=task_id, has_lsl_stream=False)))
             return time()
@@ -285,7 +288,7 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
                 for f in done:
                     if f.exception() is not None:
                         session.logger.error(f"Task startup failed: {f.exception()}")
-            _get_task_instance(session, task_args, edf_fname)
+            _get_task_instance(session, task_args, edf_fname, fname)
 
             this_task_kwargs["task_name"] = task_id
             this_task_kwargs["subj_id"] += "_" + tsk_start_time
@@ -298,7 +301,8 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
             t01 = time()
             stimulus_id = task_args.stim_args.stimulus_id
             if "calibration_task" in stimulus_id:  # if not calibration record with start method
-                this_task_kwargs.update({"fname": edf_fname, "instructions": calib_instructions})
+                this_task_kwargs.update({"fname": edf_fname, "run_fname": fname,
+                                         "instructions": calib_instructions})
                 calib_instructions = False  # Only show the instructions the first time
 
             events = task_args.task_instance.run(**this_task_kwargs)
@@ -311,8 +315,9 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
             stop_acq(session, task_args, next_task_id=next_rec_task)
             session.logger.info(f"stop_acq took: {time() - t_stop:.2f}")
 
-            # Signal CTR to stop LSL rec
-            meta.post_message(Request(source='STM', destination='CTR', body=TaskCompletion(task_id=task_id)))
+            # Signal CTR to stop LSL rec (fname tells CTR which bucket of RecordingFiles to snapshot)
+            meta.post_message(Request(source='STM', destination='CTR',
+                                      body=TaskCompletion(task_id=task_id, fname=fname)))
             task_completion_time = time()
             session.logger.info(f'FINISHED TASK: {task_id}')
             t_log = time()
@@ -325,11 +330,15 @@ def _perform_task(device_log_entry_dict, message, session, subj_id: str, task_lo
     return None
 
 
-def _get_task_instance(session: StmSession, task_args: TaskArgs, edf_fname):
+def _get_task_instance(session: StmSession, task_args: TaskArgs, edf_fname: str, fname: str):
     """Ensure a task instance exists and start the eyetracker if needed.
 
     If the instance was pre-constructed during ``_create_tasks``, this
     skips construction entirely and only performs eyetracker setup.
+
+    Args:
+        fname: Unique per-run identifier used to tag RecordingFiles messages
+            so CTR can bucket them against the correct task run.
     """
     global calib_instructions
 
@@ -353,7 +362,9 @@ def _get_task_instance(session: StmSession, task_args: TaskArgs, edf_fname):
             task_args.task_instance.render_image()
             created_files = session.eye_tracker.start(edf_fname)
             if created_files:
-                files_msg = RecordingFiles(files={session.eye_tracker.streamName: created_files})
+                files_msg = RecordingFiles(
+                    fname=fname,
+                    files={session.eye_tracker.streamName: created_files})
                 meta.post_message(Request(source="STM", destination="CTR", body=files_msg))
 
 def _create_tasks(message, session, task_log_entry):

--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -268,7 +268,14 @@ class SessionState:
     session: object = None  # liesl.Session, typed as object to avoid import dependency
     rec_fname: Optional[str] = None
     obs_log_id: Optional[str] = None
-    task_video_files: Dict[str, List[str]] = field(default_factory=dict)
+    # Accumulated video files keyed by fname (the unique per-run identifier:
+    # "{session_name}_{tsk_start_time}_{task_id}").  Each RecordingFiles message
+    # is tagged with its fname; TaskCompletion carries the same fname for its
+    # matching run.  This makes buffering resilient to out-of-order message
+    # arrival (ACQ's RecordingFiles for the next task arriving before STM's
+    # TaskCompletion for the current task) and to repeated runs of the same
+    # task within a session (recalibration, subject repeats, session restarts).
+    task_video_files: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
 
     # Device tracking
     frame_preview_devices: Dict[str, str] = field(default_factory=dict)
@@ -630,25 +637,31 @@ class SessionController:
 
                 elif "TaskCompletion" == message.msg_type:
                     body = message.body
-                    # Snapshot and clear video files NOW, on the message reader
-                    # thread, before the next message can be read.  This prevents
-                    # a race where RecordingFiles for the NEXT task is buffered
-                    # before the GUI thread calls stop_lsl_recording, causing the
-                    # current task to steal the next task's files.
-                    video_files = dict(self.state.task_video_files)
-                    self.state.task_video_files.clear()
+                    # Pop the bucket for THIS specific task run, keyed by fname.
+                    # RecordingFiles messages are tagged with the same fname so
+                    # files for the next task that arrive before this TaskCompletion
+                    # stay in their own bucket and are picked up by the next
+                    # TaskCompletion.  Non-recording tasks (has_lsl_stream=False)
+                    # send TaskCompletion without an fname and get an empty dict.
+                    run_fname = getattr(body, "fname", None)
+                    if run_fname is not None:
+                        video_files = self.state.task_video_files.pop(run_fname, {})
+                    else:
+                        video_files = {}
                     self.logger.debug(
-                        f"TaskCompletion msg for {body.task_id}, "
+                        f"TaskCompletion msg for {body.task_id} (fname={run_fname}), "
                         f"video_files={list(video_files.keys())}")
                     self.listener.on_task_finished(
                         body.task_id, str(body.has_lsl_stream), video_files)
 
                 elif "RecordingFiles" == message.msg_type:
                     body = message.body
+                    task_bucket = self.state.task_video_files.setdefault(body.fname, {})
                     for stream_name, filenames in body.files.items():
-                        existing = self.state.task_video_files.get(stream_name, [])
-                        self.state.task_video_files[stream_name] = existing + filenames
-                    self.logger.debug(f"Buffered recording files: {body.files}")
+                        existing = task_bucket.get(stream_name, [])
+                        task_bucket[stream_name] = existing + filenames
+                    self.logger.debug(
+                        f"Buffered recording files for fname={body.fname}: {body.files}")
 
                 elif "NoEyetracker" == message.msg_type:
                     self.listener.on_no_eyetracker(

--- a/neurobooth_os/tasks/eye_tracker_calibrate.py
+++ b/neurobooth_os/tasks/eye_tracker_calibrate.py
@@ -17,9 +17,12 @@ class Calibrate(Task_Eyetracker):
 
     def present_stimulus(self, **kwargs):
         fname = kwargs["fname"]
+        run_fname = kwargs["run_fname"]
 
         edf_basename = op.split(fname)[-1]
-        body = RecordingFiles(files={self.eye_tracker.streamName: [edf_basename]})
+        body = RecordingFiles(
+            fname=run_fname,
+            files={self.eye_tracker.streamName: [edf_basename]})
         post_message(Request(source="STM", destination="CTR", body=body))
 
         self.fname = fname

--- a/tests/pytest/test_video_files_race.py
+++ b/tests/pytest/test_video_files_race.py
@@ -1,19 +1,23 @@
-"""Test that TaskCompletion snapshots video files atomically.
+"""Test that TaskCompletion snapshots video files atomically by fname.
 
-Reproduces the race condition from GitHub issue #659 where
-RecordingFiles for the NEXT task could be buffered into
-task_video_files before the GUI thread's stop_lsl_recording had
-a chance to snapshot them, causing the current task to steal
-the next task's files.
+Reproduces the race condition from GitHub issue #659 where RecordingFiles
+for the NEXT task could be swept into the CURRENT task's snapshot.
 
-The fix moves the snapshot from stop_lsl_recording (GUI thread)
-into the TaskCompletion handler (message reader thread), making
-it atomic with respect to message processing.
+The real race is in message insertion order, not thread timing:
+ACQ's RecordingFiles for the next task can be inserted into the message
+queue BEFORE STM's TaskCompletion for the current task, because ACQ
+processes TransitionRecording faster than STM posts TaskCompletion.
+
+The fix: both RecordingFiles and TaskCompletion carry an ``fname`` field
+(``{session_name}_{tsk_start_time}_{task_id}``) that uniquely identifies
+a single task run.  task_video_files is keyed by fname, so each
+TaskCompletion pops only its own bucket.  Repeated runs of the same task
+produce different fnames (different tsk_start_time) and therefore
+different buckets.
 """
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
-from unittest.mock import MagicMock
 
 from neurobooth_os.msg.messages import RecordingFiles, TaskCompletion
 from neurobooth_os.session_controller import SessionState
@@ -27,23 +31,26 @@ class _Capture:
 
 def _simulate_message_sequence(state: SessionState, messages, capture: _Capture):
     """Replay a sequence of (msg_type, body) through the same logic as
-    _message_reader_loop, without needing DB or threading.
+    SessionController._message_reader_loop, without needing DB or threading.
     """
     for msg_type, body in messages:
         if msg_type == "RecordingFiles":
+            task_bucket = state.task_video_files.setdefault(body.fname, {})
             for stream_name, filenames in body.files.items():
-                existing = state.task_video_files.get(stream_name, [])
-                state.task_video_files[stream_name] = existing + filenames
+                existing = task_bucket.get(stream_name, [])
+                task_bucket[stream_name] = existing + filenames
 
         elif msg_type == "TaskCompletion":
-            # This is the fix: snapshot on the message reader thread
-            video_files = dict(state.task_video_files)
-            state.task_video_files.clear()
+            run_fname = getattr(body, "fname", None)
+            if run_fname is not None:
+                video_files = state.task_video_files.pop(run_fname, {})
+            else:
+                video_files = {}
             capture.calls.append((body.task_id, video_files))
 
 
 class TestVideoFilesSnapshotAtomicity:
-    """Verify that each TaskCompletion receives only its own task's files."""
+    """Verify that each TaskCompletion receives only its own task run's files."""
 
     def test_sequential_tasks_get_own_files(self):
         """Normal case: RecordingFiles arrives before TaskCompletion for
@@ -52,14 +59,18 @@ class TestVideoFilesSnapshotAtomicity:
         capture = _Capture()
 
         messages = [
-            ("RecordingFiles", RecordingFiles(files={
-                "FlirFrameIndex": ["calib_flir.avi"],
-            })),
-            ("TaskCompletion", TaskCompletion(task_id="calibration_obs_1")),
-            ("RecordingFiles", RecordingFiles(files={
-                "FlirFrameIndex": ["pursuit_flir.avi"],
-            })),
-            ("TaskCompletion", TaskCompletion(task_id="pursuit_obs")),
+            ("RecordingFiles", RecordingFiles(
+                fname="100001_2026-04-10_09h-00m-00s_calibration_obs_1",
+                files={"FlirFrameIndex": ["calib_flir.avi"]})),
+            ("TaskCompletion", TaskCompletion(
+                task_id="calibration_obs_1",
+                fname="100001_2026-04-10_09h-00m-00s_calibration_obs_1")),
+            ("RecordingFiles", RecordingFiles(
+                fname="100001_2026-04-10_09h-01m-00s_pursuit_obs",
+                files={"FlirFrameIndex": ["pursuit_flir.avi"]})),
+            ("TaskCompletion", TaskCompletion(
+                task_id="pursuit_obs",
+                fname="100001_2026-04-10_09h-01m-00s_pursuit_obs")),
         ]
 
         _simulate_message_sequence(state, messages, capture)
@@ -74,74 +85,89 @@ class TestVideoFilesSnapshotAtomicity:
         assert task_id_1 == "pursuit_obs"
         assert files_1 == {"FlirFrameIndex": ["pursuit_flir.avi"]}
 
-    def test_next_task_files_arrive_before_completion(self):
-        """Race condition scenario: RecordingFiles for the NEXT task
-        arrives before TaskCompletion for the current task.
+    def test_next_task_files_arrive_before_current_completion(self):
+        """The real race: RecordingFiles for the NEXT task is inserted into
+        the message queue BEFORE TaskCompletion for the CURRENT task.
 
-        With the old code (snapshot in stop_lsl_recording), the GUI thread
-        could see both tasks' files. With the fix, the snapshot happens
-        immediately at TaskCompletion, before the next RecordingFiles
-        can be processed.
+        This is the exact sequence observed in session 3185 (#659 regression):
+          302308  ACQ→CTR  RecordingFiles   calibration files
+          302309  STM→CTR  TaskCompletion   intro_occulo_obs_1
+          302316  STM→CTR  TaskCompletion   calibration_obs_1
+
+        With fname-keyed buckets, intro_occulo's TaskCompletion only pops its
+        own bucket, leaving calibration's files intact for the later
+        TaskCompletion.
         """
         state = SessionState()
         capture = _Capture()
 
-        # This message order reproduces the race:
-        # 1. RecordingFiles for intro_occulo (current task)
-        # 2. TaskCompletion for intro_occulo
-        # 3. RecordingFiles for calibration (NEXT task, via TransitionRecording)
-        # 4. TaskCompletion for calibration
-        #
-        # In the old code, if the GUI was slow (500ms poll), step 3 could
-        # be buffered before the GUI processed step 2's event, causing
-        # calibration's files to be swept into intro_occulo's snapshot.
+        intro_fname = "100001_2026-04-10_06h-52m-56s_intro_occulo_obs_1"
+        calib_fname = "100001_2026-04-10_06h-53m-09s_calibration_obs_1"
+
         messages = [
-            ("RecordingFiles", RecordingFiles(files={
-                "IPhoneFrameIndex": ["intro_IPhone.mov"],
-            })),
-            ("TaskCompletion", TaskCompletion(task_id="intro_occulo_obs_1")),
-            ("RecordingFiles", RecordingFiles(files={
-                "FlirFrameIndex": ["calib_flir.avi"],
-                "IPhoneFrameIndex": ["calib_IPhone.mov"],
-            })),
-            ("TaskCompletion", TaskCompletion(task_id="calibration_obs_1")),
+            # intro_occulo's own files arrive normally
+            ("RecordingFiles", RecordingFiles(
+                fname=intro_fname,
+                files={"IPhoneFrameIndex": ["intro_IPhone.mov", "intro_IPhone.json"]})),
+            # THEN calibration's files arrive (ACQ processed TransitionRecording fast)
+            ("RecordingFiles", RecordingFiles(
+                fname=calib_fname,
+                files={
+                    "FlirFrameIndex": ["calib_flir.avi"],
+                    "IPhoneFrameIndex": ["calib_IPhone.mov", "calib_IPhone.json"],
+                })),
+            # THEN intro_occulo's TaskCompletion arrives (STM was slower)
+            ("TaskCompletion", TaskCompletion(
+                task_id="intro_occulo_obs_1", fname=intro_fname)),
+            # Then calibration's EyeLink RecordingFiles and TaskCompletion
+            ("RecordingFiles", RecordingFiles(
+                fname=calib_fname,
+                files={"EyeLink": ["calib.edf"]})),
+            ("TaskCompletion", TaskCompletion(
+                task_id="calibration_obs_1", fname=calib_fname)),
         ]
 
         _simulate_message_sequence(state, messages, capture)
 
         assert len(capture.calls) == 2
 
-        # intro_occulo gets ONLY its own iPhone file
+        # intro_occulo gets ONLY its own files
         task_id_0, files_0 = capture.calls[0]
         assert task_id_0 == "intro_occulo_obs_1"
-        assert files_0 == {"IPhoneFrameIndex": ["intro_IPhone.mov"]}
-        assert "FlirFrameIndex" not in files_0  # Must NOT have calibration's FLIR
+        assert files_0 == {"IPhoneFrameIndex": ["intro_IPhone.mov", "intro_IPhone.json"]}
+        assert "FlirFrameIndex" not in files_0
 
-        # calibration gets its own FLIR and iPhone files
+        # calibration gets ALL its files — FLIR, iPhone, AND EyeLink
         task_id_1, files_1 = capture.calls[1]
         assert task_id_1 == "calibration_obs_1"
         assert files_1 == {
             "FlirFrameIndex": ["calib_flir.avi"],
-            "IPhoneFrameIndex": ["calib_IPhone.mov"],
+            "IPhoneFrameIndex": ["calib_IPhone.mov", "calib_IPhone.json"],
+            "EyeLink": ["calib.edf"],
         }
 
     def test_multiple_recording_files_per_task(self):
-        """ACQ and STM each send RecordingFiles for the same task.
-        Both should be captured in the snapshot."""
+        """ACQ and STM each send RecordingFiles for the same task run.
+        Both should accumulate in the same bucket."""
         state = SessionState()
         capture = _Capture()
 
+        calib_fname = "100001_2026-04-10_06h-53m-09s_calibration_obs_1"
+
         messages = [
             # ACQ sends camera files
-            ("RecordingFiles", RecordingFiles(files={
-                "FlirFrameIndex": ["calib_flir.avi"],
-                "IPhoneFrameIndex": ["calib_IPhone.mov"],
-            })),
+            ("RecordingFiles", RecordingFiles(
+                fname=calib_fname,
+                files={
+                    "FlirFrameIndex": ["calib_flir.avi"],
+                    "IPhoneFrameIndex": ["calib_IPhone.mov"],
+                })),
             # STM sends EyeLink file
-            ("RecordingFiles", RecordingFiles(files={
-                "EyeLink": ["calib.edf"],
-            })),
-            ("TaskCompletion", TaskCompletion(task_id="calibration_obs_1")),
+            ("RecordingFiles", RecordingFiles(
+                fname=calib_fname,
+                files={"EyeLink": ["calib.edf"]})),
+            ("TaskCompletion", TaskCompletion(
+                task_id="calibration_obs_1", fname=calib_fname)),
         ]
 
         _simulate_message_sequence(state, messages, capture)
@@ -155,39 +181,79 @@ class TestVideoFilesSnapshotAtomicity:
             "EyeLink": ["calib.edf"],
         }
 
-    def test_no_lsl_stream_task_gets_empty_files(self):
-        """Tasks with has_lsl_stream=False still snapshot (and clear)
-        video files to prevent leaking into the next task."""
+    def test_repeated_task_gets_separate_buckets(self):
+        """A task that runs twice in the same session (e.g., recalibration
+        or a restarted session) produces different fnames because
+        tsk_start_time differs. Each run's files must land in the correct
+        bucket and not leak into the other."""
         state = SessionState()
         capture = _Capture()
 
+        calib1_fname = "100001_2026-04-10_06h-53m-09s_calibration_obs_1"
+        calib2_fname = "100001_2026-04-10_06h-59m-42s_calibration_obs_1"
+
         messages = [
+            ("RecordingFiles", RecordingFiles(
+                fname=calib1_fname,
+                files={"FlirFrameIndex": ["calib1_flir.avi"]})),
             ("TaskCompletion", TaskCompletion(
-                task_id="intro_sess_obs_1", has_lsl_stream=False)),
-            ("RecordingFiles", RecordingFiles(files={
-                "FlirFrameIndex": ["calib_flir.avi"],
-            })),
-            ("TaskCompletion", TaskCompletion(task_id="calibration_obs_1")),
+                task_id="calibration_obs_1", fname=calib1_fname)),
+            ("RecordingFiles", RecordingFiles(
+                fname=calib2_fname,
+                files={"FlirFrameIndex": ["calib2_flir.avi"]})),
+            ("TaskCompletion", TaskCompletion(
+                task_id="calibration_obs_1", fname=calib2_fname)),
         ]
 
         _simulate_message_sequence(state, messages, capture)
 
         assert len(capture.calls) == 2
-        # intro_sess had no RecordingFiles
-        assert capture.calls[0] == ("intro_sess_obs_1", {})
-        # calibration still gets its files
-        assert capture.calls[1][1] == {"FlirFrameIndex": ["calib_flir.avi"]}
+        # First run gets its own file
+        assert capture.calls[0][1] == {"FlirFrameIndex": ["calib1_flir.avi"]}
+        # Second run gets its own file — not a union with the first
+        assert capture.calls[1][1] == {"FlirFrameIndex": ["calib2_flir.avi"]}
 
-    def test_state_is_clean_after_all_tasks(self):
-        """task_video_files should be empty after all tasks complete."""
+    def test_non_recording_task_completion_gets_empty_dict(self):
+        """Non-recording tasks send TaskCompletion with no fname (and
+        has_lsl_stream=False). Those get an empty dict; they don't
+        inadvertently pop any bucket."""
         state = SessionState()
         capture = _Capture()
 
+        calib_fname = "100001_2026-04-10_06h-53m-09s_calibration_obs_1"
+
         messages = [
-            ("RecordingFiles", RecordingFiles(files={"A": ["f1"]})),
-            ("TaskCompletion", TaskCompletion(task_id="task1")),
-            ("RecordingFiles", RecordingFiles(files={"B": ["f2"]})),
-            ("TaskCompletion", TaskCompletion(task_id="task2")),
+            # A non-recording task completes with no fname
+            ("TaskCompletion", TaskCompletion(
+                task_id="intro_sess_obs_1", has_lsl_stream=False)),
+            # Then calibration runs normally
+            ("RecordingFiles", RecordingFiles(
+                fname=calib_fname,
+                files={"FlirFrameIndex": ["calib_flir.avi"]})),
+            ("TaskCompletion", TaskCompletion(
+                task_id="calibration_obs_1", fname=calib_fname)),
+        ]
+
+        _simulate_message_sequence(state, messages, capture)
+
+        assert len(capture.calls) == 2
+        assert capture.calls[0] == ("intro_sess_obs_1", {})
+        assert capture.calls[1][1] == {"FlirFrameIndex": ["calib_flir.avi"]}
+
+    def test_state_is_clean_after_all_tasks(self):
+        """task_video_files should be empty after all tasks' TaskCompletions
+        have been processed."""
+        state = SessionState()
+        capture = _Capture()
+
+        fname_a = "100001_2026-04-10_09h-00m-00s_task1"
+        fname_b = "100001_2026-04-10_09h-01m-00s_task2"
+
+        messages = [
+            ("RecordingFiles", RecordingFiles(fname=fname_a, files={"A": ["f1"]})),
+            ("TaskCompletion", TaskCompletion(task_id="task1", fname=fname_a)),
+            ("RecordingFiles", RecordingFiles(fname=fname_b, files={"B": ["f2"]})),
+            ("TaskCompletion", TaskCompletion(task_id="task2", fname=fname_b)),
         ]
 
         _simulate_message_sequence(state, messages, capture)


### PR DESCRIPTION
## Summary

Fixes the #659 regression where video files were being attached to the wrong task in `log_sensor_file`. Observed on v0.81.0 session 3185: calibration_obs_1's FLIR `.avi` and iPhone `.mov`/`.json` files were absent from its row and appeared on intro_occulo_obs_1's row instead.

## Root cause

The previous fix (d0dfbf8) assumed message ordering at CTR was `[RecordingFiles current] → [TaskCompletion current] → [RecordingFiles next] → [TaskCompletion next]` and moved the snapshot of `task_video_files` to the message reader thread. In practice ACQ processes `TransitionRecording` faster than STM posts `TaskCompletion`, producing `[RecordingFiles current] → [RecordingFiles next] → [TaskCompletion current] → [TaskCompletion next]`. Session 3185 evidence:

```
302308  ACQ→CTR  RecordingFiles   calibration files
302309  STM→CTR  TaskCompletion   intro_occulo_obs_1
302316  STM→CTR  TaskCompletion   calibration_obs_1
```

The global-clear snapshot at `302309` swept calibration's iPhone files into intro_occulo's row and left calibration with none.

## Fix

Tag both `RecordingFiles` and `TaskCompletion` with the unique per-run identifier `fname = {session_name}_{tsk_start_time}_{task_id}` and bucket `task_video_files` by `fname`. CTR pops only its own bucket on `TaskCompletion`, so out-of-order arrival no longer mixes files between tasks. Repeated runs of the same `task_id` (recalibration, session restart, subject repeats) produce different `tsk_start_time` values and therefore different fnames, so their files stay separate.

## Files changed

- `neurobooth_os/msg/messages.py` — `fname` field on `RecordingFiles` (required) and `TaskCompletion` (optional)
- `neurobooth_os/iout/lsl_streamer.py` — `start_recording_devices(filename, fname, task_devices)` tags the message
- `neurobooth_os/server_acq.py` — extracts `fname` from `StartRecording`/`TransitionRecording`, preserves it alongside the full path
- `neurobooth_os/server_stm.py` — constructs `fname` in `_perform_task`, threads through to `_get_task_instance` and `TaskCompletion`
- `neurobooth_os/tasks/eye_tracker_calibrate.py` — uses `kwargs["run_fname"]` for its `RecordingFiles` tag
- `neurobooth_os/session_controller.py` — `task_video_files: Dict[fname, Dict[stream, files]]`, buckets by `body.fname`, pops by `TaskCompletion.fname`

## Test coverage

`tests/pytest/test_video_files_race.py` rewritten to match the new semantics:
- Normal sequential tasks
- **The real session 3185 race** (RecordingFiles for next task inserted before TaskCompletion for current task) — this is the regression case
- Multiple RecordingFiles contributions to the same task (ACQ + STM EyeLink)
- **Repeated task within a session** (same task_id, different tsk_start_time → separate buckets)
- Non-recording tasks (TaskCompletion with no fname → empty dict, no bucket popped)
- State cleanup after all tasks complete

All 29 tests in the pytest suite pass.

## Documentation

- `docs/arch/video_filename_tracking_current.md` — describes current mechanism and explicitly compares the resulting data to the pre-#611 system (column-by-column)
- `extras/sql/check_missing_video_files.sql` — post-deployment verification query

## What this does not fix

- #671 (clock offset bug in `file_start_time`/`file_end_time`) — independent issue
- #677 (proposed two-table redesign) — long-term architecture change, blocked by external-repo coordination

Closes #659