### PR TITLE
Reset device state before retrying device connection

### DIFF
--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -337,6 +337,14 @@ class SessionController:
 
     def prepare_devices(self, conn, collection_id: str, selected_tasks: List[str]) -> None:
         """Send PrepareRequest to all server nodes."""
+        self.state.session_prepared_count = 0
+        self.state.stream_ids = {}
+        self.state.inlets = {}
+        self.state.inlet_keys = []
+        self.state.frame_preview_devices = {}
+        self.state.auto_frame_preview_device = None
+        self.listener.on_inlet_update([])
+
         database = cfg.neurobooth_config.database.dbname
 
         for node in get_nodes():


### PR DESCRIPTION
## Summary
- Fixes #700 — after an EyeLink-not-found error and retry, the GUI showed devices from the previous attempt as already connected
- **Root cause:** `prepare_devices()` never reset `session_prepared_count`, `inlets`, `stream_ids`, or other device tracking fields before sending new `PrepareRequest` messages. Stale state from the failed attempt persisted, causing the GUI to display phantom connections and potentially triggering a premature "devices ready" signal.
- Resets all device-related `SessionState` fields and notifies the GUI (via `on_inlet_update([])`) at the top of `prepare_devices()` so each attempt starts clean

## Test plan
- [ ] Start a session where EyeLink is expected but not found (e.g., EyeLink powered off)
- [ ] Observe the EyeLink-not-found error
- [ ] Click "Connect devices" again to retry
- [ ] Confirm the GUI shows all devices as disconnected at the start of the retry — no phantom connections from the previous attempt
- [ ] Confirm devices that successfully connect on retry appear correctly
- [ ] Confirm normal first-attempt connection still works as expected