### PR TITLE
Add MouseDeviceArgs (#708)

### DIFF
--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -447,6 +447,22 @@ class MbientDeviceArgs(DeviceArgs):
         return Mbient
 
 
+class MouseDeviceArgs(DeviceArgs):
+    """DeviceArgs for the Mouse device.
+
+    Mouse has no device-specific fields; this subclass exists solely to
+    provide the ``device_class`` binding that drives pluggable instantiation.
+    Its addition lets the Mouse YAML move from ``arg_parser: DeviceArgs`` to
+    ``arg_parser: MouseDeviceArgs``, removing the only remaining consumer of
+    the legacy ``device_start_function`` fallback in ``instance_device_class``.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mouse_tracker import MouseStream
+        return MouseStream
+
+
 class InstructionArgs(EnvArgs):
     """
         Arguments controlling psychopy instructions

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -310,6 +310,11 @@ class TestDeviceArgsClassRegistry:
         from neurobooth_os.iout.mbient import Mbient
         assert MbientDeviceArgs.device_class() is Mbient
 
+    def test_mouse_args(self):
+        from neurobooth_os.iout.stim_param_reader import MouseDeviceArgs
+        from neurobooth_os.iout.mouse_tracker import MouseStream
+        assert MouseDeviceArgs.device_class() is MouseStream
+
 
 # ---------------------------------------------------------------------------
 # RECORD_PER_TASK capability assignments


### PR DESCRIPTION
## Summary

- Adds a ``MouseDeviceArgs(DeviceArgs)`` subclass whose only job is to bind the Mouse device to ``MouseStream`` via ``device_class()``.
- Unblocks the configs-side cleanup in #708 where the Mouse YAML switches from ``arg_parser: DeviceArgs`` to ``arg_parser: MouseDeviceArgs`` and drops its legacy ``device_start_function`` line.

Part of #708 (backward-compat shim removal).

## Notes

- The base-class ``instance_device_class`` fallback (string match on ``start_mouse_stream``) stays for this change. Its removal is tracked as a later item in #708.
- One test added in ``test_device_pluggable.py`` mirroring the existing subclass-wiring tests.

## Test plan

- [x] ``test_device_pluggable.py`` passes locally (36 tests)
- [ ] Verify in staging that Mouse still initializes after the companion configs PR lands