### PR TITLE
Fix task hang when operator advances too quickly

### DIFF
--- a/neurobooth_os/tasks/task_basic.py
+++ b/neurobooth_os/tasks/task_basic.py
@@ -372,6 +372,8 @@ class BasicTask:
 
         """
 
+        clear(event)  # Flush stale keys from rapid task transitions
+
         # Instruction phase (with potential repeat)
         while True:
             self.present_instructions()

--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -269,9 +269,7 @@ def play_video(win, mov, wait_time=1, stop=True, keyList=None):
     while mov.status != visual.FINISHED:
         mov.draw()
         win.flip()
-        if event.getKeys(keyList=keyList):
-            if clock.getTime() < wait_time:
-                continue
+        if clock.getTime() >= wait_time and event.getKeys(keyList=keyList):
             if stop:
                 mov.stop()
                 mov.seek(0)


### PR DESCRIPTION
## Summary
- Fixes #681 — `intro_occulo_obs_1` hung silently when the operator pressed space rapidly before the task reached its keypress-waiting step
- **Root cause:** `play_video()` consumed buffered keypresses during the 1-second guard period (eat-and-discard), and `run()` had no initial event buffer flush — by the time `repeat_advance()` waited for input, all keypresses had been discarded
- Adds `clear(event)` at the start of `BasicTask.run()` to flush stale keys from task transitions
- Short-circuits the key check in `play_video()` so `event.getKeys()` is never called during the guard period, preventing keys from being consumed and lost

## Test plan
- [ ] Start a session with the MVP-30 collection
- [ ] Rapidly press space through intro_sess and progress_bar tasks, keep pressing while intro_occulo is loading
- [ ] Confirm intro_occulo does NOT hang — instruction video plays for at least 1 second, continue/repeat slide waits for a fresh keypress
- [ ] Verify normal operation: instruction videos can still be skipped with space after 1 second
- [ ] Verify pressing 'r' at the continue/repeat slide still repeats instructions