### PR TITLE
Prevent EyeTracker shutdown crash when EyeLink failed to connect

### DIFF
--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -34,6 +34,7 @@ class EyeTracker(Device):
             raise Exception("Window should never be None.")
 
         super().__init__(device_args)
+        self.tk = None  # Set by _connect_tracker(); stays None if connection fails
         self.IP = device_args.ip
         self.sample_rate = device_args.sample_rate()
         self.msec_delay = device_args.msec_delay()
@@ -86,7 +87,8 @@ class EyeTracker(Device):
         self.recording = False
         self.paused = True
         self._connect_tracker()
-        self.state = DeviceState.CONNECTED
+        if self.tk is not None:
+            self.state = DeviceState.CONNECTED
 
     def connect(self) -> None:
         """No-op: EyeTracker connects during ``__init__`` because it needs the PsychoPy window."""
@@ -102,6 +104,7 @@ class EyeTracker(Device):
             msg = Request(source="EyeTracker", destination="CTR", body=body)
             post_message(msg)
             self.logger.error(msg_text)
+            self.state = DeviceState.DISCONNECTED
             return
 
         self.tk.setAddress(self.IP)
@@ -278,6 +281,9 @@ class EyeTracker(Device):
         self.state = DeviceState.STOPPED
 
     def close(self) -> None:
+        if self.tk is None:
+            self.state = DeviceState.DISCONNECTED
+            return  # Connection never succeeded; nothing to close
         if self.recording:
             self.stop()
         self.tk.close()


### PR DESCRIPTION
## Summary
- `EyeTracker._connect_tracker` swallows `RuntimeError` from `pylink.EyeLink(IP)`, posts a `NoEyetracker` warning to CTR, and returns — but never sets `self.tk`.
- `EyeTracker.__init__` then unconditionally set `self.state = DeviceState.CONNECTED`, so the half-initialized object looked healthy to `device_manager`.
- On shutdown (e.g. operator presses **Terminate Servers** → STM receives `TerminateServerRequest` → `session.shutdown()` → `device_manager.close_streams()` → `EyeTracker.close()`), `self.tk.close()` raised `AttributeError: 'EyeTracker' object has no attribute 'tk'`. That exception escaped `run_stm` and `main`, logged as two `CRITICAL` rows, and any devices later in the close loop never got `close()` called.

## Fix
- Initialize `self.tk = None` at the top of `__init__` so the attribute always exists.
- Only set `self.state = DeviceState.CONNECTED` when connection actually succeeded.
- Set `self.state = DeviceState.DISCONNECTED` in the RuntimeError branch (belt-and-suspenders — state is honest even if `_connect_tracker` is called directly).
- Short-circuit `close()` when `self.tk is None`.

Preserves the existing "session proceeds without EyeLink" workflow — the operator sees the `NoEyetracker` warning on CTR and decides whether to continue.

## Observed impact
Session `100898_2026-04-16` produced two `CRITICAL` rows in `log_application` at 13:25:04 UTC (the STM teardown crash described above). These were two of the three critical rows since 2026-04-10.

## Test plan
- [ ] Start a session with EyeLink powered off; confirm the `NoEyetracker` warning appears on CTR and the session proceeds.
- [ ] Press **Terminate Servers**; confirm STM exits cleanly with no `AttributeError` and no `CRITICAL` rows in `log_application`.
- [ ] Start a session with EyeLink reachable; confirm normal recording and clean shutdown still work.