### PR TITLE
Add log_sensor_file timing-nullable migration required by v0.86.0

### DIFF
--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -330,7 +330,7 @@ class DeviceManager:
             finally:
                 conn.close()
         except Exception as e:
-            self.logger.error(
+            self.logger.critical(
                 f"Early log_sensor_file write failed for log_task_id={log_task_id}: {e}")
 
     def stop_recording_devices(self, task_devices: List[DeviceArgs]) -> None:

--- a/neurobooth_os/server_stm.py
+++ b/neurobooth_os/server_stm.py
@@ -444,7 +444,7 @@ def _register_eyetracker_files(session: StmSession, log_task_id: str,
         finally:
             conn.close()
     except Exception as e:
-        session.logger.error(
+        session.logger.critical(
             f"Early log_sensor_file write failed for EyeTracker "
             f"(log_task_id={log_task_id}): {e}")
 

--- a/sql/migration/log_sensor_file_mod_1_v0.86.0.sql
+++ b/sql/migration/log_sensor_file_mod_1_v0.86.0.sql
@@ -1,0 +1,20 @@
+-- Modifications to neurobooth database schema associated with system enhancements
+
+-- These changes can be run at any time BEFORE the associated code changes are applied
+-- as it doesn't break anything if it's used for any earlier version and
+-- it doesn't break anything if it runs more than once. If those commitments don't hold
+-- for some future changes, a separate script will be provided.
+
+-- Each change is commented with the version it is required for
+
+-- The changes are applied in the order required.
+
+-- required for version v0.86.0 and later:
+--   ACQ writes log_sensor_file rows at device.start() time with timing
+--   fields NULL (to be populated by XDF post-processing). Without this
+--   migration the early-write INSERT fails with a NotNullViolation,
+--   falling back to split_xdf's INSERT which registers only the HDF5
+--   path and leaves the raw video/EDF files unregistered.
+ALTER TABLE IF EXISTS public.log_sensor_file
+    ALTER COLUMN file_start_time DROP NOT NULL,
+    ALTER COLUMN file_end_time   DROP NOT NULL;


### PR DESCRIPTION
## Summary
PR #686 (v0.86.0) changed ACQ to write `log_sensor_file` rows at `device.start()` time with `file_start_time` / `file_end_time` left NULL (to be populated later by XDF post-processing). The schema change required to allow those NULLs was never shipped with the PR.

## Impact
On every DB that still has the old NOT NULL constraint (staging confirmed):
- Every early-write `INSERT` from `DeviceManager._register_sensor_files` raises `psycopg2.errors.NotNullViolation`. The exception is caught and logged at ERROR level (`"Early log_sensor_file write failed for log_task_id=..."`) but **the recording continues**, so the bug is silent to the operator.
- `split_xdf.log_to_database`'s `UPDATE` finds no early row (rowcount 0) and falls through to its `INSERT` fallback, which registers **only the HDF5 path**.
- The raw `.mov`, `.avi`, `.bag`, `.edf`, `.json` files are never registered. The neurobooth-terra copy script reports `"log_sensor_file_id not found"` for every file in the session.

Observed on session **3202 (100001_2026-04-19)**: 382 `log_sensor_file` rows, all containing only the HDF5 path.

## Migration
```sql
ALTER TABLE IF EXISTS public.log_sensor_file
    ALTER COLUMN file_start_time DROP NOT NULL,
    ALTER COLUMN file_end_time   DROP NOT NULL;
```

Follows the pattern of `log_session_mod_1_v0.55.0.sql` — idempotent, safe to run before or after the code is deployed.

## Applied
- **Staging**: applied, verified `is_nullable` flipped from `NO` to `YES` on both columns.
- **Prod**: not applied by this PR — needs to be run manually by whoever has prod DB credentials.

## Release notes (for the next release, e.g. v0.86.2)
- **Required DB migration**: before/after deploying, apply `sql/migration/log_sensor_file_mod_1_v0.86.0.sql` to drop NOT NULL on `log_sensor_file.file_start_time` / `file_end_time`. Without it, raw video/EDF files are silently unregistered — operator sees nothing but downstream copy scripts emit `"log_sensor_file_id not found"` for every file.

## Follow-up
Session 3202's raw files on `/space/billnted/5/.../100001_2026-04-19/` are still orphaned in the DB. A separate backfill script (or re-run of XDF split) is needed to register them; not included here because it's a one-off data task.