### PR TITLE
Restore control buttons when Stop-session confirmation is cancelled

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -140,10 +140,7 @@ class GuiEventListener(SessionEventListener):
             title="Warning",
             location=get_popup_location(self.window))
         confirmed = response == "OK"
-        if confirmed:
-            _session_button_state(self.window, disabled=True)
-        elif resume_on_cancel:
-            _session_button_state(self.window, disabled=False)
+        _session_button_state(self.window, disabled=confirmed)
         return confirmed
 
     def prompt_shutdown_confirmation(self):
@@ -437,7 +434,6 @@ def gui(logger):
 
             elif event == "Stop tasks":
                 controller.stop_session(resume_on_cancel=False)
-                _session_button_state(window, disabled=True)
 
             elif event == "Calibrate":
                 write_output(window, "Eyetracker recalibration scheduled. "


### PR DESCRIPTION
Closes #689.

## Summary
Pressing **Stop Session** and then **Cancel** at the confirmation prompt left Stop / Pause / Calibrate greyed out, forcing **Terminate Servers** to recover.

## Root cause
The `"Stop tasks"` event handler in `gui.py:438-440` was:

```python
elif event == "Stop tasks":
    controller.stop_session(resume_on_cancel=False)
    _session_button_state(window, disabled=True)   # runs on BOTH OK and Cancel
```

That trailing disable call (added in #673 / commit 4acc090 to "prevent duplicate cancel signals") was:
- **Redundant on the OK path** — `prompt_stop_confirmation` has disabled the buttons on confirm since #595 / commit 08be599, two weeks earlier. The popup is modal, so no second Stop can be queued between click and confirm.
- **Wrong on the Cancel path** — it stamped the disabled state on top of a cancelled prompt. This is the #689 bug.

## Fix
1. Delete the redundant `_session_button_state(window, disabled=True)` from the event handler.
2. Simplify `prompt_stop_confirmation` so the cancel branch always re-enables:

```python
# Before
if confirmed:
    _session_button_state(self.window, disabled=True)
elif resume_on_cancel:
    _session_button_state(self.window, disabled=False)

# After
_session_button_state(self.window, disabled=confirmed)
```

The simpler form is idempotent and resilient to any future caller that pre-disables the buttons before invoking the prompt.

## Test plan
- [ ] Start a session and wait for the control buttons to enable on `tasks_created`.
- [ ] Click **Stop** → **Cancel** → Stop / Pause / Calibrate remain enabled, session continues.
- [ ] Click **Stop** → **OK** → buttons disable, session ends.
- [ ] Click **Pause** → **Continue tasks** → buttons remain enabled.
- [ ] Click **Pause** → **Stop tasks** → **Cancel** → buttons remain enabled, session resumes.
- [ ] Click **Pause** → **Stop tasks** → **OK** → buttons disable, session ends.

## Risk
Very low. Single-file change, 1 insertion / 5 deletions. No callers of `stop_session` outside `pause_session` and the one event handler; no behavior change on the OK path (buttons end up disabled either way).