### PR TITLE
Show OK-to-terminate message when session stopped early

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -526,7 +526,7 @@ def gui(logger):
                     write_task_notes(state.sess_info["subject_id_date"],
                                      state.sess_info["staff_id"], task_id, "")
                     window["-frame_preview-"].update(disabled=False)
-                if task_id == state.last_task:
+                if task_id == state.last_task or state.session_stopping:
                     _session_button_state(window, disabled=True)
                     controller._join_lsl_stop()
                     write_output(window, "\nSession complete: OK to terminate", 'blue')

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -154,8 +154,13 @@ def run_stm(logger):
                     if "PrepareRequest" == current_msg_type:
                         request: PrepareRequest = message.body
                         session, task_log_entry = prepare_session(request, logger)
-                        perf_mode = os.environ.get("NB_ENABLE_PROCESS_LOG", "").upper()
-                        if perf_mode in ("P", "M", "A"):
+                        # ProcessMonitor is disabled on STM: psutil's
+                        # process iteration causes GIL contention with
+                        # PsychoPy's rendering loop, leading to
+                        # RecursionError in pyglet's GL callback chain.
+                        # Use NB_ENABLE_PROCESS_LOG on ACQ servers only.
+                        if False:  # was: perf_mode in ("P", "M", "A")
+                            perf_mode = os.environ.get("NB_ENABLE_PROCESS_LOG", "").upper()
                             log_dir = config.neurobooth_config.presentation.local_log_dir
                             if log_dir is not None:
                                 session_log_dir = os.path.join(log_dir, session.session_name)

--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -244,6 +244,7 @@ class SessionState:
     # Server tracking (was: module-level globals)
     running_servers: List[str] = field(default_factory=list)
     last_task: Optional[str] = None
+    session_stopping: bool = False
     start_pressed: bool = False
     session_prepared_count: int = 0
     auto_frame_preview_device: Optional[str] = None
@@ -431,6 +432,7 @@ class SessionController:
         """
         confirmed = self.listener.prompt_stop_confirmation(resume_on_cancel)
         if confirmed:
+            self.state.session_stopping = True
             self.listener.on_output("Stop session scheduled. Session will end after the current task.")
             self.send_cancel()
         elif resume_on_cancel:


### PR DESCRIPTION
## Summary
- Add `session_stopping` flag to `SessionState`, set when operator confirms "Stop tasks"
- GUI now shows "Session complete: OK to terminate" after the current task finishes, even if it wasn't the last scheduled task