### PR TITLE
Add post-session log_sensor_file validator

### DIFF
--- a/extras/perf/validate_session_files.py
+++ b/extras/perf/validate_session_files.py
@@ -1,0 +1,140 @@
+"""Validate that every raw file in a finished session has a matching
+log_sensor_file row — without copying anything or modifying the database.
+
+This mirrors the "log_sensor_file_id not found" check inside
+``neurobooth_terra.dataflow.copy_files`` (used by neurobooth-terra's
+``scripts/dataflow_copy.py``), lifted out so it can be run ad-hoc from a
+neurobooth-os checkout right after a session ends, to catch registration
+gaps before the end-of-day copy runs.
+
+Preconditions:
+    Run XDF post-processing first (``neurobooth_os/iout/split_xdf.py``).
+    Without it, log_sensor_file won't have HDF5 paths or timing populated,
+    and every .hdf5 on disk will report as "not found". XDF split is
+    idempotent — it is safe to run it early here and let the normal EOD
+    pipeline run it again:
+
+    * ``split_xdf.write_device_hdf5`` calls ``h5io.write_hdf5(..., overwrite=True)``
+    * ``split_xdf.log_to_database`` is UPDATE-then-INSERT guarded by
+      ``NOT (sensor_file_path @> ARRAY[<hdf5>])``, so a second run is a
+      no-op for rows already populated.
+
+DB connection:
+    Uses the same SSH tunnel + credentials as the other perf scripts, via
+    ``_db.get_conn()`` → ``extras/perf/db_credentials.json``.
+
+Usage:
+    python validate_session_files.py --nas-dir /path/to/NAS
+    python validate_session_files.py --nas-dir /path/to/NAS 100001_2026-04-19
+    python validate_session_files.py --nas-dir /path/to/NAS 100001_2026-04-19 100002_2026-04-19
+
+Exit codes: 0 if every trackable file is registered, 1 if any are missing.
+"""
+import argparse
+import os
+import sys
+
+from _db import get_conn
+
+
+# Mirror the exclusion list in neurobooth_terra.dataflow.copy_files:
+# these extensions are not tracked in log_sensor_file.
+UNTRACKED_EXTENSIONS = ("xdf", "txt", "csv", "jittered", "asc", "log")
+
+
+def list_session_files(session_dir: str) -> list:
+    """Walk a session directory and return every file in the form stored
+    in log_sensor_file.sensor_file_path: ``<session>/<basename>``.
+    """
+    session_name = os.path.basename(os.path.normpath(session_dir))
+    files = []
+    for root, _, basenames in os.walk(session_dir):
+        for b in basenames:
+            rel = os.path.relpath(os.path.join(root, b), session_dir)
+            rel = rel.replace(os.sep, "/")
+            files.append(f"{session_name}/{rel}")
+    return files
+
+
+_VALIDATE_SQL = """
+SELECT 1
+FROM log_sensor_file lsf
+JOIN log_task lt ON lsf.log_task_id = lt.log_task_id
+WHERE lsf.sensor_file_path @> ARRAY[%s]::text[]
+  AND lt.task_id IS NOT NULL
+LIMIT 1
+"""
+
+
+def validate_session(conn, session: str, src_dir: str) -> tuple:
+    """Validate one session. Returns ``(n_total, n_found, n_missing)``."""
+    session_dir = os.path.join(src_dir, session)
+    if not os.path.isdir(session_dir):
+        print(f"[{session}] skipped — directory not found at {session_dir}")
+        return 0, 0, 0
+
+    all_files = list_session_files(session_dir)
+    trackable = [f for f in all_files
+                 if not any(ext in f for ext in UNTRACKED_EXTENSIONS)]
+    n_skipped = len(all_files) - len(trackable)
+
+    missing = []
+    with conn.cursor() as cur:
+        for fname in trackable:
+            cur.execute(_VALIDATE_SQL, (fname,))
+            if cur.fetchone() is None:
+                missing.append(fname)
+
+    n_total = len(trackable)
+    n_found = n_total - len(missing)
+    print(f"[{session}] {n_total} trackable files, "
+          f"{n_found} registered, {len(missing)} missing "
+          f"({n_skipped} untracked-extension files skipped)")
+    for f in missing:
+        print(f"  log_sensor_file_id not found for {f}")
+    return n_total, n_found, len(missing)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--nas-dir", required=True,
+                        help="Path to the NAS root containing session folders.")
+    parser.add_argument("sessions", nargs="*",
+                        help="Session names (e.g. 100001_2026-04-19). "
+                             "If omitted, every folder under --nas-dir is checked "
+                             "(except 'old').")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.nas_dir):
+        parser.error(f"--nas-dir does not exist: {args.nas_dir}")
+
+    if args.sessions:
+        sessions = args.sessions
+    else:
+        sessions = [d for d in os.listdir(args.nas_dir)
+                    if os.path.isdir(os.path.join(args.nas_dir, d))
+                    and d != "old"]
+
+    total = found = missing = 0
+    conn, tunnel = get_conn()
+    try:
+        for session in sessions:
+            t, f, m = validate_session(conn, session, args.nas_dir)
+            total += t
+            found += f
+            missing += m
+    finally:
+        conn.close()
+        tunnel.stop()
+
+    print("=" * 60)
+    print(f"Sessions checked:      {len(sessions)}")
+    print(f"Total trackable files: {total}")
+    print(f"Registered:            {found}")
+    print(f"Missing:               {missing}")
+    return 0 if missing == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Lifts the `log_sensor_file_id not found` check out of `neurobooth_terra.dataflow.copy_files` into a standalone diagnostic at `extras/perf/validate_session_files.py`, so we can catch registration gaps immediately after a session ends — before the end-of-day copy runs.

Motivated by the v0.86.0 missing-migration incident (PR #697): session **3202 (100001_2026-04-19)** had every raw `.mov` / `.avi` / `.bag` / `.edf` / `.json` file orphaned from the DB because ACQ's early-write `INSERT` was rejected by a still-in-place `NOT NULL` constraint. The copy script surfaced it, but only hours later and only after writing incomplete records. This tool lets an operator see the same problem as soon as they hit Terminate Servers.

## What it does
- Walks a session directory (`--nas-dir <root> [session_name ...]`).
- Applies the same untracked-extension filter the copy script uses (`xdf`, `txt`, `csv`, `jittered`, `asc`, `log`).
- Queries `log_sensor_file` with the same predicate `copy_files` uses: `sensor_file_path @> ARRAY[<fname>]` filtered to `log_task.task_id IS NOT NULL`.
- Prints `log_sensor_file_id not found for <path>` for each miss, plus a one-line per-session summary and a grand total.
- Exits 0 when every trackable file is registered, 1 when any are missing — safe to wire into a CI-style "did my session register cleanly?" check.

**Reads only.** No files copied, no DB writes.

## Dependencies
Only what `extras/perf/` already requires: `psycopg2` + `sshtunnel` via the existing `_db.get_conn()` helper (credentials from `extras/perf/db_credentials.json`). No `neurobooth_terra` import.

## Preconditions
Run XDF post-processing (`neurobooth_os/iout/split_xdf.py`) before the validator, otherwise every `.hdf5` file on disk will flag as "not found". `split_xdf` is idempotent — running it early and letting the EOD pipeline re-run it is safe (detailed in the module docstring).

## Usage
```bash
python validate_session_files.py --nas-dir /space/billnted/5/neurobooth/data
python validate_session_files.py --nas-dir /space/billnted/5/neurobooth/data 100001_2026-04-19
```

## Sanity-tested
Ran the query against staging session 3202: HDF5 paths return a hit, raw `.edf` path returns nothing — matches the known orphaned state of that session.

## Follow-up
`scripts/validate_session_files.py` in `neurobooth-terra` was the first draft during this investigation; it can be deleted now that this one lives alongside the code it diagnoses.