### PR TITLE
Suppress iPhone listener panic during shutdown

### DIFF
--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -931,6 +931,10 @@ class IPhoneListeningThread(threading.Thread):
                 raise IPhonePanic('Communications Breakdown') from e
             # Simply log anything unexpected
             self.logger.error(f'iPhone: Listening loop encountered an unexpected OSError: {e}')
+        except IPhonePanic:
+            if not self._running:
+                return  # _get_packet wraps shutdown OSErrors as IPhonePanic; ignore once we've stopped
+            raise  # Propagate real panics to run() so it can disconnect
         except Exception as e:  # Simply log any other unexpected errors
             self.logger.error(f'iPhone: Listening loop encountered an unexpected error: {e}')
 


### PR DESCRIPTION
## Summary
- `IPhoneListeningThread.listen` already ignores `OSError` raised when the socket is closed during shutdown (via the `not self._running` check).
- `_get_packet` wraps shutdown-time `OSError`s (e.g. `WinError 10038`) as `IPhonePanic`, which is **not** an `OSError`, so it fell through to the generic `except Exception` handler and logged an error once per session at teardown.
- Add an `except IPhonePanic` branch before the generic one: silently return when the thread has already been stopped; otherwise re-raise so `run()` can still drive `panic()` / `disconnect()` for real panics.

## Why
Cleaner end-of-session logs. The "iPhone connection lost: [WinError 10038] An operation was attempted on something that is not a socket" error appeared in every recent session at teardown and was masking the signal/noise ratio of the error log when scanning for real iPhone issues.

## Test plan
- [ ] Run a full session and confirm no `iPhone: Listening loop encountered an unexpected error` rows at shutdown in `log_application`.
- [ ] Confirm a mid-session iPhone disconnect still triggers `IPhone.panic()` / disconnect (i.e. real panics are not swallowed).