### PR TITLE
Prevent concurrent gui.py instances from corrupting message_queue

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -444,21 +444,36 @@ def _start_activation_listener(window,
 def _raise_self_window(window, logger: Optional[logging.Logger] = None) -> None:
     """From GUI-A: raise this process's own main window.
 
-    Called in response to ``-activate-request-`` on the main thread. Uses the
-    one-shot grant from GUI-B's AllowSetForegroundWindow so the direct
-    SetForegroundWindow on our own HWND is permitted.
+    Called on the main thread in response to ``-activate-request-``. The
+    approach that's actually reliable even against foreground-lock is to
+    briefly set tkinter's ``-topmost`` attribute on our own top-level window
+    and schedule it back off a moment later — that forces visible Z-order
+    (topmost renders above all non-topmost windows) regardless of whether
+    SetForegroundWindow is honored. 1-second dwell gives the operator time
+    to notice and click before the window drops back into the normal layer.
     """
+    if logger:
+        logger.info("Raise self: handling -activate-request-")
+
+    tk_ok = False
     try:
-        window.bring_to_front()
-    except Exception:
-        pass
+        window.TKroot.deiconify()          # un-minimize if minimized
+        window.TKroot.lift()               # raise in tk Z-order
+        window.TKroot.attributes('-topmost', True)
+        # Schedule un-topmost via tk after(). Runs on the main thread.
+        window.TKroot.after(1000, lambda: window.TKroot.attributes('-topmost', False))
+        window.TKroot.focus_force()
+        tk_ok = True
+    except Exception as e:
+        if logger:
+            logger.info("Raise self: tk path failed: %s", e)
 
     try:
         frame_str = window.TKroot.wm_frame()
         hwnd = int(frame_str, 0)
     except (ValueError, AttributeError, TypeError):
         if logger:
-            logger.info("Raise self: could not resolve own HWND")
+            logger.info("Raise self: could not resolve own HWND (tk_ok=%s)", tk_ok)
         return
 
     user32 = ctypes.windll.user32
@@ -471,14 +486,15 @@ def _raise_self_window(window, logger: Optional[logging.Logger] = None) -> None:
     user32.IsIconic.restype = ctypes.c_bool
 
     SW_RESTORE = 9
-    iconic = user32.IsIconic(hwnd)
+    iconic = bool(user32.IsIconic(hwnd))
     if iconic:
         user32.ShowWindow(hwnd, SW_RESTORE)
-    result = user32.SetForegroundWindow(hwnd)
+    sfw_result = bool(user32.SetForegroundWindow(hwnd))
+
     if logger:
         logger.info(
-            "Raise self: hwnd=%s iconic=%s SetForegroundWindow=%s",
-            hex(hwnd), bool(iconic), bool(result),
+            "Raise self: hwnd=%s iconic=%s SetForegroundWindow=%s tk_ok=%s",
+            hex(hwnd), iconic, sfw_result, tk_ok,
         )
 
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -194,16 +194,14 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
     user32.IsIconic.restype = ctypes.c_bool
     user32.ShowWindow.argtypes = [HWND, ctypes.c_int]
     user32.ShowWindow.restype = ctypes.c_bool
-    user32.BringWindowToTop.argtypes = [HWND]
-    user32.BringWindowToTop.restype = ctypes.c_bool
+    user32.SetWindowPos.argtypes = [
+        HWND, HWND, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_uint,
+    ]
+    user32.SetWindowPos.restype = ctypes.c_bool
     user32.SetForegroundWindow.argtypes = [HWND]
     user32.SetForegroundWindow.restype = ctypes.c_bool
-    user32.GetForegroundWindow.argtypes = []
-    user32.GetForegroundWindow.restype = HWND
-    user32.AttachThreadInput.argtypes = [DWORD, DWORD, ctypes.c_bool]
-    user32.AttachThreadInput.restype = ctypes.c_bool
-    kernel32.GetCurrentThreadId.argtypes = []
-    kernel32.GetCurrentThreadId.restype = DWORD
+    kernel32.GetConsoleWindow.argtypes = []
+    kernel32.GetConsoleWindow.restype = HWND
 
     matches = []
 
@@ -223,33 +221,38 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
     if not matches:
         return False
 
-    SW_RESTORE = 9
-    for hwnd in matches:
-        if user32.IsIconic(hwnd):
-            user32.ShowWindow(hwnd, SW_RESTORE)
-        user32.BringWindowToTop(hwnd)
-
     target = matches[-1]
 
-    # Attach to the foreground thread's input queue so SetForegroundWindow is
-    # not refused by Windows foreground-lock. Without this, when GUI-A is
-    # open but covered, the spawning cmd.exe console keeps focus instead of
-    # GUI-A rising to the top.
-    fg_hwnd = user32.GetForegroundWindow()
-    our_tid = kernel32.GetCurrentThreadId()
-    fg_tid = 0
-    attached = False
-    if fg_hwnd:
-        pid_out = DWORD(0)
-        fg_tid = user32.GetWindowThreadProcessId(fg_hwnd, ctypes.byref(pid_out))
-        if fg_tid and fg_tid != our_tid:
-            attached = bool(user32.AttachThreadInput(our_tid, fg_tid, True))
+    # Minimize our own cmd.exe console so it stops dominating the Z-order.
+    # Without this, the spawning cmd keeps foreground and covers GUI-A even
+    # after we raise it.
+    SW_MINIMIZE = 6
+    console_hwnd = kernel32.GetConsoleWindow()
+    if console_hwnd:
+        user32.ShowWindow(console_hwnd, SW_MINIMIZE)
 
-    try:
-        user32.SetForegroundWindow(target)
-    finally:
-        if attached:
-            user32.AttachThreadInput(our_tid, fg_tid, False)
+    # Restore target if minimized.
+    SW_RESTORE = 9
+    if user32.IsIconic(target):
+        user32.ShowWindow(target, SW_RESTORE)
+
+    # Force target to top of Z-order via the TOPMOST→NOTOPMOST dance.
+    # Unlike SetForegroundWindow, SetWindowPos is not refused by Windows
+    # foreground-lock — it's a pure Z-order operation. The window is lifted
+    # above everything (including other topmost windows), then dropped back
+    # into the normal layer at the top of its class.
+    HWND_TOPMOST = ctypes.c_void_p(-1)
+    HWND_NOTOPMOST = ctypes.c_void_p(-2)
+    SWP_NOMOVE = 0x2
+    SWP_NOSIZE = 0x1
+    SWP_SHOWWINDOW = 0x40
+    flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW
+    user32.SetWindowPos(target, HWND_TOPMOST, 0, 0, 0, 0, flags)
+    user32.SetWindowPos(target, HWND_NOTOPMOST, 0, 0, 0, 0, flags)
+
+    # Best-effort focus transfer; may be refused by foreground-lock, but the
+    # Z-order and console-minimize above already made GUI-A visible.
+    user32.SetForegroundWindow(target)
 
     return True
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -157,8 +157,52 @@ def _release_gui_lock(lock_state: Optional[GuiLockResult]) -> None:
             pass
 
 
+def _activate_running_gui(holder_pid: Optional[int]) -> bool:
+    """Bring the existing GUI's main window to the foreground, restoring if minimized.
+
+    Returns True if at least one window owned by ``holder_pid`` was found and
+    an activation attempt was made; False otherwise. The caller falls back to
+    a popup when this returns False (e.g., GUI-A is mid-startup and has no
+    window yet, or we have no PID to search for).
+
+    Windows' foreground-lock protection may silently refuse SetForegroundWindow
+    when the caller was not recently the foreground process. In that case, the
+    Z-order change from BringWindowToTop and the SW_RESTORE from IsIconic still
+    take effect — the window un-minimizes and rises above its siblings, even if
+    focus doesn't transfer.
+    """
+    if holder_pid is None:
+        return False
+
+    user32 = ctypes.windll.user32
+    matches = []
+
+    EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_void_p, ctypes.c_void_p)
+
+    def _enum_proc(hwnd, _lparam):
+        pid = ctypes.c_ulong(0)
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+        if pid.value == holder_pid and user32.IsWindowVisible(hwnd):
+            if user32.GetWindowTextLengthW(hwnd) > 0:
+                matches.append(hwnd)
+        return True
+
+    user32.EnumWindows(EnumWindowsProc(_enum_proc), 0)
+
+    if not matches:
+        return False
+
+    hwnd = matches[0]
+    SW_RESTORE = 9
+    if user32.IsIconic(hwnd):
+        user32.ShowWindow(hwnd, SW_RESTORE)
+    user32.BringWindowToTop(hwnd)
+    user32.SetForegroundWindow(hwnd)
+    return True
+
+
 def _show_already_running_popup() -> None:
-    """Native Windows MessageBox telling the operator the GUI is already running."""
+    """Native Windows MessageBox; fallback only when the running GUI's window cannot be found."""
     MB_ICONERROR = 0x10
     MB_TOPMOST = 0x40000
     ctypes.windll.user32.MessageBoxW(
@@ -782,12 +826,14 @@ def main():
         # the shared queue when a second instance runs while the first is alive.
         lock_state = _acquire_gui_lock()
         if not lock_state.acquired:
-            _show_already_running_popup()
+            activated = _activate_running_gui(lock_state.holder_pid)
+            if not activated:
+                _show_already_running_popup()
             logger.warning(
                 "Refusing to start: another GUI instance holds %s "
-                "(pid=%s, started=%s, reason=%s)",
+                "(pid=%s, started=%s, reason=%s, activated=%s)",
                 lock_state.path, lock_state.holder_pid,
-                lock_state.holder_started, lock_state.reason,
+                lock_state.holder_started, lock_state.reason, activated,
             )
             exit_code = 1
             return

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -175,15 +175,17 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
         return False
 
     user32 = ctypes.windll.user32
+    kernel32 = ctypes.windll.kernel32
     HWND = ctypes.c_void_p
+    DWORD = ctypes.c_ulong
 
     # Without explicit argtypes, ctypes defaults HWND args to c_int (32-bit),
     # truncating 64-bit handles on x64 Windows — calls then hit invalid
     # handles and silently no-op.
     user32.EnumWindows.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
     user32.EnumWindows.restype = ctypes.c_bool
-    user32.GetWindowThreadProcessId.argtypes = [HWND, ctypes.POINTER(ctypes.c_ulong)]
-    user32.GetWindowThreadProcessId.restype = ctypes.c_ulong
+    user32.GetWindowThreadProcessId.argtypes = [HWND, ctypes.POINTER(DWORD)]
+    user32.GetWindowThreadProcessId.restype = DWORD
     user32.IsWindowVisible.argtypes = [HWND]
     user32.IsWindowVisible.restype = ctypes.c_bool
     user32.GetWindowTextLengthW.argtypes = [HWND]
@@ -196,13 +198,19 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
     user32.BringWindowToTop.restype = ctypes.c_bool
     user32.SetForegroundWindow.argtypes = [HWND]
     user32.SetForegroundWindow.restype = ctypes.c_bool
+    user32.GetForegroundWindow.argtypes = []
+    user32.GetForegroundWindow.restype = HWND
+    user32.AttachThreadInput.argtypes = [DWORD, DWORD, ctypes.c_bool]
+    user32.AttachThreadInput.restype = ctypes.c_bool
+    kernel32.GetCurrentThreadId.argtypes = []
+    kernel32.GetCurrentThreadId.restype = DWORD
 
     matches = []
 
     EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, HWND, ctypes.c_void_p)
 
     def _enum_proc(hwnd, _lparam):
-        pid = ctypes.c_ulong(0)
+        pid = DWORD(0)
         user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
         if pid.value == holder_pid and user32.IsWindowVisible(hwnd):
             if user32.GetWindowTextLengthW(hwnd) > 0:
@@ -221,7 +229,28 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
             user32.ShowWindow(hwnd, SW_RESTORE)
         user32.BringWindowToTop(hwnd)
 
-    user32.SetForegroundWindow(matches[-1])
+    target = matches[-1]
+
+    # Attach to the foreground thread's input queue so SetForegroundWindow is
+    # not refused by Windows foreground-lock. Without this, when GUI-A is
+    # open but covered, the spawning cmd.exe console keeps focus instead of
+    # GUI-A rising to the top.
+    fg_hwnd = user32.GetForegroundWindow()
+    our_tid = kernel32.GetCurrentThreadId()
+    fg_tid = 0
+    attached = False
+    if fg_hwnd:
+        pid_out = DWORD(0)
+        fg_tid = user32.GetWindowThreadProcessId(fg_hwnd, ctypes.byref(pid_out))
+        if fg_tid and fg_tid != our_tid:
+            attached = bool(user32.AttachThreadInput(our_tid, fg_tid, True))
+
+    try:
+        user32.SetForegroundWindow(target)
+    finally:
+        if attached:
+            user32.AttachThreadInput(our_tid, fg_tid, False)
+
     return True
 
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -157,19 +157,15 @@ def _release_gui_lock(lock_state: Optional[GuiLockResult]) -> None:
             pass
 
 
-def _activate_running_gui(holder_pid: Optional[int]) -> bool:
+def _activate_running_gui(holder_pid: Optional[int], logger: Optional[logging.Logger] = None) -> bool:
     """Bring the existing GUI's main window to the foreground, restoring if minimized.
 
     Returns True if at least one window owned by ``holder_pid`` was found and
-    an activation attempt was made; False otherwise. The caller falls back to
-    a popup when this returns False (e.g., GUI-A is mid-startup and has no
-    window yet, or we have no PID to search for).
+    an activation attempt was made; False otherwise.
 
-    Windows' foreground-lock protection may silently refuse SetForegroundWindow
-    when the caller was not recently the foreground process. In that case, the
-    Z-order change from BringWindowToTop and the SW_RESTORE from IsIconic still
-    take effect — the window un-minimizes and rises above its siblings, even if
-    focus doesn't transfer.
+    Uses a kitchen-sink combination of Win32 calls because Windows' foreground-
+    lock and Z-order semantics are finicky — each call does part of the job.
+    See inline comments for what each piece does.
     """
     if holder_pid is None:
         return False
@@ -178,10 +174,9 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
     kernel32 = ctypes.windll.kernel32
     HWND = ctypes.c_void_p
     DWORD = ctypes.c_ulong
+    RECT = ctypes.c_long * 4
 
-    # Without explicit argtypes, ctypes defaults HWND args to c_int (32-bit),
-    # truncating 64-bit handles on x64 Windows — calls then hit invalid
-    # handles and silently no-op.
+    # Explicit argtypes prevent HWND truncation on x64 Windows.
     user32.EnumWindows.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
     user32.EnumWindows.restype = ctypes.c_bool
     user32.GetWindowThreadProcessId.argtypes = [HWND, ctypes.POINTER(DWORD)]
@@ -190,6 +185,12 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
     user32.IsWindowVisible.restype = ctypes.c_bool
     user32.GetWindowTextLengthW.argtypes = [HWND]
     user32.GetWindowTextLengthW.restype = ctypes.c_int
+    user32.GetWindowTextW.argtypes = [HWND, ctypes.c_wchar_p, ctypes.c_int]
+    user32.GetWindowTextW.restype = ctypes.c_int
+    user32.GetClassNameW.argtypes = [HWND, ctypes.c_wchar_p, ctypes.c_int]
+    user32.GetClassNameW.restype = ctypes.c_int
+    user32.GetWindowRect.argtypes = [HWND, ctypes.POINTER(RECT)]
+    user32.GetWindowRect.restype = ctypes.c_bool
     user32.IsIconic.argtypes = [HWND]
     user32.IsIconic.restype = ctypes.c_bool
     user32.ShowWindow.argtypes = [HWND, ctypes.c_int]
@@ -198,6 +199,8 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
         HWND, HWND, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_uint,
     ]
     user32.SetWindowPos.restype = ctypes.c_bool
+    user32.BringWindowToTop.argtypes = [HWND]
+    user32.BringWindowToTop.restype = ctypes.c_bool
     user32.SetForegroundWindow.argtypes = [HWND]
     user32.SetForegroundWindow.restype = ctypes.c_bool
     kernel32.GetConsoleWindow.argtypes = []
@@ -210,49 +213,108 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
     def _enum_proc(hwnd, _lparam):
         pid = DWORD(0)
         user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
-        if pid.value == holder_pid and user32.IsWindowVisible(hwnd):
-            if user32.GetWindowTextLengthW(hwnd) > 0:
-                matches.append(hwnd)
+        if pid.value != holder_pid or not user32.IsWindowVisible(hwnd):
+            return True
+        if user32.GetWindowTextLengthW(hwnd) <= 0:
+            return True
+        # Exclude console windows in case one is attributed to the python PID.
+        cls = ctypes.create_unicode_buffer(256)
+        user32.GetClassNameW(hwnd, cls, 256)
+        if cls.value == "ConsoleWindowClass":
+            return True
+        matches.append(hwnd)
         return True
 
     callback = EnumWindowsProc(_enum_proc)
     user32.EnumWindows(callback, 0)
 
     if not matches:
+        if logger:
+            logger.info("Activate: no matching windows for pid=%s", holder_pid)
         return False
 
-    target = matches[-1]
+    # Pick the largest-area match as the primary target (the main window is
+    # almost always the biggest visible titled window of its app).
+    target = matches[0]
+    target_area = -1
+    for hwnd in matches:
+        rect = RECT()
+        if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+            area = max(0, rect[2] - rect[0]) * max(0, rect[3] - rect[1])
+            if area > target_area:
+                target_area = area
+                target = hwnd
+
+    if logger:
+        match_info = []
+        for hwnd in matches:
+            title_buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(hwnd, title_buf, 256)
+            cls_buf = ctypes.create_unicode_buffer(256)
+            user32.GetClassNameW(hwnd, cls_buf, 256)
+            rect = RECT()
+            user32.GetWindowRect(hwnd, ctypes.byref(rect))
+            match_info.append(
+                f"hwnd={hex(hwnd) if hwnd else hwnd} "
+                f"title={title_buf.value!r} class={cls_buf.value!r} "
+                f"rect=({rect[0]},{rect[1]},{rect[2]},{rect[3]})"
+            )
+        logger.info(
+            "Activate: pid=%s matches=%d target_hwnd=%s target_area=%d",
+            holder_pid, len(matches),
+            hex(target) if target else target, target_area,
+        )
+        for m in match_info:
+            logger.info("Activate match: %s", m)
 
     # Minimize our own cmd.exe console so it stops dominating the Z-order.
-    # Without this, the spawning cmd keeps foreground and covers GUI-A even
-    # after we raise it.
     SW_MINIMIZE = 6
     console_hwnd = kernel32.GetConsoleWindow()
     if console_hwnd:
         user32.ShowWindow(console_hwnd, SW_MINIMIZE)
+        if logger:
+            logger.info("Activate: minimized own console hwnd=%s", hex(console_hwnd))
 
-    # Restore target if minimized.
+    # Restore any iconic match (harmless for non-iconic).
     SW_RESTORE = 9
-    if user32.IsIconic(target):
-        user32.ShowWindow(target, SW_RESTORE)
+    for hwnd in matches:
+        if user32.IsIconic(hwnd):
+            user32.ShowWindow(hwnd, SW_RESTORE)
 
-    # Force target to top of Z-order via the TOPMOST→NOTOPMOST dance.
-    # Unlike SetForegroundWindow, SetWindowPos is not refused by Windows
-    # foreground-lock — it's a pure Z-order operation. The window is lifted
-    # above everything (including other topmost windows), then dropped back
-    # into the normal layer at the top of its class.
+    # Force target to top of Z-order. Not subject to foreground-lock — this is
+    # a pure Z-order operation.
     HWND_TOPMOST = ctypes.c_void_p(-1)
     HWND_NOTOPMOST = ctypes.c_void_p(-2)
     SWP_NOMOVE = 0x2
     SWP_NOSIZE = 0x1
     SWP_SHOWWINDOW = 0x40
     flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW
-    user32.SetWindowPos(target, HWND_TOPMOST, 0, 0, 0, 0, flags)
-    user32.SetWindowPos(target, HWND_NOTOPMOST, 0, 0, 0, 0, flags)
+    r1 = user32.SetWindowPos(target, HWND_TOPMOST, 0, 0, 0, 0, flags)
+    r2 = user32.SetWindowPos(target, HWND_NOTOPMOST, 0, 0, 0, 0, flags)
 
-    # Best-effort focus transfer; may be refused by foreground-lock, but the
-    # Z-order and console-minimize above already made GUI-A visible.
-    user32.SetForegroundWindow(target)
+    # SwitchToThisWindow simulates Alt+Tab and is the only documented-ish API
+    # that reliably bypasses foreground-lock. Undocumented by Microsoft but
+    # present on every Windows since XP. Wrap in try/except in case it's ever
+    # removed.
+    r3 = None
+    try:
+        switch_to = user32.SwitchToThisWindow
+        switch_to.argtypes = [HWND, ctypes.c_bool]
+        switch_to.restype = None
+        switch_to(target, True)
+        r3 = "called"
+    except (AttributeError, OSError) as e:
+        r3 = f"unavailable: {e}"
+
+    r4 = user32.BringWindowToTop(target)
+    r5 = user32.SetForegroundWindow(target)
+
+    if logger:
+        logger.info(
+            "Activate: results SetWindowPos_topmost=%s SetWindowPos_notopmost=%s "
+            "SwitchToThisWindow=%s BringWindowToTop=%s SetForegroundWindow=%s",
+            r1, r2, r3, r4, r5,
+        )
 
     return True
 
@@ -882,7 +944,7 @@ def main():
         # the shared queue when a second instance runs while the first is alive.
         lock_state = _acquire_gui_lock()
         if not lock_state.acquired:
-            activated = _activate_running_gui(lock_state.holder_pid)
+            activated = _activate_running_gui(lock_state.holder_pid, logger)
             if not activated:
                 _show_already_running_popup()
             logger.warning(

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -158,166 +158,23 @@ def _release_gui_lock(lock_state: Optional[GuiLockResult]) -> None:
             pass
 
 
-def _activate_running_gui(holder_pid: Optional[int], logger: Optional[logging.Logger] = None) -> bool:
-    """Bring the existing GUI's main window to the foreground, restoring if minimized.
-
-    Returns True if at least one window owned by ``holder_pid`` was found and
-    an activation attempt was made; False otherwise.
-
-    Uses a kitchen-sink combination of Win32 calls because Windows' foreground-
-    lock and Z-order semantics are finicky — each call does part of the job.
-    See inline comments for what each piece does.
+def _minimize_own_console() -> None:
+    """Minimize this process's attached cmd.exe console so it doesn't briefly
+    dominate the Z-order after a refused second-launch. No-op if we have no
+    attached console (e.g., launched under pythonw.exe).
     """
-    if holder_pid is None:
-        return False
-
-    user32 = ctypes.windll.user32
     kernel32 = ctypes.windll.kernel32
+    user32 = ctypes.windll.user32
     HWND = ctypes.c_void_p
-    DWORD = ctypes.c_ulong
-    RECT = ctypes.c_long * 4
-
-    # Explicit argtypes prevent HWND truncation on x64 Windows.
-    user32.EnumWindows.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-    user32.EnumWindows.restype = ctypes.c_bool
-    user32.GetWindowThreadProcessId.argtypes = [HWND, ctypes.POINTER(DWORD)]
-    user32.GetWindowThreadProcessId.restype = DWORD
-    user32.IsWindowVisible.argtypes = [HWND]
-    user32.IsWindowVisible.restype = ctypes.c_bool
-    user32.GetWindowTextLengthW.argtypes = [HWND]
-    user32.GetWindowTextLengthW.restype = ctypes.c_int
-    user32.GetWindowTextW.argtypes = [HWND, ctypes.c_wchar_p, ctypes.c_int]
-    user32.GetWindowTextW.restype = ctypes.c_int
-    user32.GetClassNameW.argtypes = [HWND, ctypes.c_wchar_p, ctypes.c_int]
-    user32.GetClassNameW.restype = ctypes.c_int
-    user32.GetWindowRect.argtypes = [HWND, ctypes.POINTER(RECT)]
-    user32.GetWindowRect.restype = ctypes.c_bool
-    user32.IsIconic.argtypes = [HWND]
-    user32.IsIconic.restype = ctypes.c_bool
-    user32.ShowWindow.argtypes = [HWND, ctypes.c_int]
-    user32.ShowWindow.restype = ctypes.c_bool
-    user32.SetWindowPos.argtypes = [
-        HWND, HWND, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_uint,
-    ]
-    user32.SetWindowPos.restype = ctypes.c_bool
-    user32.BringWindowToTop.argtypes = [HWND]
-    user32.BringWindowToTop.restype = ctypes.c_bool
-    user32.SetForegroundWindow.argtypes = [HWND]
-    user32.SetForegroundWindow.restype = ctypes.c_bool
     kernel32.GetConsoleWindow.argtypes = []
     kernel32.GetConsoleWindow.restype = HWND
+    user32.ShowWindow.argtypes = [HWND, ctypes.c_int]
+    user32.ShowWindow.restype = ctypes.c_bool
 
-    matches = []
-
-    EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, HWND, ctypes.c_void_p)
-
-    def _enum_proc(hwnd, _lparam):
-        pid = DWORD(0)
-        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
-        if pid.value != holder_pid or not user32.IsWindowVisible(hwnd):
-            return True
-        if user32.GetWindowTextLengthW(hwnd) <= 0:
-            return True
-        # Exclude console windows in case one is attributed to the python PID.
-        cls = ctypes.create_unicode_buffer(256)
-        user32.GetClassNameW(hwnd, cls, 256)
-        if cls.value == "ConsoleWindowClass":
-            return True
-        matches.append(hwnd)
-        return True
-
-    callback = EnumWindowsProc(_enum_proc)
-    user32.EnumWindows(callback, 0)
-
-    if not matches:
-        if logger:
-            logger.info("Activate: no matching windows for pid=%s", holder_pid)
-        return False
-
-    # Pick the largest-area match as the primary target (the main window is
-    # almost always the biggest visible titled window of its app).
-    target = matches[0]
-    target_area = -1
-    for hwnd in matches:
-        rect = RECT()
-        if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
-            area = max(0, rect[2] - rect[0]) * max(0, rect[3] - rect[1])
-            if area > target_area:
-                target_area = area
-                target = hwnd
-
-    if logger:
-        match_info = []
-        for hwnd in matches:
-            title_buf = ctypes.create_unicode_buffer(256)
-            user32.GetWindowTextW(hwnd, title_buf, 256)
-            cls_buf = ctypes.create_unicode_buffer(256)
-            user32.GetClassNameW(hwnd, cls_buf, 256)
-            rect = RECT()
-            user32.GetWindowRect(hwnd, ctypes.byref(rect))
-            match_info.append(
-                f"hwnd={hex(hwnd) if hwnd else hwnd} "
-                f"title={title_buf.value!r} class={cls_buf.value!r} "
-                f"rect=({rect[0]},{rect[1]},{rect[2]},{rect[3]})"
-            )
-        logger.info(
-            "Activate: pid=%s matches=%d target_hwnd=%s target_area=%d",
-            holder_pid, len(matches),
-            hex(target) if target else target, target_area,
-        )
-        for m in match_info:
-            logger.info("Activate match: %s", m)
-
-    # Minimize our own cmd.exe console so it stops dominating the Z-order.
-    SW_MINIMIZE = 6
     console_hwnd = kernel32.GetConsoleWindow()
     if console_hwnd:
+        SW_MINIMIZE = 6
         user32.ShowWindow(console_hwnd, SW_MINIMIZE)
-        if logger:
-            logger.info("Activate: minimized own console hwnd=%s", hex(console_hwnd))
-
-    # Restore any iconic match (harmless for non-iconic).
-    SW_RESTORE = 9
-    for hwnd in matches:
-        if user32.IsIconic(hwnd):
-            user32.ShowWindow(hwnd, SW_RESTORE)
-
-    # Force target to top of Z-order. Not subject to foreground-lock — this is
-    # a pure Z-order operation.
-    HWND_TOPMOST = ctypes.c_void_p(-1)
-    HWND_NOTOPMOST = ctypes.c_void_p(-2)
-    SWP_NOMOVE = 0x2
-    SWP_NOSIZE = 0x1
-    SWP_SHOWWINDOW = 0x40
-    flags = SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW
-    r1 = user32.SetWindowPos(target, HWND_TOPMOST, 0, 0, 0, 0, flags)
-    r2 = user32.SetWindowPos(target, HWND_NOTOPMOST, 0, 0, 0, 0, flags)
-
-    # SwitchToThisWindow simulates Alt+Tab and is the only documented-ish API
-    # that reliably bypasses foreground-lock. Undocumented by Microsoft but
-    # present on every Windows since XP. Wrap in try/except in case it's ever
-    # removed.
-    r3 = None
-    try:
-        switch_to = user32.SwitchToThisWindow
-        switch_to.argtypes = [HWND, ctypes.c_bool]
-        switch_to.restype = None
-        switch_to(target, True)
-        r3 = "called"
-    except (AttributeError, OSError) as e:
-        r3 = f"unavailable: {e}"
-
-    r4 = user32.BringWindowToTop(target)
-    r5 = user32.SetForegroundWindow(target)
-
-    if logger:
-        logger.info(
-            "Activate: results SetWindowPos_topmost=%s SetWindowPos_notopmost=%s "
-            "SwitchToThisWindow=%s BringWindowToTop=%s SetForegroundWindow=%s",
-            r1, r2, r3, r4, r5,
-        )
-
-    return True
 
 
 def _show_already_running_popup() -> None:
@@ -1160,20 +1017,17 @@ def main():
         # the shared queue when a second instance runs while the first is alive.
         lock_state = _acquire_gui_lock()
         if not lock_state.acquired:
-            # Primary path: IPC signal so GUI-A raises its own window.
+            _minimize_own_console()
             ipc_ok = _signal_gui_to_activate(lock_state.holder_pid, logger)
-            # Fallback path: direct Z-order manipulation. Runs even when IPC
-            # succeeds, because it also minimizes our own cmd console (a UX
-            # improvement independent of Z-order) and provides a backstop if
-            # GUI-A is slow to process the IPC event.
-            activated = _activate_running_gui(lock_state.holder_pid, logger)
-            if not ipc_ok and not activated:
+            if not ipc_ok:
+                # IPC failed (GUI-A mid-startup, listener not ready, etc.).
+                # Fall back to a plain popup so the operator sees something.
                 _show_already_running_popup()
             logger.warning(
                 "Refusing to start: another GUI instance holds %s "
-                "(pid=%s, started=%s, reason=%s, ipc=%s, activated=%s)",
+                "(pid=%s, started=%s, reason=%s, ipc=%s)",
                 lock_state.path, lock_state.holder_pid,
-                lock_state.holder_started, lock_state.reason, ipc_ok, activated,
+                lock_state.holder_started, lock_state.reason, ipc_ok,
             )
             exit_code = 1
             return

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -175,9 +175,31 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
         return False
 
     user32 = ctypes.windll.user32
+    HWND = ctypes.c_void_p
+
+    # Without explicit argtypes, ctypes defaults HWND args to c_int (32-bit),
+    # truncating 64-bit handles on x64 Windows — calls then hit invalid
+    # handles and silently no-op.
+    user32.EnumWindows.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    user32.EnumWindows.restype = ctypes.c_bool
+    user32.GetWindowThreadProcessId.argtypes = [HWND, ctypes.POINTER(ctypes.c_ulong)]
+    user32.GetWindowThreadProcessId.restype = ctypes.c_ulong
+    user32.IsWindowVisible.argtypes = [HWND]
+    user32.IsWindowVisible.restype = ctypes.c_bool
+    user32.GetWindowTextLengthW.argtypes = [HWND]
+    user32.GetWindowTextLengthW.restype = ctypes.c_int
+    user32.IsIconic.argtypes = [HWND]
+    user32.IsIconic.restype = ctypes.c_bool
+    user32.ShowWindow.argtypes = [HWND, ctypes.c_int]
+    user32.ShowWindow.restype = ctypes.c_bool
+    user32.BringWindowToTop.argtypes = [HWND]
+    user32.BringWindowToTop.restype = ctypes.c_bool
+    user32.SetForegroundWindow.argtypes = [HWND]
+    user32.SetForegroundWindow.restype = ctypes.c_bool
+
     matches = []
 
-    EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_void_p, ctypes.c_void_p)
+    EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, HWND, ctypes.c_void_p)
 
     def _enum_proc(hwnd, _lparam):
         pid = ctypes.c_ulong(0)
@@ -187,17 +209,19 @@ def _activate_running_gui(holder_pid: Optional[int]) -> bool:
                 matches.append(hwnd)
         return True
 
-    user32.EnumWindows(EnumWindowsProc(_enum_proc), 0)
+    callback = EnumWindowsProc(_enum_proc)
+    user32.EnumWindows(callback, 0)
 
     if not matches:
         return False
 
-    hwnd = matches[0]
     SW_RESTORE = 9
-    if user32.IsIconic(hwnd):
-        user32.ShowWindow(hwnd, SW_RESTORE)
-    user32.BringWindowToTop(hwnd)
-    user32.SetForegroundWindow(hwnd)
+    for hwnd in matches:
+        if user32.IsIconic(hwnd):
+            user32.ShowWindow(hwnd, SW_RESTORE)
+        user32.BringWindowToTop(hwnd)
+
+    user32.SetForegroundWindow(matches[-1])
     return True
 
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -10,6 +10,7 @@ import msvcrt
 import os
 import os.path as op
 import sys
+import threading
 import time as time_mod
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -331,6 +332,156 @@ def _show_already_running_popup() -> None:
     )
 
 
+# Named kernel event used for IPC between a rejected second-launch (GUI-B) and
+# the already-running GUI (GUI-A). GUI-A holds a handle for its lifetime; GUI-B
+# opens and signals the event, which wakes GUI-A's listener thread, which posts
+# an event into the FreeSimpleGUI event loop, which restores/raises the window
+# from WITHIN GUI-A's own process. A process raising its own window is the
+# reliable workaround for Windows foreground-lock refusing cross-process
+# SetForegroundWindow — especially when combined with AllowSetForegroundWindow
+# called by GUI-B to grant GUI-A focus-change permission.
+_ACTIVATE_EVENT_NAME = "Local\\NeuroboothActivateGui"
+_GUI_ACTIVATE_EVENT_HANDLE: Optional[int] = None
+
+
+def _open_or_create_activation_event() -> Optional[int]:
+    """Create (or open) the named auto-reset event used for cross-process activation."""
+    kernel32 = ctypes.windll.kernel32
+    kernel32.CreateEventW.argtypes = [
+        ctypes.c_void_p, ctypes.c_bool, ctypes.c_bool, ctypes.c_wchar_p,
+    ]
+    kernel32.CreateEventW.restype = ctypes.c_void_p
+    # bManualReset=False (auto-reset), bInitialState=False (non-signaled).
+    handle = kernel32.CreateEventW(None, False, False, _ACTIVATE_EVENT_NAME)
+    return handle or None
+
+
+def _signal_gui_to_activate(holder_pid: Optional[int],
+                            logger: Optional[logging.Logger] = None) -> bool:
+    """From GUI-B: grant foreground authority to GUI-A and signal it to raise itself."""
+    if holder_pid is None:
+        return False
+
+    user32 = ctypes.windll.user32
+    kernel32 = ctypes.windll.kernel32
+
+    user32.AllowSetForegroundWindow.argtypes = [ctypes.c_ulong]
+    user32.AllowSetForegroundWindow.restype = ctypes.c_bool
+    kernel32.OpenEventW.argtypes = [ctypes.c_ulong, ctypes.c_bool, ctypes.c_wchar_p]
+    kernel32.OpenEventW.restype = ctypes.c_void_p
+    kernel32.SetEvent.argtypes = [ctypes.c_void_p]
+    kernel32.SetEvent.restype = ctypes.c_bool
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle.restype = ctypes.c_bool
+    kernel32.GetLastError.argtypes = []
+    kernel32.GetLastError.restype = ctypes.c_ulong
+
+    granted = bool(user32.AllowSetForegroundWindow(holder_pid))
+
+    EVENT_MODIFY_STATE = 0x0002
+    handle = kernel32.OpenEventW(EVENT_MODIFY_STATE, False, _ACTIVATE_EVENT_NAME)
+    if not handle:
+        if logger:
+            logger.info(
+                "Activate IPC: OpenEventW failed err=%s grant=%s",
+                kernel32.GetLastError(), granted,
+            )
+        return False
+
+    signaled = bool(kernel32.SetEvent(handle))
+    kernel32.CloseHandle(handle)
+
+    if logger:
+        logger.info(
+            "Activate IPC: grant=%s open=%s set=%s pid=%s",
+            granted, True, signaled, holder_pid,
+        )
+    return signaled
+
+
+def _start_activation_listener(window,
+                               logger: Optional[logging.Logger] = None) -> Optional[threading.Thread]:
+    """From GUI-A: create the activation event and spawn a listener thread.
+
+    The listener blocks on WaitForSingleObject and, when signaled by GUI-B,
+    posts ``-activate-request-`` into the FreeSimpleGUI event loop so the
+    main thread can restore and raise the window from within this process.
+    """
+    global _GUI_ACTIVATE_EVENT_HANDLE
+
+    kernel32 = ctypes.windll.kernel32
+    kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+
+    handle = _open_or_create_activation_event()
+    if handle is None:
+        if logger:
+            logger.warning("Activation event creation failed; second-launch raise disabled")
+        return None
+
+    _GUI_ACTIVATE_EVENT_HANDLE = handle
+    INFINITE = 0xFFFFFFFF
+    WAIT_OBJECT_0 = 0
+
+    def _listener():
+        while True:
+            result = kernel32.WaitForSingleObject(handle, INFINITE)
+            if result != WAIT_OBJECT_0:
+                break
+            try:
+                window.write_event_value("-activate-request-", True)
+            except Exception:
+                break  # window closed / torn down
+
+    thread = threading.Thread(target=_listener, daemon=True,
+                              name="GuiActivationListener")
+    thread.start()
+    if logger:
+        logger.info("Activation listener started")
+    return thread
+
+
+def _raise_self_window(window, logger: Optional[logging.Logger] = None) -> None:
+    """From GUI-A: raise this process's own main window.
+
+    Called in response to ``-activate-request-`` on the main thread. Uses the
+    one-shot grant from GUI-B's AllowSetForegroundWindow so the direct
+    SetForegroundWindow on our own HWND is permitted.
+    """
+    try:
+        window.bring_to_front()
+    except Exception:
+        pass
+
+    try:
+        frame_str = window.TKroot.wm_frame()
+        hwnd = int(frame_str, 0)
+    except (ValueError, AttributeError, TypeError):
+        if logger:
+            logger.info("Raise self: could not resolve own HWND")
+        return
+
+    user32 = ctypes.windll.user32
+    HWND = ctypes.c_void_p
+    user32.SetForegroundWindow.argtypes = [HWND]
+    user32.SetForegroundWindow.restype = ctypes.c_bool
+    user32.ShowWindow.argtypes = [HWND, ctypes.c_int]
+    user32.ShowWindow.restype = ctypes.c_bool
+    user32.IsIconic.argtypes = [HWND]
+    user32.IsIconic.restype = ctypes.c_bool
+
+    SW_RESTORE = 9
+    iconic = user32.IsIconic(hwnd)
+    if iconic:
+        user32.ShowWindow(hwnd, SW_RESTORE)
+    result = user32.SetForegroundWindow(hwnd)
+    if logger:
+        logger.info(
+            "Raise self: hwnd=%s iconic=%s SetForegroundWindow=%s",
+            hex(hwnd), bool(iconic), bool(result),
+        )
+
+
 def setup_log(sg_handler=None):
     logger = make_db_logger("", "")
     logger.setLevel(logging.DEBUG)
@@ -602,6 +753,7 @@ def gui(logger):
 
         window = _win_gen(_init_layout, conn)
         gui_listener.set_window(window)
+        _start_activation_listener(window, logger)
 
         plttr = stream_plotter()
         log_sess = LogSession(application_version=state.release_version, config_version=state.config_version)
@@ -611,7 +763,13 @@ def gui(logger):
             ############################################################
             # Initial Window -> Select subject, study and tasks
             ############################################################
-            if event == "study_id":
+            if event == "-activate-request-":
+                # A rejected second-launch signaled us via the IPC event.
+                # Raise our own window from this process (bypasses Windows
+                # foreground-lock in a way that cross-process calls can't).
+                _raise_self_window(window, logger)
+
+            elif event == "study_id":
                 study_id = values[event]
                 log_sess.study_id = study_id
                 _get_collections(window, study_id)
@@ -944,14 +1102,20 @@ def main():
         # the shared queue when a second instance runs while the first is alive.
         lock_state = _acquire_gui_lock()
         if not lock_state.acquired:
+            # Primary path: IPC signal so GUI-A raises its own window.
+            ipc_ok = _signal_gui_to_activate(lock_state.holder_pid, logger)
+            # Fallback path: direct Z-order manipulation. Runs even when IPC
+            # succeeds, because it also minimizes our own cmd console (a UX
+            # improvement independent of Z-order) and provides a backstop if
+            # GUI-A is slow to process the IPC event.
             activated = _activate_running_gui(lock_state.holder_pid, logger)
-            if not activated:
+            if not ipc_ok and not activated:
                 _show_already_running_popup()
             logger.warning(
                 "Refusing to start: another GUI instance holds %s "
-                "(pid=%s, started=%s, reason=%s, activated=%s)",
+                "(pid=%s, started=%s, reason=%s, ipc=%s, activated=%s)",
                 lock_state.path, lock_state.holder_pid,
-                lock_state.holder_started, lock_state.reason, activated,
+                lock_state.holder_started, lock_state.reason, ipc_ok, activated,
             )
             exit_code = 1
             return

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -3,11 +3,16 @@
 Runs RC user interface for controlling a neurobooth session
 """
 import base64
+import ctypes
+import json
+import logging
+import msvcrt
 import os
 import os.path as op
-import logging
 import sys
 import time as time_mod
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Dict, Optional, List
 
 import cv2
@@ -27,12 +32,141 @@ from neurobooth_os.iout.metadator import LogSession
 import neurobooth_os.iout.metadator as meta
 import neurobooth_os.config as cfg
 from neurobooth_os.msg.messages import FramePreviewReply
-from util.nb_types import Subject
+from neurobooth_os.util.nb_types import Subject
 from neurobooth_os.session_controller import (
     SessionState, SessionController, SessionEventListener, VersionMismatchError,
     get_nodes, resize_frame_preview,
     create_session_dict, request_frame_preview,
 )
+
+
+_GUI_LOCK_FD: Optional[int] = None
+_GUI_LOCK_PATH: Optional[str] = None
+
+
+@dataclass
+class GuiLockResult:
+    """Outcome of attempting to acquire the single-instance GUI lock."""
+    acquired: bool
+    path: str
+    holder_pid: Optional[int] = None
+    holder_started: Optional[str] = None
+    reason: Optional[str] = None
+
+
+def _gui_lock_path() -> str:
+    base = os.environ.get("NB_INSTALL", os.path.expanduser("~"))
+    return os.path.join(base, "gui.lock")
+
+
+def _read_lock_holder_info(path: str) -> "tuple[Optional[int], Optional[str]]":
+    """Read PID/start from gui.lock without contending for the lock."""
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(1)
+            raw = fh.read()
+        data = json.loads(raw.decode("utf-8"))
+        pid = data.get("pid")
+        started = data.get("started")
+        return (
+            int(pid) if pid is not None else None,
+            str(started) if started is not None else None,
+        )
+    except (OSError, ValueError, UnicodeDecodeError):
+        return (None, None)
+
+
+def _acquire_gui_lock() -> GuiLockResult:
+    """Acquire the single-instance GUI lock. Keeps the fd open for process lifetime."""
+    global _GUI_LOCK_FD, _GUI_LOCK_PATH
+
+    path = _gui_lock_path()
+
+    try:
+        fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+    except OSError as e:
+        return GuiLockResult(acquired=False, path=path, reason=f"open_failed: {e}")
+
+    holder_pid, holder_started = _read_lock_holder_info(path)
+
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+    except OSError:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return GuiLockResult(
+            acquired=False, path=path,
+            holder_pid=holder_pid, holder_started=holder_started,
+            reason="locked",
+        )
+
+    started = datetime.now(timezone.utc).isoformat()
+    try:
+        payload = json.dumps({"pid": os.getpid(), "started": started}).encode("utf-8")
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, b" " + payload)
+        os.ftruncate(fd, 1 + len(payload))
+        os.fsync(fd)
+    except OSError as e:
+        _GUI_LOCK_FD = fd
+        _GUI_LOCK_PATH = path
+        return GuiLockResult(
+            acquired=True, path=path,
+            holder_pid=os.getpid(),
+            reason=f"io_failed: {e}",
+        )
+
+    _GUI_LOCK_FD = fd
+    _GUI_LOCK_PATH = path
+    return GuiLockResult(
+        acquired=True, path=path,
+        holder_pid=os.getpid(), holder_started=started,
+    )
+
+
+def _release_gui_lock(lock_state: Optional[GuiLockResult]) -> None:
+    """Release the GUI lock held by this process. Idempotent; no-op on None / not-acquired."""
+    global _GUI_LOCK_FD, _GUI_LOCK_PATH
+
+    if lock_state is None or not lock_state.acquired:
+        return
+
+    fd = _GUI_LOCK_FD
+    path = _GUI_LOCK_PATH
+    _GUI_LOCK_FD = None
+    _GUI_LOCK_PATH = None
+
+    if fd is not None:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    if path is not None:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _show_already_running_popup() -> None:
+    """Native Windows MessageBox telling the operator the GUI is already running."""
+    MB_ICONERROR = 0x10
+    MB_TOPMOST = 0x40000
+    ctypes.windll.user32.MessageBoxW(
+        0,
+        "Neurobooth is already running. Please use the existing window.",
+        "Neurobooth",
+        MB_ICONERROR | MB_TOPMOST,
+    )
 
 
 def setup_log(sg_handler=None):
@@ -637,11 +771,29 @@ def main():
     """The starting point of Neurobooth"""
     logger = None
     exit_code = 0
+    lock_state: Optional[GuiLockResult] = None
     try:
         cfg.load_config_by_service_name("CTR")  # Load Neurobooth-OS configuration
         enable_crash_handler("CTR")
         logger = setup_log(sg_handler=Handler().setLevel(logging.DEBUG))
         logger.debug("Starting GUI")
+
+        # Must precede gui(): gui() calls meta.clear_msg_queue, which corrupts
+        # the shared queue when a second instance runs while the first is alive.
+        lock_state = _acquire_gui_lock()
+        if not lock_state.acquired:
+            _show_already_running_popup()
+            logger.warning(
+                "Refusing to start: another GUI instance holds %s "
+                "(pid=%s, started=%s, reason=%s)",
+                lock_state.path, lock_state.holder_pid,
+                lock_state.holder_started, lock_state.reason,
+            )
+            exit_code = 1
+            return
+        if lock_state.reason:
+            logger.warning("GUI lock acquired with warning: %s", lock_state.reason)
+
         gui(logger)
         logger.debug("Stopping GUI")
     except Exception as argument:
@@ -651,6 +803,7 @@ def main():
                         exc_info=sys.exc_info())
         exit_code = 1
     finally:
+        _release_gui_lock(lock_state)
         logging.shutdown()
         os._exit(exit_code)
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -362,38 +362,39 @@ def _raise_self_window(window, logger: Optional[logging.Logger] = None) -> None:
 
     sfw_result = bool(user32.SetForegroundWindow(hwnd))
 
-    # If we still aren't the foreground process, flash the taskbar icon so
-    # the operator has a clear visual indicator. FLASHW_TIMERNOFG flashes
-    # until the window becomes foreground (i.e., until the user clicks it).
-    flash_called = False
-    if not sfw_result:
-        class FLASHWINFO(ctypes.Structure):
-            _fields_ = [
-                ("cbSize", ctypes.c_uint),
-                ("hwnd", HWND),
-                ("dwFlags", ctypes.c_uint),
-                ("uCount", ctypes.c_uint),
-                ("dwTimeout", ctypes.c_uint),
-            ]
-        FLASHW_ALL = 0x3
-        FLASHW_TIMERNOFG = 0xC
-        fi = FLASHWINFO(
-            cbSize=ctypes.sizeof(FLASHWINFO),
-            hwnd=hwnd,
-            dwFlags=FLASHW_ALL | FLASHW_TIMERNOFG,
-            uCount=0,
-            dwTimeout=0,
-        )
-        user32.FlashWindowEx.argtypes = [ctypes.POINTER(FLASHWINFO)]
-        user32.FlashWindowEx.restype = ctypes.c_bool
-        user32.FlashWindowEx(ctypes.byref(fi))
-        flash_called = True
+    # Flash the taskbar unconditionally. FlashWindowEx is a no-op when the
+    # window already has focus, so calling it regardless of sfw_result costs
+    # nothing on the success path and gives the operator an attention
+    # indicator when Windows silently revoked the foreground transfer
+    # (sfw_result=True is a point-in-time ack, not a durable guarantee).
+    # FLASHW_TIMERNOFG keeps the taskbar button highlighted until the window
+    # comes to the foreground (i.e., until the user clicks it).
+    class FLASHWINFO(ctypes.Structure):
+        _fields_ = [
+            ("cbSize", ctypes.c_uint),
+            ("hwnd", HWND),
+            ("dwFlags", ctypes.c_uint),
+            ("uCount", ctypes.c_uint),
+            ("dwTimeout", ctypes.c_uint),
+        ]
+    FLASHW_ALL = 0x3
+    FLASHW_TIMERNOFG = 0xC
+    fi = FLASHWINFO(
+        cbSize=ctypes.sizeof(FLASHWINFO),
+        hwnd=hwnd,
+        dwFlags=FLASHW_ALL | FLASHW_TIMERNOFG,
+        uCount=0,
+        dwTimeout=0,
+    )
+    user32.FlashWindowEx.argtypes = [ctypes.POINTER(FLASHWINFO)]
+    user32.FlashWindowEx.restype = ctypes.c_bool
+    user32.FlashWindowEx(ctypes.byref(fi))
 
     if logger:
         logger.info(
             "Raise self: hwnd=%s iconic=%s SwitchToThisWindow=%s "
-            "SetForegroundWindow=%s FlashWindowEx=%s tk_ok=%s",
-            hex(hwnd), iconic, switch_called, sfw_result, flash_called, tk_ok,
+            "SetForegroundWindow=%s tk_ok=%s",
+            hex(hwnd), iconic, switch_called, sfw_result, tk_ok,
         )
 
 

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -489,12 +489,54 @@ def _raise_self_window(window, logger: Optional[logging.Logger] = None) -> None:
     iconic = bool(user32.IsIconic(hwnd))
     if iconic:
         user32.ShowWindow(hwnd, SW_RESTORE)
+
+    # SwitchToThisWindow simulates Alt+Tab and tends to bypass foreground-lock
+    # more reliably than SetForegroundWindow alone. Undocumented by Microsoft
+    # but present on every Windows since XP.
+    switch_called = False
+    try:
+        switch_to = user32.SwitchToThisWindow
+        switch_to.argtypes = [HWND, ctypes.c_bool]
+        switch_to.restype = None
+        switch_to(hwnd, True)
+        switch_called = True
+    except (AttributeError, OSError):
+        pass
+
     sfw_result = bool(user32.SetForegroundWindow(hwnd))
+
+    # If we still aren't the foreground process, flash the taskbar icon so
+    # the operator has a clear visual indicator. FLASHW_TIMERNOFG flashes
+    # until the window becomes foreground (i.e., until the user clicks it).
+    flash_called = False
+    if not sfw_result:
+        class FLASHWINFO(ctypes.Structure):
+            _fields_ = [
+                ("cbSize", ctypes.c_uint),
+                ("hwnd", HWND),
+                ("dwFlags", ctypes.c_uint),
+                ("uCount", ctypes.c_uint),
+                ("dwTimeout", ctypes.c_uint),
+            ]
+        FLASHW_ALL = 0x3
+        FLASHW_TIMERNOFG = 0xC
+        fi = FLASHWINFO(
+            cbSize=ctypes.sizeof(FLASHWINFO),
+            hwnd=hwnd,
+            dwFlags=FLASHW_ALL | FLASHW_TIMERNOFG,
+            uCount=0,
+            dwTimeout=0,
+        )
+        user32.FlashWindowEx.argtypes = [ctypes.POINTER(FLASHWINFO)]
+        user32.FlashWindowEx.restype = ctypes.c_bool
+        user32.FlashWindowEx(ctypes.byref(fi))
+        flash_called = True
 
     if logger:
         logger.info(
-            "Raise self: hwnd=%s iconic=%s SetForegroundWindow=%s tk_ok=%s",
-            hex(hwnd), iconic, sfw_result, tk_ok,
+            "Raise self: hwnd=%s iconic=%s SwitchToThisWindow=%s "
+            "SetForegroundWindow=%s FlashWindowEx=%s tk_ok=%s",
+            hex(hwnd), iconic, switch_called, sfw_result, flash_called, tk_ok,
         )
 
 

--- a/tests/pytest/test_gui_single_instance.py
+++ b/tests/pytest/test_gui_single_instance.py
@@ -183,22 +183,7 @@ def test_acquire_returns_open_failed_on_permission_error(lock_env, monkeypatch):
     assert "denied" in result.reason
 
 
-def test_activate_running_gui_returns_false_on_none_pid():
+def test_signal_gui_to_activate_returns_false_on_none_pid():
     import neurobooth_os.gui as gui_mod
 
-    assert gui_mod._activate_running_gui(None) is False
-
-
-def test_activate_running_gui_returns_false_when_no_window_matches():
-    """PID exists but has no visible top-level windows — e.g., a background process.
-
-    Uses os.getpid() for the current test process, which (running under pytest)
-    has no top-level FreeSimpleGUI window — so the PID filter finds no matches.
-    """
-    import neurobooth_os.gui as gui_mod
-
-    # A PID that is almost certainly not hosting a visible titled window
-    # owned by a real Windows GUI app. Uses a high arbitrary PID unlikely
-    # to exist; function short-circuits once EnumWindows finishes with no
-    # matches.
-    assert gui_mod._activate_running_gui(2**31 - 1) is False
+    assert gui_mod._signal_gui_to_activate(None) is False

--- a/tests/pytest/test_gui_single_instance.py
+++ b/tests/pytest/test_gui_single_instance.py
@@ -181,3 +181,24 @@ def test_acquire_returns_open_failed_on_permission_error(lock_env, monkeypatch):
     assert result.reason is not None
     assert result.reason.startswith("open_failed:")
     assert "denied" in result.reason
+
+
+def test_activate_running_gui_returns_false_on_none_pid():
+    import neurobooth_os.gui as gui_mod
+
+    assert gui_mod._activate_running_gui(None) is False
+
+
+def test_activate_running_gui_returns_false_when_no_window_matches():
+    """PID exists but has no visible top-level windows — e.g., a background process.
+
+    Uses os.getpid() for the current test process, which (running under pytest)
+    has no top-level FreeSimpleGUI window — so the PID filter finds no matches.
+    """
+    import neurobooth_os.gui as gui_mod
+
+    # A PID that is almost certainly not hosting a visible titled window
+    # owned by a real Windows GUI app. Uses a high arbitrary PID unlikely
+    # to exist; function short-circuits once EnumWindows finishes with no
+    # matches.
+    assert gui_mod._activate_running_gui(2**31 - 1) is False

--- a/tests/pytest/test_gui_single_instance.py
+++ b/tests/pytest/test_gui_single_instance.py
@@ -1,0 +1,183 @@
+"""Tests for the single-instance GUI lock (issue #510).
+
+The cross-process race test uses a **subprocess**, NOT a same-process
+second acquire. Windows byte-range lock semantics for two handles in the
+same process are historically documented as "undefined" by Microsoft and
+differ across Windows editions. The real-world scenario the lock protects
+against is always two separate processes (double-click race), so the test
+exercises that path directly. Do not simplify this to a same-process
+re-acquire — it can appear to pass on one Windows SKU and fail on another.
+"""
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="msvcrt byte-range locks are Windows-only",
+)
+
+
+@pytest.fixture
+def lock_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("NB_INSTALL", str(tmp_path))
+    import neurobooth_os.gui as gui_mod
+    monkeypatch.setattr(gui_mod, "_GUI_LOCK_FD", None)
+    monkeypatch.setattr(gui_mod, "_GUI_LOCK_PATH", None)
+    yield tmp_path
+    if gui_mod._GUI_LOCK_FD is not None:
+        try:
+            os.close(gui_mod._GUI_LOCK_FD)
+        except OSError:
+            pass
+
+
+def test_acquire_writes_lock_file_and_locks_it(lock_env):
+    import neurobooth_os.gui as gui_mod
+
+    result = gui_mod._acquire_gui_lock()
+
+    try:
+        assert result.acquired is True
+        assert result.path == str(lock_env / "gui.lock")
+        assert result.holder_pid == os.getpid()
+        assert result.reason is None
+
+        lock_path = lock_env / "gui.lock"
+        assert lock_path.exists()
+
+        with open(lock_path, "rb") as f:
+            f.seek(1)
+            payload = json.loads(f.read().decode("utf-8"))
+        assert payload["pid"] == os.getpid()
+        datetime.fromisoformat(payload["started"])
+    finally:
+        gui_mod._release_gui_lock(result)
+
+
+def test_second_acquire_is_refused_via_subprocess(lock_env):
+    import neurobooth_os.gui as gui_mod
+
+    helper = (
+        'import os, msvcrt, json, sys\n'
+        'from datetime import datetime, timezone\n'
+        'path = os.path.join(os.environ["NB_INSTALL"], "gui.lock")\n'
+        'fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)\n'
+        'os.lseek(fd, 0, os.SEEK_SET)\n'
+        'msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)\n'
+        'payload = json.dumps({"pid": os.getpid(), '
+        '"started": datetime.now(timezone.utc).isoformat()}).encode("utf-8")\n'
+        'os.lseek(fd, 0, os.SEEK_SET)\n'
+        'os.write(fd, b" " + payload)\n'
+        'os.ftruncate(fd, 1 + len(payload))\n'
+        'os.fsync(fd)\n'
+        'print("ACQUIRED", flush=True)\n'
+        'sys.stdin.read()\n'
+    )
+
+    env = os.environ.copy()
+    env["NB_INSTALL"] = str(lock_env)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", helper],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        first_line = proc.stdout.readline().strip()
+        assert first_line == "ACQUIRED", (
+            f"subprocess did not acquire lock (got {first_line!r}); "
+            f"stderr: {proc.stderr.read()!r}"
+        )
+
+        result = gui_mod._acquire_gui_lock()
+        assert result.acquired is False
+        assert result.reason == "locked"
+        assert result.holder_pid == proc.pid
+        assert result.holder_started is not None
+        datetime.fromisoformat(result.holder_started)
+    finally:
+        try:
+            proc.stdin.close()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+def test_stale_lock_file_allows_reacquire(lock_env):
+    import neurobooth_os.gui as gui_mod
+
+    lock_path = lock_env / "gui.lock"
+    stale_payload = json.dumps(
+        {"pid": 99999, "started": "2020-01-01T00:00:00+00:00"}
+    ).encode("utf-8")
+    lock_path.write_bytes(b" " + stale_payload)
+
+    result = gui_mod._acquire_gui_lock()
+
+    try:
+        assert result.acquired is True
+        assert result.holder_pid == os.getpid()
+
+        with open(lock_path, "rb") as f:
+            f.seek(1)
+            payload = json.loads(f.read().decode("utf-8"))
+        assert payload["pid"] == os.getpid()
+        assert payload["pid"] != 99999
+    finally:
+        gui_mod._release_gui_lock(result)
+
+
+def test_release_unlinks_file_and_clears_state(lock_env):
+    import neurobooth_os.gui as gui_mod
+
+    result = gui_mod._acquire_gui_lock()
+    assert result.acquired is True
+    lock_path = lock_env / "gui.lock"
+    assert lock_path.exists()
+
+    gui_mod._release_gui_lock(result)
+
+    assert not lock_path.exists()
+    assert gui_mod._GUI_LOCK_FD is None
+    assert gui_mod._GUI_LOCK_PATH is None
+
+
+def test_release_is_idempotent_and_noop_on_failed_acquire(lock_env):
+    import neurobooth_os.gui as gui_mod
+
+    gui_mod._release_gui_lock(None)
+
+    gui_mod._release_gui_lock(
+        gui_mod.GuiLockResult(acquired=False, path="doesnotexist")
+    )
+
+    result = gui_mod._acquire_gui_lock()
+    gui_mod._release_gui_lock(result)
+    gui_mod._release_gui_lock(result)
+
+
+def test_acquire_returns_open_failed_on_permission_error(lock_env, monkeypatch):
+    import neurobooth_os.gui as gui_mod
+
+    monkeypatch.setattr(
+        "os.open",
+        MagicMock(side_effect=PermissionError("denied")),
+    )
+
+    result = gui_mod._acquire_gui_lock()
+
+    assert result.acquired is False
+    assert result.reason is not None
+    assert result.reason.startswith("open_failed:")
+    assert "denied" in result.reason


### PR DESCRIPTION
## Summary

A second `gui.py` launched while the first is still running (typically from a fast double-click on the desktop shortcut) calls `clear_msg_queue` at startup, wiping the first GUI's in-flight messages and deadlocking ACQ/STM waiting on replies that never arrive.

### Core fix: single-instance lock (issue #510)

- Acquire a Windows `msvcrt` byte-range lock on `%NB_INSTALL%/gui.lock` **before** `gui()` runs, gating the destructive `clear_msg_queue` call.
- OS releases the lock on process termination (clean exit, crash, Task Manager kill, power loss) — stale lock files require no cleanup code.
- Does **not** kill the first GUI, which would orphan remote ACQ/STM holding hardware and half-written session files.

### UX: activate the existing GUI

When a second launch is refused, instead of just showing a popup (which could end up hidden behind cmd consoles), the code:

- Minimizes the spawning cmd console so it doesn't dominate the Z-order.
- Signals the already-running GUI via a named kernel event (IPC) and grants it focus-change permission via `AllowSetForegroundWindow`.
- The running GUI listens on the event in a daemon thread; when signaled, it raises **its own** main window using tkinter's `-topmost` attribute briefly, followed by `SwitchToThisWindow` + `SetForegroundWindow`. Falls back to `FlashWindowEx` to flash the taskbar icon when foreground transfer is refused.
- If IPC itself fails (e.g., the other GUI is mid-startup with no listener yet), a native Windows `MessageBox` is shown as a fallback.

Windows foreground-lock occasionally revokes focus-change permission under specific timing/input patterns, so the activation is best-effort by design. In that rare case the taskbar still shows the GUI — the operator can click the taskbar entry.

### Incidental

Fixes a pre-existing import in `gui.py` (`from util.nb_types` → `from neurobooth_os.util.nb_types`) that only resolved when the file was run as a script, not when imported as a module — it blocked the new tests.

## Test plan

- [x] `pytest tests/pytest/test_gui_single_instance.py -v` — 7/7 passing (includes a cross-process subprocess race test; same-process locking semantics on Windows are undefined and must not be used)
- [x] `pytest tests/pytest/ -v` full suite — 33/33 passing, no regressions
- [x] Two-cmd test on CTR — CMD-1 starts normally; CMD-2 raises CMD-1's GUI and exits 1
- [x] Double-click shortcut test on CTR — existing GUI comes forward on repeat launches
- [ ] Stale-file test on CTR — kill GUI via Task Manager, restart succeeds cleanly, `gui.lock` payload updates to new PID
- [ ] DB-untouched test on CTR — sentinel rows in `message_queue` still present after a rejected second GUI

Closes #510.