### PR TITLE
Fix access violation during mbient reset and harden iPhone listener

### DIFF
--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -7,7 +7,6 @@ import json
 import struct
 import threading
 from datetime import datetime
-import select
 import uuid
 import logging
 import time
@@ -412,6 +411,8 @@ class IPhone(Device, CameraPreviewer):
                 bytes_to_pull = MAX_RECV
 
             packet = sock.recv(bytes_to_pull)
+            if len(packet) == 0:
+                raise IPhonePanic("iPhone connection lost: socket closed during transfer")
             bytes_received += len(packet)
             fragments.append(packet)
 
@@ -428,11 +429,16 @@ class IPhone(Device, CameraPreviewer):
         :returns: (payload, version, type, tag): Payload is either a message dictionary (tag == 0) or byte string
             (tag == 1 or tag == 2).
         """
-        ready, _, _ = select.select([self.sock], [], [], timeout_sec)
-        if not ready:
+        self.sock.settimeout(timeout_sec)
+        try:
+            first_frame = self.sock.recv(16)
+        except socket.timeout:
             raise IPhoneTimeout(f"Timeout for packet receive exceeded ({timeout_sec} sec)")
+        except OSError as e:
+            raise IPhonePanic(f"iPhone connection lost: {e}") from e
 
-        first_frame = self.sock.recv(16)
+        if len(first_frame) == 0:
+            raise IPhonePanic("iPhone connection lost: socket closed")
         version, type_, tag, payload_size = struct.unpack("!IIII", first_frame)
 
         if tag in (

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -706,6 +706,7 @@ class Mbient(Device):
                 self.stop()
 
             self.reset(timeout_sec=timeout_sec)
+            sleep(2)  # Let the native BLE stack finish tearing down before reconnecting
             self._ble_connect()
             self.setup()
 


### PR DESCRIPTION
## Summary

- Add 2s delay between mbient `reset()` and `_ble_connect()` in `reset_and_reconnect()` to let the native BLE stack finish tearing down before a new MetaWear object connects to the same MAC address. Without this, overlapping native lifetimes cause memory corruption that crashes the process.
- Replace `select.select()` with `socket.settimeout()` in iPhone `_get_packet()` so that a bad socket raises a clean `IPhonePanic` (notifying the GUI) instead of a Windows access violation. Also guard `recvall()` against infinite loop on closed socket.

## Root cause

Log analysis of session 101065 (2026-04-14) shows:
1. Mbient RH reset completes, `_ble_connect()` starts immediately
2. 3.8s later, the OLD native BLE connection fires a delayed disconnect — the native stack is still cleaning up
3. The NEW `MetaWear` object's `connect()` overlaps with the old teardown
4. Native memory corruption crashes the iPhone listener thread's `select.select()`

The `connect()` method already has a `sleep(retry_delay_sec)` after reset (line 735); `reset_and_reconnect()` was missing it.

## Test plan

- [ ] Run a session through coord_pause mbient resets — verify no crash
- [ ] Verify iPhone PANIC message appears in GUI if iPhone connection is lost
- [ ] Check mbient reset timing is acceptable (~2s longer per device)

Closes #669
Related: #674