### PR TITLE
Pluggable device registration (#696)

### DIFF
--- a/neurobooth_os/iout/camera_intel.py
+++ b/neurobooth_os/iout/camera_intel.py
@@ -30,7 +30,7 @@ class RealSenseException(Exception):
 
 class VidRec_Intel(Device):
 
-    capabilities = DeviceCapability.RECORD
+    capabilities = DeviceCapability.RECORD | DeviceCapability.RECORD_PER_TASK
 
     def __init__(
         self,

--- a/neurobooth_os/iout/device.py
+++ b/neurobooth_os/iout/device.py
@@ -34,6 +34,7 @@ class DeviceCapability(Flag):
     WEARABLE = auto()         # BLE/wireless; may disconnect unexpectedly, supports reconnect
     CALIBRATABLE = auto()     # Supports calibration (eyelink)
     RECORD_PER_TASK = auto()  # Recording is driven by the per-task lifecycle (cameras)
+    RESETTABLE = auto()       # Participates in operator-triggered reset (mbient)
 
 
 class DeviceState(Enum):

--- a/neurobooth_os/iout/device.py
+++ b/neurobooth_os/iout/device.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from enum import Enum, Flag, auto
-from typing import ByteString, ClassVar, List, Optional
+from typing import Any, ByteString, ClassVar, List, Mapping, Optional
 
 from neurobooth_os.iout.stim_param_reader import DeviceArgs
 from neurobooth_os.log_manager import APP_LOG_NAME
@@ -16,12 +16,13 @@ class CameraPreviewException(Exception):
 
 
 class CameraPreviewer:
-    def frame_preview(self) -> ByteString:
-        """
-        Retrieve a single frame from a camera.
+    """Deprecated: retained only as a transitional shim.
 
-        :returns: The raw data of the image/frame, or an empty byte string if an error occurs.
-        """
+    New devices should declare ``CAMERA_PREVIEW`` in their ``capabilities`` and
+    override ``Device.frame_preview`` directly. This class is scheduled for
+    removal once all camera devices are migrated; see issue #696.
+    """
+    def frame_preview(self) -> ByteString:
         raise NotImplementedError()
 
 
@@ -32,6 +33,7 @@ class DeviceCapability(Flag):
     CAMERA_PREVIEW = auto()   # Supports frame_preview()
     WEARABLE = auto()         # BLE/wireless; may disconnect unexpectedly, supports reconnect
     CALIBRATABLE = auto()     # Supports calibration (eyelink)
+    RECORD_PER_TASK = auto()  # Recording is driven by the per-task lifecycle (cameras)
 
 
 class DeviceState(Enum):
@@ -131,3 +133,58 @@ class Device(ABC):
             True if the device has the capability.
         """
         return cap in self.capabilities
+
+    def bring_up(self, context: Mapping[str, Any]) -> Optional["Device"]:
+        """Perform the full startup handshake and return self, or None to skip.
+
+        Default: call ``connect()`` and, for pure STREAM devices, ``start()``.
+        Devices with the ``RECORD`` capability defer ``start()`` to
+        ``DeviceManager.start_recording_devices`` (per-task). Devices with
+        optional connect (wearables, iPhone) or that depend on items in
+        ``context`` (e.g. a PsychoPy window) should override this method.
+
+        Args:
+            context: Mapping of shared objects that some devices may need
+                during start-up. The canonical key is ``"psychopy_window"``
+                (used by EyeTracker); devices that do not need anything from
+                context ignore the argument.
+
+        Returns:
+            ``self`` on success, or ``None`` if the device should be skipped
+            (e.g. a wearable that failed to connect).
+        """
+        self.connect()
+        if (self.has_capability(DeviceCapability.STREAM)
+                and not self.has_capability(DeviceCapability.RECORD)):
+            self.start()
+        return self
+
+    def on_task_reconnect(self) -> None:
+        """Hook called by DeviceManager before each task starts.
+
+        No-op by default. Override for wearables or other devices whose
+        connection may have dropped between tasks.
+        """
+        pass
+
+    def on_session_reset(self) -> bool:
+        """Hook called when the operator requests a device reset.
+
+        No-op by default; returns ``True`` to indicate nothing needed doing.
+        Override for devices that support an operator-driven reset
+        (e.g. Mbient ``reset_and_reconnect``).
+
+        Returns:
+            True on success, False otherwise.
+        """
+        return True
+
+    def frame_preview(self) -> ByteString:
+        """Return a single preview frame as encoded image bytes.
+
+        Default implementation raises; override on devices that declare the
+        ``CAMERA_PREVIEW`` capability.
+        """
+        raise CameraPreviewException(
+            f"Device {self.device_id} does not support frame preview."
+        )

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -1,7 +1,7 @@
 import os.path as op
 import threading
 import logging
-from typing import List, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple
 
 import numpy as np
 
@@ -30,9 +30,6 @@ class EyeTracker(Device):
         win=None,
         with_lsl: bool = True,
     ) -> None:
-        if win is None:
-            raise Exception("Window should never be None.")
-
         super().__init__(device_args)
         self.tk = None  # Set by _connect_tracker(); stays None if connection fails
         self.IP = device_args.ip
@@ -42,12 +39,39 @@ class EyeTracker(Device):
         self.validation_area_proportion: Tuple[float, float] = device_args.validation_area_proportion()
         self.streamName = "EyeLink"
         self.with_lsl = with_lsl
-        mon = monitors.getAllMonitors()[0]
-        self.monitor_width, self.monitor_height = monitors.Monitor(mon).getSizePix()
         self.calibration_type = device_args.calibration_type()
         self.win = win
 
-        # Setup outlet stream info
+        self.monitor_width: Optional[int] = None
+        self.monitor_height: Optional[int] = None
+        self.stream_info = None
+
+        self.calibrated = True
+        self.recording = False
+        self.paused = True
+
+        if self.win is not None:
+            self.connect()
+
+    def bring_up(self, context: Mapping[str, Any]) -> Optional[Device]:
+        """Pull the PsychoPy window from context, then run the standard connect."""
+        self.win = context["psychopy_window"]
+        self.connect()
+        return self
+
+    def connect(self) -> None:
+        """Create the LSL outlet and connect to the EyeLink tracker.
+
+        Requires ``self.win`` to be set (via ``__init__`` or ``bring_up``).
+        """
+        if self.win is None:
+            raise RuntimeError(
+                "EyeTracker.connect() requires a PsychoPy window. "
+                "Pass win= to __init__ or supply psychopy_window in bring_up context."
+            )
+        mon = monitors.getAllMonitors()[0]
+        self.monitor_width, self.monitor_height = monitors.Monitor(mon).getSizePix()
+
         self.stream_info = set_stream_description(
             stream_info=StreamInfo(
                 "EyeLink", "Gaze", 13, self.sample_rate, "double64", self.outlet_id
@@ -83,16 +107,9 @@ class EyeTracker(Device):
 
         self.logger.debug(f'EyeLink: sample_rate={str(self.sample_rate)}')
 
-        self.calibrated = True
-        self.recording = False
-        self.paused = True
         self._connect_tracker()
         if self.tk is not None:
             self.state = DeviceState.CONNECTED
-
-    def connect(self) -> None:
-        """No-op: EyeTracker connects during ``__init__`` because it needs the PsychoPy window."""
-        pass
 
     def _connect_tracker(self):
         try:

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -16,7 +16,7 @@ from neurobooth_os.iout.stim_param_reader import FlirDeviceArgs
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.log_manager import APP_LOG_NAME
 from neurobooth_os.msg.messages import DeviceInitialization, Request
-from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState, CameraPreviewer
+from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 import neurobooth_os.iout.metadator as meta
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
@@ -27,9 +27,13 @@ class FlirException(Exception):
         super().__init__(*args, **kwargs)
 
 
-class VidRec_Flir(Device, CameraPreviewer):
+class VidRec_Flir(Device):
 
-    capabilities = DeviceCapability.RECORD | DeviceCapability.CAMERA_PREVIEW
+    capabilities = (
+        DeviceCapability.RECORD
+        | DeviceCapability.RECORD_PER_TASK
+        | DeviceCapability.CAMERA_PREVIEW
+    )
 
     def __init__(
         self,

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -10,12 +10,12 @@ from datetime import datetime
 import uuid
 import logging
 import time
-from typing import Dict, List, Tuple, Any, Optional, Union, ByteString
+from typing import Dict, List, Tuple, Any, Mapping, Optional, Union, ByteString
 from enum import IntEnum
 from hashlib import md5
 from base64 import b64decode
 
-from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState, CameraPreviewer
+from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.metadator import post_message, read_sensors
 from neurobooth_os.iout.stim_param_reader import IPhoneDeviceArgs
 from neurobooth_os.iout.usbmux import USBMux
@@ -93,7 +93,7 @@ def _handle_panic(func):
     return wrapper_panic
 
 
-class IPhone(Device, CameraPreviewer):
+class IPhone(Device):
     """
     Handles interactions with an iPhone device running the Neurobooth app.
     Intended Lifecycle:
@@ -104,7 +104,11 @@ class IPhone(Device, CameraPreviewer):
     At any point during the lifecycle a panic may occur if an error is encountered. This will disconnect the iPhone.
     """
 
-    capabilities = DeviceCapability.RECORD | DeviceCapability.CAMERA_PREVIEW
+    capabilities = (
+        DeviceCapability.RECORD
+        | DeviceCapability.RECORD_PER_TASK
+        | DeviceCapability.CAMERA_PREVIEW
+    )
 
     # Constants for interfacing with the app
     TYPE_MESSAGE = 101
@@ -518,6 +522,10 @@ class IPhone(Device, CameraPreviewer):
 
         if DEBUG_LOGGING:
             self.logger.debug(f'LSL Push: {lsl_sample}')
+
+    def bring_up(self, context: Mapping[str, Any]) -> Optional[Device]:
+        """Connect to the iPhone; return ``None`` if the handshake fails."""
+        return self if self.connect() else None
 
     def connect(self) -> bool:
         """

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -193,7 +193,7 @@ class IPhone(Device):
     MESSAGE_TYPES = set(MESSAGE_TYPES)
     MESSAGE_KEYS = {"MessageType", "SessionID", "TimeStamp", "Message"}
 
-    def __init__(self, name, sess_id="", mock=False, device_args: IPhoneDeviceArgs = None, enable_timeout_exceptions=False):
+    def __init__(self, name="IPhoneFrameIndex", sess_id="", mock=False, device_args: IPhoneDeviceArgs = None, enable_timeout_exceptions=False):
         super().__init__(device_args)
         self.connected = False
         self.tag = 0

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -317,15 +317,19 @@ class DeviceManager:
                 stream.on_task_reconnect()
 
     def reset_devices(self) -> Dict[str, bool]:
-        """Call ``on_session_reset`` on every Device-backed stream.
+        """Call ``on_session_reset`` on devices that declare ``RESETTABLE``.
+
+        Devices opt in via the ``RESETTABLE`` capability so the operator's
+        "Reset" result only lists devices that actually performed a reset
+        (today: Mbients). Other devices inherit the ``on_session_reset``
+        default but are never invoked.
 
         Returns:
-            Mapping of device name to whether the reset succeeded (defaults to
-            ``True`` for devices without an override).
+            Mapping of device name to whether the reset succeeded.
         """
         results: Dict[str, bool] = {}
         for name, stream in self.streams.items():
-            if self._is_device(stream):
+            if self._is_device(stream) and stream.has_capability(DeviceCapability.RESETTABLE):
                 results[name] = stream.on_session_reset()
         return results
 

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -4,73 +4,14 @@ import threading
 from neurobooth_os.iout.stim_param_reader import DeviceArgs, TaskArgs
 from neurobooth_os.log_manager import APP_LOG_NAME
 from neurobooth_os import config
-from typing import Any, Dict, List, Callable, ByteString, Optional
+from typing import Any, Dict, List, Mapping, ByteString, Optional, Type
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import neurobooth_os.iout.metadator as meta
 from neurobooth_os.iout.device import (
-    Device, DeviceCapability, CameraPreviewer, CameraPreviewException,
+    Device, DeviceCapability, CameraPreviewException,
 )
-from neurobooth_os.iout.mbient import Mbient
 from neurobooth_os.msg.messages import DeviceInitialization, Request
-
-# --------------------------------------------------------------------------------
-# Wrappers for device setup procedures.
-# --------------------------------------------------------------------------------
-def start_eyelink_stream(win, device_args):
-    from neurobooth_os.iout.eyelink_tracker import EyeTracker
-    return EyeTracker(win=win, device_args=device_args)
-
-
-def start_mouse_stream(_, device_args):
-    from neurobooth_os.iout.mouse_tracker import MouseStream
-    device = MouseStream(device_args)
-    device.connect()
-    device.start()
-    return device
-
-
-def start_mbient_stream(_, device_args):
-    device = Mbient(device_args)
-    if not device.connect():
-        return None
-    device.start()
-    return device
-
-
-def start_intel_stream(_, device_args):
-    from neurobooth_os.iout.camera_intel import VidRec_Intel
-    device = VidRec_Intel(device_args)
-    device.connect()
-    return device
-
-
-def start_flir_stream(_, device_args):
-    from neurobooth_os.iout.flir_cam import VidRec_Flir
-    device = VidRec_Flir(device_args)
-    device.connect()
-    return device
-
-
-def start_webcam_stream(_, device_args):
-    from neurobooth_os.iout.webcam import VidRec_Webcam
-    device = VidRec_Webcam(device_args)
-    device.connect()
-    return device
-
-
-def start_iphone_stream(_, device_args):
-    from neurobooth_os.iout.iphone import IPhone
-    device = IPhone(name="IPhoneFrameIndex", device_args=device_args)
-    return device if device.connect() else None
-
-
-def start_yeti_stream(_, device_args):
-    from neurobooth_os.iout.microphone import MicStream
-    device = MicStream(device_args)
-    device.connect()
-    device.start()
-    return device
 
 
 config.load_config(validate_paths=False)
@@ -81,11 +22,8 @@ SERVER_ASSIGNMENTS['presentation'] = config.neurobooth_config.presentation.devic
 SERVER_ASSIGNMENTS['control'] = config.neurobooth_config.control.devices
 
 
-N_ASYNC_THREADS: int = 3  # The maximum number of mbients on one machine
-ASYNC_STARTUP: List[str] = [
-    # Mbient BLE connections are serialized to avoid crashes from concurrent BLE operations.
-    # See docs/perf/Mbient Connection Times [2026-04-03].md for timing analysis.
-]
+N_ASYNC_THREADS: int = 3
+ASYNC_STARTUP: List[str] = []  # Device IDs whose bring_up runs concurrently in the thread pool.
 
 
 class DeviceNotFoundException(Exception):
@@ -154,15 +92,25 @@ class DeviceManager:
     def create_streams(self, win=None, task_params=None) -> None:
         """Initialize devices and LSL streams for this node's assigned devices.
 
+        Each device's startup lifecycle is driven by its ``Device.bring_up``
+        override, so this method stays device-type-agnostic: it looks up the
+        ``Device`` class from the ``DeviceArgs`` subclass, instantiates it,
+        and hands it a shared ``context`` dict.
+
         Args:
             win: PsychoPy window (required for EyeTracker on the presentation node).
             task_params: Mapping of task IDs to TaskArgs. Used to determine which
                 devices are needed across all tasks in the collection.
         """
-        if self.marker_stream:  # TODO: Handle the marker stream better
-            from neurobooth_os.iout import marker_stream
-            self.logger.debug(f'Device Manager Starting: marker')
-            self.streams["marker"] = marker_stream()
+        context: Mapping[str, Any] = {"psychopy_window": win}
+
+        if self.marker_stream:
+            from neurobooth_os.iout.marker import MarkerStreamDevice
+            self.logger.debug('Device Manager Starting: marker')
+            marker = MarkerStreamDevice()
+            marker.connect()
+            marker.start()
+            self.streams[MarkerStreamDevice.DEVICE_ID] = marker
 
         register_lock = threading.Lock()
 
@@ -170,11 +118,8 @@ class DeviceManager:
             device_id = device_args.device_id
             self.logger.debug(f'Device Manager Starting: {device_id}')
             self.logger.debug(f'Device Manager Starting with args: {device_args}')
-            device_start_function: Callable = meta.str_fileid_to_eval(
-                device_args.device_start_function,
-                allowed_modules=meta._ALLOWED_DEVICE_MODULES,
-            )
-            device = device_start_function(win, device_args)
+            device_cls: Type[Device] = device_args.instance_device_class()
+            device = device_cls(device_args).bring_up(context)
             if device is None:
                 self.logger.warning(f'Device Manager Failed to Start: {device_id}')
                 return
@@ -243,16 +188,16 @@ class DeviceManager:
     # ---- Recording device lifecycle ----
 
     def _get_camera_devices(self, task_devices: List[DeviceArgs]) -> List[Device]:
-        """Return camera-type recording devices for the given task.
+        """Return per-task recording devices (cameras) for the given task.
 
-        Excludes devices like EyeTracker that have RECORD capability but are
-        managed separately by the presentation server.
+        Selects devices whose recording is driven by the task lifecycle via the
+        ``RECORD_PER_TASK`` capability. EyeTracker declares ``RECORD`` but not
+        ``RECORD_PER_TASK``, so it is excluded here (it is managed by the
+        presentation server during initialization).
         """
-        return [
-            device for device in
-            self.get_devices_with_capability(DeviceCapability.RECORD, task_devices).values()
-            if not device.has_capability(DeviceCapability.CALIBRATABLE)
-        ]
+        return list(self.get_devices_with_capability(
+            DeviceCapability.RECORD_PER_TASK, task_devices
+        ).values())
 
     def start_recording_devices(self, filename: str, fname: str,
                                  task_devices: List[DeviceArgs],
@@ -286,7 +231,7 @@ class DeviceManager:
                 try:
                     created = future.result()
                     if created:
-                        stream_name = getattr(device, 'streamName', None) or getattr(device, 'stream_name', None)
+                        stream_name = getattr(device, 'streamName', None)
                         if stream_name:
                             all_files[stream_name] = created
                             device_files.append((device, created))
@@ -345,47 +290,42 @@ class DeviceManager:
         for device in cameras:  # Wait for cameras to actually stop
             device.ensure_stopped(10)
 
-    def get_eyelink_stream(self) -> Optional[Device]:
-        """Return the EyeTracker device, or None if not present."""
+    def get_calibration_device(self) -> Optional[Device]:
+        """Return the first device with the ``CALIBRATABLE`` capability, if any.
+
+        Today only EyeTracker declares ``CALIBRATABLE``; the "first wins" rule
+        is explicit here so a second calibratable device would be a config
+        issue rather than a silent bug.
+        """
         calibratables = self.get_devices_with_capability(DeviceCapability.CALIBRATABLE)
         if calibratables:
             return next(iter(calibratables.values()))
         return None
 
-    # ---- Mbient-specific methods ----
+    # ---- Session-level hooks ----
 
-    def get_mbient_streams(self) -> Dict[str, Mbient]:
-        """Return all Mbient devices.
+    def reconnect_for_task(self) -> None:
+        """Call ``on_task_reconnect`` on every Device-backed stream.
 
-        Filters by isinstance rather than WEARABLE capability, because callers
-        depend on Mbient-specific methods (``task_start_reconnect``,
-        ``reset_and_reconnect``).
+        Devices override this hook when they need per-task recovery (e.g.,
+        Mbient re-establishes dropped BLE links). Default is a no-op.
         """
-        return {
-            name: stream for name, stream in self.streams.items()
-            if isinstance(stream, Mbient)
-        }
+        for stream in self.streams.values():
+            if self._is_device(stream):
+                stream.on_task_reconnect()
 
-    def mbient_reconnect(self) -> None:
-        """Attempt to reconnect any Mbient devices that have disconnected."""
-        Mbient.task_start_reconnect(list(self.get_mbient_streams().values()))
-
-    def mbient_reset(self) -> Dict[str, bool]:
-        """Reset all Mbient devices sequentially and attempt to reconnect.
+    def reset_devices(self) -> Dict[str, bool]:
+        """Call ``on_session_reset`` on every Device-backed stream.
 
         Returns:
-            Mapping of device name to whether the reset succeeded.
+            Mapping of device name to whether the reset succeeded (defaults to
+            ``True`` for devices without an override).
         """
-        mbient_streams = self.get_mbient_streams()
-
-        if len(mbient_streams) == 0:
-            self.logger.debug('No mbients to reset.')
-            return {}
-
-        return {
-            stream_name: stream.reset_and_reconnect()
-            for stream_name, stream in mbient_streams.items()
-        }
+        results: Dict[str, bool] = {}
+        for name, stream in self.streams.items():
+            if self._is_device(stream):
+                results[name] = stream.on_session_reset()
+        return results
 
     def camera_frame_preview(self, device_id: str) -> ByteString:
         """Capture a single preview frame from a camera device.
@@ -403,7 +343,7 @@ class DeviceManager:
             raise CameraPreviewException(f'Device {device_id} unavailable.')
 
         camera = self.streams[device_id]
-        if not isinstance(camera, CameraPreviewer):
+        if not self._is_device(camera) or not camera.has_capability(DeviceCapability.CAMERA_PREVIEW):
             raise CameraPreviewException(f'Device {device_id} is not a valid preview device.')
 
         return camera.frame_preview()
@@ -420,16 +360,13 @@ class DeviceManager:
     def reconnect_streams(self) -> None:
         """Restart any non-camera streams that have stopped, and re-post DeviceInitialization messages.
 
-        Camera-type recording devices are skipped because they are started
-        per-task via ``start_recording_devices()``. The EyeTracker (RECORD but
-        also CALIBRATABLE) is *not* skipped, matching pre-refactor behavior.
+        Skips devices with ``RECORD_PER_TASK`` because they are (re)started
+        per-task via ``start_recording_devices()``. EyeTracker declares
+        ``RECORD | CALIBRATABLE`` (not ``RECORD_PER_TASK``) and so is included
+        here, matching pre-refactor behavior.
         """
         for stream_name, stream in self.streams.items():
-            # Skip camera-type recording devices (they are started per-task, not reconnected).
-            # EyeTracker has RECORD but is NOT skipped here (matches old is_camera() behavior).
-            if (self._is_device(stream)
-                    and stream.has_capability(DeviceCapability.RECORD)
-                    and not stream.has_capability(DeviceCapability.CALIBRATABLE)):
+            if self._is_device(stream) and stream.has_capability(DeviceCapability.RECORD_PER_TASK):
                 continue
 
             if not stream.streaming:

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -119,7 +119,9 @@ class DeviceManager:
             self.logger.debug(f'Device Manager Starting: {device_id}')
             self.logger.debug(f'Device Manager Starting with args: {device_args}')
             device_cls: Type[Device] = device_args.instance_device_class()
-            device = device_cls(device_args).bring_up(context)
+            # Pass device_args as a keyword so Device subclasses with extra
+            # positional parameters (e.g. IPhone's name) still bind correctly.
+            device = device_cls(device_args=device_args).bring_up(context)
             if device is None:
                 self.logger.warning(f'Device Manager Failed to Start: {device_id}')
                 return

--- a/neurobooth_os/iout/marker.py
+++ b/neurobooth_os/iout/marker.py
@@ -1,8 +1,10 @@
 import time
 import uuid
+from typing import Any, List, Mapping, Optional
 
 from pylsl import StreamInfo, StreamOutlet
 
+from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.msg.messages import DeviceInitialization, Request
 import neurobooth_os.iout.metadator as meta
@@ -52,3 +54,62 @@ def marker_stream(name="Marker", outlet_id=None):
     outlet_marker.streaming = True
 
     return outlet_marker
+
+
+class MarkerStreamDevice(Device):
+    """Device wrapper around the LSL marker outlet.
+
+    The marker outlet has no hardware, sensors, or YAML config — it exists to
+    let tasks annotate the data stream. Wrapping it in a ``Device`` lets
+    ``DeviceManager`` treat it like any other stream instead of special-casing
+    the presentation node.
+
+    Tasks call ``push_sample()`` directly on this object via the
+    ``marker_outlet`` that ``STMSession`` forwards from ``DeviceManager.streams``.
+    """
+
+    capabilities = DeviceCapability.STREAM
+
+    DEVICE_ID = "marker"
+
+    def __init__(self, name: str = "Marker", outlet_id: Optional[str] = None) -> None:
+        super().__init__(device_args=None)
+        self.device_id = self.DEVICE_ID
+        self.sensor_ids = [self.DEVICE_ID]
+        self.name = name
+        if outlet_id is not None:
+            self.outlet_id = outlet_id
+
+    def connect(self) -> None:
+        stream_info = set_stream_description(
+            stream_info=StreamInfo(
+                self.name, "Markers", 1, channel_format="string", source_id=self.outlet_id
+            ),
+            device_id=self.device_id,
+            sensor_ids=self.sensor_ids,
+            data_version=DataVersion(1, 0),
+            columns=['Marker'],
+            column_desc={'Marker': 'Marker message string'},
+        )
+        self.outlet = StreamOutlet(stream_info)
+        self.outlet.push_sample([f"Stream-created_0_{time.time()}"])
+
+        body = DeviceInitialization(stream_name=self.name, outlet_id=self.outlet_id)
+        meta.post_message(Request(source="marker", destination='CTR', body=body))
+        self.state = DeviceState.CONNECTED
+
+    def start(self, filename: Optional[str] = None) -> List[str]:
+        self.streaming = True
+        self.state = DeviceState.STARTED
+        return []
+
+    def stop(self) -> None:
+        self.streaming = False
+        self.state = DeviceState.STOPPED
+        if self.outlet is not None:
+            self.outlet.__del__()
+            self.outlet = None
+
+    def push_sample(self, sample: List[Any]) -> None:
+        """Forward a marker sample to the underlying LSL outlet."""
+        self.outlet.push_sample(sample)

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -455,7 +455,11 @@ class Mbient(Device):
     If the sensor disconnects at any point, a reconnect will be attempted.
     """
 
-    capabilities = DeviceCapability.STREAM | DeviceCapability.WEARABLE
+    capabilities = (
+        DeviceCapability.STREAM
+        | DeviceCapability.WEARABLE
+        | DeviceCapability.RESETTABLE
+    )
 
     # Class variables to ensure that the BLE scan only happens during one connect() call.
     # Will need to switch to a multiprocess.Manager if intending to use multiprocessing.

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -5,7 +5,7 @@ from ctypes import c_void_p
 from time import sleep, time
 import multiprocessing as mp
 import logging
-from typing import Any, Dict, List, Callable, NamedTuple, Optional
+from typing import Any, Dict, List, Callable, Mapping, NamedTuple, Optional
 from abc import ABC, abstractmethod
 from enum import IntEnum
 
@@ -718,6 +718,25 @@ class Mbient(Device):
         except Exception as e:
             self.logger.error(self.format_message(f'Error during reset and reconnect: {e}'))
             return False
+
+    def bring_up(self, context: Mapping[str, Any]) -> Optional[Device]:
+        """Connect and start streaming, returning None if the BLE handshake fails."""
+        if not self.connect():
+            return None
+        self.start()
+        return self
+
+    def on_task_reconnect(self) -> None:
+        """Before each task, reconnect this Mbient if its BLE link dropped.
+
+        The class-level static method handles scanning and retry budgeting
+        across all Mbient instances; we delegate the single-device call to it.
+        """
+        Mbient.task_start_reconnect([self])
+
+    def on_session_reset(self) -> bool:
+        """Reset the board and re-establish the BLE connection (operator action)."""
+        return self.reset_and_reconnect()
 
     def connect(self) -> bool:
         """

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -39,11 +39,6 @@ _ALLOWED_TASK_MODULES: frozenset = frozenset({
     "tasks",  # prefix-match: covers tasks.*, tasks.MOT.task.*, etc.
 })
 
-_ALLOWED_DEVICE_MODULES: frozenset = frozenset({
-    "iout.lsl_streamer",
-})
-
-
 class LogSession(BaseModel):
     log_session_id: Optional[int] = None
     subject_id: Optional[str] = None

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -2,9 +2,12 @@ from os import environ, path
 
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt, Field, PositiveInt, PositiveFloat, \
     SerializeAsAny
-from typing import Optional, List, Callable, Tuple, Dict
+from typing import TYPE_CHECKING, Optional, List, Callable, Tuple, Dict, Type
 import os
 import yaml
+
+if TYPE_CHECKING:
+    from neurobooth_os.iout.device import Device
 
 """
 Loads yaml files containing task/stimulus/instruction parameters and validates them.
@@ -127,7 +130,7 @@ class DeviceArgs(EnvArgs):
 
     # Attributes required for program execution
     device_id: str                                  # Unique identifier for device
-    device_start_function: str      # A string representing the function that starts the device
+    device_start_function: Optional[str] = ""       # Deprecated: kept for backwards compatibility with legacy configs
     arg_parser: str                 # A string representing the function that parses the device arguments into objects
     sensor_ids: Optional[List[str]]                 # List of unique identifiers for sensors contained in device
     sensor_array: List[SerializeAsAny[SensorArgs]] = []     # List of the SensorArgs for sensors in device
@@ -154,6 +157,42 @@ class DeviceArgs(EnvArgs):
                 kwargs['device_sn'] = sn
         super().__init__(**kwargs)
 
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        """Return the concrete ``Device`` subclass to instantiate from these args.
+
+        Each ``DeviceArgs`` subclass overrides this with a lazy import of its
+        concrete Device, which avoids import cycles and lets acquisition nodes
+        avoid loading device modules they don't use.
+
+        The base implementation dispatches on the legacy
+        ``device_start_function`` field to preserve backwards compatibility
+        with configs that use ``arg_parser: iout.stim_param_reader.py::DeviceArgs()``
+        (currently only the Mouse device). New devices should declare their own
+        ``DeviceArgs`` subclass and override this method directly.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} has no device_class binding. "
+            "Define a DeviceArgs subclass that overrides device_class()."
+        )
+
+    def instance_device_class(self) -> Type["Device"]:
+        """Resolve the Device class for this instance.
+
+        Preference order:
+            1. A subclass that overrides :meth:`device_class`.
+            2. Legacy fallback via :attr:`device_start_function` for configs
+               still using the base ``DeviceArgs`` (Mouse).
+        """
+        try:
+            return type(self).device_class()
+        except NotImplementedError:
+            fn = (self.device_start_function or "").lower()
+            if "start_mouse_stream" in fn:
+                from neurobooth_os.iout.mouse_tracker import MouseStream
+                return MouseStream
+            raise
+
 
 class MicYetiDeviceArgs(DeviceArgs):
 
@@ -168,6 +207,11 @@ class MicYetiDeviceArgs(DeviceArgs):
         mic_nm = kwargs['ENV_devices'][my_id]['microphone_name']
         kwargs['microphone_name'] = mic_nm
         super().__init__(**kwargs)
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.microphone import MicStream
+        return MicStream
 
 
 class EyelinkDeviceArgs(DeviceArgs):
@@ -204,6 +248,11 @@ class EyelinkDeviceArgs(DeviceArgs):
     def calibration_type(self):
         return self.sensor_array[0].calibration_type
 
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.eyelink_tracker import EyeTracker
+        return EyeTracker
+
 
 class IPhoneDeviceArgs(DeviceArgs):
     """
@@ -232,6 +281,11 @@ class IPhoneDeviceArgs(DeviceArgs):
 
     def lenspos(self):
         return str(self.sensor_array[0].lenspos)
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.iphone import IPhone
+        return IPhone
 
 
 class FlirDeviceArgs(DeviceArgs):
@@ -277,6 +331,11 @@ class FlirDeviceArgs(DeviceArgs):
 
     def offset_y(self):
         return self.sensor_array[0].offsetY
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.flir_cam import VidRec_Flir
+        return VidRec_Flir
 
 
 class IntelDeviceArgs(DeviceArgs):
@@ -327,6 +386,11 @@ class IntelDeviceArgs(DeviceArgs):
                 return True
         return False
 
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.camera_intel import VidRec_Intel
+        return VidRec_Intel
+
 
 class WebcamDeviceArgs(DeviceArgs):
     """
@@ -356,6 +420,11 @@ class WebcamDeviceArgs(DeviceArgs):
     def height_px(self):
         return self.sensor_array[0].height_px
 
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.webcam import VidRec_Webcam
+        return VidRec_Webcam
+
 
 class MbientDeviceArgs(DeviceArgs):
 
@@ -371,6 +440,11 @@ class MbientDeviceArgs(DeviceArgs):
 
         super().__init__(**kwargs)
         self.device_name = self.device_id.split("_")[1]
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mbient import Mbient
+        return Mbient
 
 
 class InstructionArgs(EnvArgs):

--- a/neurobooth_os/iout/webcam.py
+++ b/neurobooth_os/iout/webcam.py
@@ -10,7 +10,7 @@ from pylsl import StreamInfo, StreamOutlet
 
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 import neurobooth_os.iout.metadator as meta
-from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState, CameraPreviewer
+from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.stim_param_reader import WebcamDeviceArgs
 
 from neurobooth_os.log_manager import APP_LOG_NAME
@@ -22,9 +22,13 @@ class WebcamException(Exception):
         super().__init__(*args, **kwargs)
 
 
-class VidRec_Webcam(Device, CameraPreviewer):
+class VidRec_Webcam(Device):
 
-    capabilities = DeviceCapability.RECORD | DeviceCapability.CAMERA_PREVIEW
+    capabilities = (
+        DeviceCapability.RECORD
+        | DeviceCapability.RECORD_PER_TASK
+        | DeviceCapability.CAMERA_PREVIEW
+    )
 
     def __init__(
         self,
@@ -47,10 +51,10 @@ class VidRec_Webcam(Device, CameraPreviewer):
 
     def connect(self) -> None:
         """Create the LSL outlet and notify the control server."""
-        self.stream_name = "WebcamFrameIndex"
+        self.streamName = "WebcamFrameIndex"
         info = set_stream_description(
             stream_info=StreamInfo(
-                name=self.stream_name,
+                name=self.streamName,
                 type="videostream",
                 channel_format="double64",
                 channel_count=2,
@@ -69,7 +73,7 @@ class VidRec_Webcam(Device, CameraPreviewer):
             size_rgb=str((self.device_args.width_px(), self.device_args.height_px())),
         )
         msg_body = DeviceInitialization(
-            stream_name=self.stream_name,
+            stream_name=self.streamName,
             outlet_id=self.outlet_id,
             device_id=self.device_args.device_id,
             camera_preview=True,
@@ -85,7 +89,7 @@ class VidRec_Webcam(Device, CameraPreviewer):
         """Re-create the LSL outlet (e.g. after stream closure)."""
         info = set_stream_description(
             stream_info=StreamInfo(
-                name=self.stream_name,
+                name=self.streamName,
                 type="videostream",
                 channel_format="double64",
                 channel_count=2,

--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -125,7 +125,7 @@ def run_acq(logger, acq_index: int = 0):
             # TODO: reset_mbients and frame_preview should be reworked as dynamic hooks that register a callback
             elif "ResetMbients" == current_msg_type:
 
-                reset_results = device_manager.mbient_reset()
+                reset_results = device_manager.reset_devices()
 
                 reply_body = MbientResetResults(results=reset_results)
                 reply = Request(
@@ -255,7 +255,7 @@ def start_recording(device_manager: DeviceManager, filename: str, fname: str,
     t0 = time()
     device_manager.start_recording_devices(filename, fname, task_devices,
                                            log_task_id=log_task_id)
-    device_manager.mbient_reconnect()  # Attempt to reconnect Mbients if disconnected
+    device_manager.reconnect_for_task()  # Per-device on_task_reconnect hook (Mbient re-establishes BLE)
     elapsed_time = time() - t0
     return elapsed_time
 

--- a/neurobooth_os/stm_session.py
+++ b/neurobooth_os/stm_session.py
@@ -69,7 +69,7 @@ class StmSession(BaseModel):
         self.prompt = True
 
         self.device_manager = self.init_device_manager()
-        self.eye_tracker = self.device_manager.get_eyelink_stream()
+        self.eye_tracker = self.device_manager.get_calibration_device()
 
     @staticmethod
     def init_window() -> visual.Window:

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -1,0 +1,323 @@
+"""Tests for the pluggable device registration added in #696.
+
+Covers the new surfaces: ``Device.bring_up`` default, the lifecycle hooks
+(``on_task_reconnect`` / ``on_session_reset`` / ``frame_preview``),
+``DeviceManager`` hook dispatch, capability-based ``camera_frame_preview``
+gating, ``MarkerStreamDevice`` delegation, and each ``DeviceArgs`` subclass's
+``device_class()`` wiring.
+
+Backward-compat fallbacks (mouse string-match in ``DeviceArgs.instance_device_class``,
+legacy ``marker_stream()`` function, ``CameraPreviewer`` shim) are intentionally
+not tested — they are scheduled for removal in #708.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from neurobooth_os.iout.device import (
+    CameraPreviewException,
+    DeviceCapability,
+    DeviceState,
+)
+from neurobooth_os.iout.lsl_streamer import DeviceManager
+from neurobooth_os.iout.mock_device import MockRecordingDevice, MockStreamDevice
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dm():
+    """DeviceManager with __init__ bypassed.
+
+    __init__ validates node_name against SERVER_ASSIGNMENTS (loaded from the
+    user's config at module import). Bypassing it keeps these tests independent
+    of any particular deployment's server assignments.
+    """
+    manager = DeviceManager.__new__(DeviceManager)
+    manager.logger = logging.getLogger('test_device_pluggable')
+    manager.streams = {}
+    manager.assigned_devices = []
+    manager.marker_stream = False
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# Device.bring_up default behavior
+# ---------------------------------------------------------------------------
+
+
+class TestBringUpDefault:
+    def test_stream_only_device_connects_and_starts(self):
+        device = MockStreamDevice()
+        result = device.bring_up({})
+        assert result is device
+        assert device.streaming
+        assert device.start_count == 1
+        assert device.state == DeviceState.STARTED
+
+    def test_recording_device_connects_but_does_not_start(self):
+        """RECORD devices defer start() to DeviceManager.start_recording_devices."""
+        device = MockRecordingDevice()
+        result = device.bring_up({})
+        assert result is device
+        assert not device.streaming
+        assert device.state == DeviceState.CONNECTED
+
+    def test_unused_context_keys_are_ignored(self):
+        device = MockStreamDevice()
+        device.bring_up({"psychopy_window": MagicMock(), "extra": 42})
+        assert device.streaming
+
+
+# ---------------------------------------------------------------------------
+# Device.frame_preview default
+# ---------------------------------------------------------------------------
+
+
+class TestFramePreviewDefault:
+    def test_device_without_override_raises(self):
+        device = MockStreamDevice()
+        with pytest.raises(CameraPreviewException):
+            device.frame_preview()
+
+    def test_capability_flag_alone_does_not_provide_implementation(self):
+        """CAMERA_PREVIEW advertises support but the subclass must still override.
+
+        MockRecordingDevice declares CAMERA_PREVIEW yet does not override
+        frame_preview, so it exercises the base default.
+        """
+        device = MockRecordingDevice()
+        with pytest.raises(CameraPreviewException):
+            device.frame_preview()
+
+
+# ---------------------------------------------------------------------------
+# Device.on_task_reconnect / on_session_reset defaults
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleHookDefaults:
+    def test_on_task_reconnect_is_noop(self):
+        MockStreamDevice().on_task_reconnect()  # must not raise
+
+    def test_on_session_reset_returns_true(self):
+        assert MockStreamDevice().on_session_reset() is True
+
+
+# ---------------------------------------------------------------------------
+# DeviceManager hook dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceManagerHooks:
+    def test_reconnect_for_task_calls_hook_on_every_device(self, dm):
+        d1 = MockStreamDevice(device_id='d1')
+        d2 = MockStreamDevice(device_id='d2')
+        d1.on_task_reconnect = MagicMock()
+        d2.on_task_reconnect = MagicMock()
+        dm.streams = {'d1': d1, 'd2': d2}
+
+        dm.reconnect_for_task()
+
+        d1.on_task_reconnect.assert_called_once()
+        d2.on_task_reconnect.assert_called_once()
+
+    def test_reconnect_for_task_skips_non_device_streams(self, dm):
+        device = MockStreamDevice()
+        device.on_task_reconnect = MagicMock()
+        dm.streams = {'device': device, 'raw_outlet': object()}
+
+        dm.reconnect_for_task()  # must not raise on raw_outlet
+
+        device.on_task_reconnect.assert_called_once()
+
+    def test_reset_devices_collects_return_values(self, dm):
+        d1 = MockStreamDevice(device_id='d1')
+        d2 = MockStreamDevice(device_id='d2')
+        d1.on_session_reset = MagicMock(return_value=True)
+        d2.on_session_reset = MagicMock(return_value=False)
+        dm.streams = {'d1': d1, 'd2': d2}
+
+        assert dm.reset_devices() == {'d1': True, 'd2': False}
+
+    def test_reset_devices_skips_non_device_streams(self, dm):
+        device = MockStreamDevice()
+        dm.streams = {'device': device, 'raw_outlet': object()}
+
+        result = dm.reset_devices()
+
+        assert list(result.keys()) == ['device']
+
+
+# ---------------------------------------------------------------------------
+# camera_frame_preview capability gating
+# ---------------------------------------------------------------------------
+
+
+class TestCameraFramePreviewGating:
+    def test_missing_device_id_raises(self, dm):
+        with pytest.raises(CameraPreviewException, match='unavailable'):
+            dm.camera_frame_preview('missing')
+
+    def test_device_without_capability_raises(self, dm):
+        device = MockStreamDevice(device_id='plain')  # STREAM only, no CAMERA_PREVIEW
+        dm.streams = {'plain': device}
+        with pytest.raises(CameraPreviewException, match='not a valid preview'):
+            dm.camera_frame_preview('plain')
+
+    def test_non_device_stream_raises(self, dm):
+        dm.streams = {'raw': object()}
+        with pytest.raises(CameraPreviewException, match='not a valid preview'):
+            dm.camera_frame_preview('raw')
+
+    def test_forwards_to_device_when_capability_present(self, dm):
+        device = MockRecordingDevice()  # declares CAMERA_PREVIEW
+        device.frame_preview = MagicMock(return_value=b'PNG-bytes')
+        dm.streams = {'cam': device}
+
+        assert dm.camera_frame_preview('cam') == b'PNG-bytes'
+        device.frame_preview.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# MarkerStreamDevice lifecycle and delegation
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerStreamDevice:
+    def test_identity(self):
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+
+        device = MarkerStreamDevice()
+        assert device.device_id == MarkerStreamDevice.DEVICE_ID == 'marker'
+        assert device.sensor_ids == ['marker']
+        assert device.has_capability(DeviceCapability.STREAM)
+
+    def test_push_sample_forwards_to_outlet(self):
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+
+        device = MarkerStreamDevice()
+        device.outlet = MagicMock()
+
+        device.push_sample(["hello"])
+
+        device.outlet.push_sample.assert_called_once_with(["hello"])
+
+    def test_start_transitions_state(self):
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+
+        device = MarkerStreamDevice()
+        device.start()
+
+        assert device.streaming
+        assert device.state == DeviceState.STARTED
+
+    def test_stop_releases_outlet_and_clears_state(self):
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+
+        class _Outlet:
+            """MagicMock doesn't auto-provide __del__, so use a real class."""
+            def __init__(self) -> None:
+                self.del_called = False
+
+            def __del__(self) -> None:
+                self.del_called = True
+
+        outlet = _Outlet()
+        device = MarkerStreamDevice()
+        device.outlet = outlet
+        device.streaming = True
+
+        device.stop()
+
+        assert not device.streaming
+        assert device.state == DeviceState.STOPPED
+        assert device.outlet is None
+        assert outlet.del_called
+
+
+# ---------------------------------------------------------------------------
+# DeviceArgs subclass device_class() wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceArgsClassRegistry:
+    """Each DeviceArgs subclass resolves to the correct concrete Device.
+
+    These are the primary path; the legacy mouse string-match fallback in the
+    base class is intentionally not tested (tracked for removal in #708).
+    """
+
+    def test_mic_yeti_args(self):
+        from neurobooth_os.iout.stim_param_reader import MicYetiDeviceArgs
+        from neurobooth_os.iout.microphone import MicStream
+        assert MicYetiDeviceArgs.device_class() is MicStream
+
+    def test_eyelink_args(self):
+        from neurobooth_os.iout.stim_param_reader import EyelinkDeviceArgs
+        from neurobooth_os.iout.eyelink_tracker import EyeTracker
+        assert EyelinkDeviceArgs.device_class() is EyeTracker
+
+    def test_iphone_args(self):
+        from neurobooth_os.iout.stim_param_reader import IPhoneDeviceArgs
+        from neurobooth_os.iout.iphone import IPhone
+        assert IPhoneDeviceArgs.device_class() is IPhone
+
+    def test_flir_args(self):
+        from neurobooth_os.iout.stim_param_reader import FlirDeviceArgs
+        from neurobooth_os.iout.flir_cam import VidRec_Flir
+        assert FlirDeviceArgs.device_class() is VidRec_Flir
+
+    def test_intel_args(self):
+        from neurobooth_os.iout.stim_param_reader import IntelDeviceArgs
+        from neurobooth_os.iout.camera_intel import VidRec_Intel
+        assert IntelDeviceArgs.device_class() is VidRec_Intel
+
+    def test_webcam_args(self):
+        from neurobooth_os.iout.stim_param_reader import WebcamDeviceArgs
+        from neurobooth_os.iout.webcam import VidRec_Webcam
+        assert WebcamDeviceArgs.device_class() is VidRec_Webcam
+
+    def test_mbient_args(self):
+        from neurobooth_os.iout.stim_param_reader import MbientDeviceArgs
+        from neurobooth_os.iout.mbient import Mbient
+        assert MbientDeviceArgs.device_class() is Mbient
+
+
+# ---------------------------------------------------------------------------
+# RECORD_PER_TASK capability assignments
+# ---------------------------------------------------------------------------
+
+
+class TestRecordPerTaskAssignment:
+    """Cameras (started per-task) declare RECORD_PER_TASK; EyeTracker does not.
+
+    This replaces the old ``RECORD and not CALIBRATABLE`` heuristic in
+    ``_get_camera_devices`` / ``reconnect_streams``.
+    """
+
+    def test_flir_has_record_per_task(self):
+        from neurobooth_os.iout.flir_cam import VidRec_Flir
+        assert DeviceCapability.RECORD_PER_TASK in VidRec_Flir.capabilities
+
+    def test_webcam_has_record_per_task(self):
+        from neurobooth_os.iout.webcam import VidRec_Webcam
+        assert DeviceCapability.RECORD_PER_TASK in VidRec_Webcam.capabilities
+
+    def test_intel_has_record_per_task(self):
+        from neurobooth_os.iout.camera_intel import VidRec_Intel
+        assert DeviceCapability.RECORD_PER_TASK in VidRec_Intel.capabilities
+
+    def test_iphone_has_record_per_task(self):
+        from neurobooth_os.iout.iphone import IPhone
+        assert DeviceCapability.RECORD_PER_TASK in IPhone.capabilities
+
+    def test_eyetracker_excludes_record_per_task(self):
+        from neurobooth_os.iout.eyelink_tracker import EyeTracker
+        assert DeviceCapability.RECORD_PER_TASK not in EyeTracker.capabilities
+        assert DeviceCapability.CALIBRATABLE in EyeTracker.capabilities

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -136,17 +136,39 @@ class TestDeviceManagerHooks:
 
         device.on_task_reconnect.assert_called_once()
 
+    def test_reset_devices_only_calls_resettable_devices(self, dm):
+        """reset_devices must filter by RESETTABLE so the operator's UI only
+        shows devices that actually performed a reset (today: Mbients).
+        """
+        resettable = MockStreamDevice(device_id='resettable')
+        resettable.capabilities = (
+            MockStreamDevice.capabilities | DeviceCapability.RESETTABLE
+        )
+        resettable.on_session_reset = MagicMock(return_value=True)
+
+        plain = MockStreamDevice(device_id='plain')
+        plain.on_session_reset = MagicMock(return_value=True)
+
+        dm.streams = {'resettable': resettable, 'plain': plain}
+
+        result = dm.reset_devices()
+
+        assert result == {'resettable': True}
+        plain.on_session_reset.assert_not_called()
+
     def test_reset_devices_collects_return_values(self, dm):
         d1 = MockStreamDevice(device_id='d1')
         d2 = MockStreamDevice(device_id='d2')
-        d1.on_session_reset = MagicMock(return_value=True)
-        d2.on_session_reset = MagicMock(return_value=False)
+        for d, ok in ((d1, True), (d2, False)):
+            d.capabilities = MockStreamDevice.capabilities | DeviceCapability.RESETTABLE
+            d.on_session_reset = MagicMock(return_value=ok)
         dm.streams = {'d1': d1, 'd2': d2}
 
         assert dm.reset_devices() == {'d1': True, 'd2': False}
 
     def test_reset_devices_skips_non_device_streams(self, dm):
         device = MockStreamDevice()
+        device.capabilities = MockStreamDevice.capabilities | DeviceCapability.RESETTABLE
         dm.streams = {'device': device, 'raw_outlet': object()}
 
         result = dm.reset_devices()
@@ -321,3 +343,24 @@ class TestRecordPerTaskAssignment:
         from neurobooth_os.iout.eyelink_tracker import EyeTracker
         assert DeviceCapability.RECORD_PER_TASK not in EyeTracker.capabilities
         assert DeviceCapability.CALIBRATABLE in EyeTracker.capabilities
+
+
+class TestResettableAssignment:
+    """Only Mbient declares RESETTABLE — the capability exists so the operator
+    "Reset" result lists only devices that actually performed a reset.
+    """
+
+    def test_mbient_has_resettable(self):
+        from neurobooth_os.iout.mbient import Mbient
+        assert DeviceCapability.RESETTABLE in Mbient.capabilities
+
+    def test_cameras_are_not_resettable(self):
+        from neurobooth_os.iout.flir_cam import VidRec_Flir
+        from neurobooth_os.iout.webcam import VidRec_Webcam
+        from neurobooth_os.iout.camera_intel import VidRec_Intel
+        for cls in (VidRec_Flir, VidRec_Webcam, VidRec_Intel):
+            assert DeviceCapability.RESETTABLE not in cls.capabilities
+
+    def test_eyetracker_is_not_resettable(self):
+        from neurobooth_os.iout.eyelink_tracker import EyeTracker
+        assert DeviceCapability.RESETTABLE not in EyeTracker.capabilities


### PR DESCRIPTION
## Summary

- Push per-device logic into ``Device`` subclass lifecycle hooks so adding a new device requires only a ``Device`` subclass plus a ``DeviceArgs`` subclass — no edits to ``DeviceManager``, ``lsl_streamer`` wrappers, or the ``_ALLOWED_DEVICE_MODULES`` allowlist.
- Add ``RECORD_PER_TASK`` and ``RESETTABLE`` capabilities to replace the legacy ``isinstance``/``CALIBRATABLE``-pair heuristics in ``DeviceManager``.
- Wrap the bare marker outlet in ``MarkerStreamDevice(Device)`` for a uniform lifecycle; retire the ``CameraPreviewer`` mixin in favor of a default ``Device.frame_preview`` gated by the ``CAMERA_PREVIEW`` capability.

Closes #696.

## Notable changes

- **New Device API:** ``bring_up(context)``, ``on_task_reconnect``, ``on_session_reset``, ``frame_preview`` defaults on ``Device``. Per-device overrides in ``EyeTracker`` (pulls ``psychopy_window`` from context), ``Mbient`` (BLE reconnect + reset hooks), and ``IPhone`` (returns ``None`` on handshake failure).
- **DeviceArgs registry:** each subclass declares its concrete ``Device`` via a ``device_class()`` classmethod (lazy import; no circular deps).
- **DeviceManager cleanup:** the 8 ``start_xxx_stream`` wrappers are gone; ``mbient_reconnect``/``mbient_reset`` replaced by generic ``reconnect_for_task``/``reset_devices``; ``get_eyelink_stream`` renamed to ``get_calibration_device``; ``camera_frame_preview`` and ``reconnect_streams`` use capability queries.
- **Backward-compat shims** (kept so deployed YAMLs still validate; tracked for removal in #708): ``device_start_function`` is ``Optional`` on ``DeviceArgs``, base ``instance_device_class`` string-matches ``start_mouse_stream`` for the Mouse YAML, ``CameraPreviewer`` class retained as a deprecation marker.

## Included fixes from the branch

- **IPhone kwarg binding (staging regression):** generic ``device_cls(device_args)`` bound the args object to IPhone's required positional ``name``; gave ``name`` a default and pass ``device_args`` by keyword.
- **Reset scope (staging regression):** the default ``on_session_reset`` returned ``True``, so the operator Reset UI lit up every device; gated ``reset_devices`` by the new ``RESETTABLE`` capability, declared only by Mbient.

## Config migration

No mandatory YAML changes — existing device configs continue to work through the backward-compat shims. Optional cleanups and full removal of the shims are tracked in #708.

## Test plan

- [x] Unit tests pass locally (69/69 — ``test_device_pluggable.py`` adds 34 tests covering the new Device/DeviceManager surfaces)
- [ ] Run a full session on staging with all real devices (Flir, Webcam, Intel, iPhone, EyeLink, Mbients, Mouse, Yeti)
- [ ] Verify "Reset Mbients" UI reports only Mbient devices, not every connected device
- [ ] Verify iPhone initialization no longer crashes with ``notifyonframe`` AttributeError
- [ ] Verify per-task recording start/stop still drives cameras (Flir / Webcam / Intel / iPhone)
- [ ] Verify EyeLink calibration path still works via ``get_calibration_device``