### PR TITLE
Retire device_start_function (#708 item 2)

### DIFF
--- a/docs/arch/adding_a_device.md
+++ b/docs/arch/adding_a_device.md
@@ -427,6 +427,3 @@ touch indirectly:
   flowing it through a YAML like every other device. If you're curious or
   want to pick it up, see the tracking issue for
   [pluggable-device cleanup](https://github.com/neurobooth/neurobooth-os/issues/708).
-- **`device_start_function` in `DeviceArgs`** is a dead field retained for
-  backward compatibility with older YAMLs; it will be removed once deployed
-  configs have migrated.

--- a/docs/arch/messaging_architecture.md
+++ b/docs/arch/messaging_architecture.md
@@ -229,7 +229,12 @@ The same function is used for other dynamic imports with different allowlists:
 | `read_next_message` | `_ALLOWED_MESSAGE_MODULES` | `msg.messages` |
 | `_dynamic_parse` (YAML config parsers) | `_ALLOWED_PARSER_MODULES` | `iout.stim_param_reader`, `tasks.MOT.task` |
 | `build_task` (task constructors) | `_ALLOWED_TASK_MODULES` | `tasks` (prefix, covers all submodules) |
-| `DeviceManager.create_streams` | `_ALLOWED_DEVICE_MODULES` | `iout.lsl_streamer` |
+
+`DeviceManager.create_streams` previously used an `_ALLOWED_DEVICE_MODULES`
+allowlist to resolve a `device_start_function` string from each device YAML.
+That mechanism was retired in #696 — each `DeviceArgs` subclass now declares
+its concrete `Device` directly via `device_class()`, so no string-to-callable
+lookup happens at device startup.
 
 ## Message Lifecycle
 

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -1016,11 +1016,10 @@ def script_capture_data(subject_id: str, recording_folder: str, capture_duration
         ENV_devices={'IPhone_dev_1': {}},
         device_id='IPhone_dev_1',
         sensor_ids=['IPhone_sens_1'],
-        # sensor array, arg parser, and device start function are not needed by the
-        # test script but are not optional and are needed for pydantic validation
+        # sensor_array and arg_parser aren't used by the test script but pydantic
+        # still requires them.
         sensor_array=[],
         arg_parser='',
-        device_start_function='',
     )
 
     iphone = IPhone("IPhone", device_args=dev_args)

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -130,7 +130,6 @@ class DeviceArgs(EnvArgs):
 
     # Attributes required for program execution
     device_id: str                                  # Unique identifier for device
-    device_start_function: Optional[str] = ""       # Deprecated: kept for backwards compatibility with legacy configs
     arg_parser: str                 # A string representing the function that parses the device arguments into objects
     sensor_ids: Optional[List[str]]                 # List of unique identifiers for sensors contained in device
     sensor_array: List[SerializeAsAny[SensorArgs]] = []     # List of the SensorArgs for sensors in device
@@ -164,12 +163,6 @@ class DeviceArgs(EnvArgs):
         Each ``DeviceArgs`` subclass overrides this with a lazy import of its
         concrete Device, which avoids import cycles and lets acquisition nodes
         avoid loading device modules they don't use.
-
-        The base implementation dispatches on the legacy
-        ``device_start_function`` field to preserve backwards compatibility
-        with configs that use ``arg_parser: iout.stim_param_reader.py::DeviceArgs()``
-        (currently only the Mouse device). New devices should declare their own
-        ``DeviceArgs`` subclass and override this method directly.
         """
         raise NotImplementedError(
             f"{cls.__name__} has no device_class binding. "
@@ -177,21 +170,8 @@ class DeviceArgs(EnvArgs):
         )
 
     def instance_device_class(self) -> Type["Device"]:
-        """Resolve the Device class for this instance.
-
-        Preference order:
-            1. A subclass that overrides :meth:`device_class`.
-            2. Legacy fallback via :attr:`device_start_function` for configs
-               still using the base ``DeviceArgs`` (Mouse).
-        """
-        try:
-            return type(self).device_class()
-        except NotImplementedError:
-            fn = (self.device_start_function or "").lower()
-            if "start_mouse_stream" in fn:
-                from neurobooth_os.iout.mouse_tracker import MouseStream
-                return MouseStream
-            raise
+        """Resolve the Device class for this instance via :meth:`device_class`."""
+        return type(self).device_class()
 
 
 class MicYetiDeviceArgs(DeviceArgs):
@@ -452,9 +432,6 @@ class MouseDeviceArgs(DeviceArgs):
 
     Mouse has no device-specific fields; this subclass exists solely to
     provide the ``device_class`` binding that drives pluggable instantiation.
-    Its addition lets the Mouse YAML move from ``arg_parser: DeviceArgs`` to
-    ``arg_parser: MouseDeviceArgs``, removing the only remaining consumer of
-    the legacy ``device_start_function`` fallback in ``instance_device_class``.
     """
 
     @classmethod

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -6,9 +6,8 @@ Covers the new surfaces: ``Device.bring_up`` default, the lifecycle hooks
 gating, ``MarkerStreamDevice`` delegation, and each ``DeviceArgs`` subclass's
 ``device_class()`` wiring.
 
-Backward-compat fallbacks (mouse string-match in ``DeviceArgs.instance_device_class``
-and the legacy ``marker_stream()`` function) are intentionally not tested —
-they are scheduled for removal in #708.
+The legacy ``marker_stream()`` function is intentionally not tested — it is
+scheduled for removal in #708.
 """
 
 import logging
@@ -269,11 +268,7 @@ class TestMarkerStreamDevice:
 
 
 class TestDeviceArgsClassRegistry:
-    """Each DeviceArgs subclass resolves to the correct concrete Device.
-
-    These are the primary path; the legacy mouse string-match fallback in the
-    base class is intentionally not tested (tracked for removal in #708).
-    """
+    """Each DeviceArgs subclass resolves to the correct concrete Device."""
 
     def test_mic_yeti_args(self):
         from neurobooth_os.iout.stim_param_reader import MicYetiDeviceArgs


### PR DESCRIPTION
## Summary

Closes out all of #708 item 2 now that configs#104 is merged.

### Code

- **``iphone.py``** — drop the dead ``device_start_function=''`` kwarg from the ``script_capture_data`` test script.
- **``stim_param_reader.py``** — delete the ``device_start_function`` field from ``DeviceArgs``, and simplify ``DeviceArgs.instance_device_class`` to just ``return type(self).device_class()``. The ``start_mouse_stream`` string-match fallback it used to carry now references a nonexistent attribute and is unreachable: every in-tree ``DeviceArgs`` subclass (including the post-configs#104 ``MouseDeviceArgs``) overrides ``device_class()``.

### Docs / tests

- **``docs/arch/messaging_architecture.md``** — drop the ``DeviceManager.create_streams | _ALLOWED_DEVICE_MODULES`` row from the allowlist table; add a short note that the field/allowlist mechanism was retired in #696.
- **``docs/arch/adding_a_device.md``** — remove the "Known open item" bullet about the deprecated field.
- **``tests/pytest/test_device_pluggable.py``** — trim the module docstring and class docstring that explained why the mouse fallback was excluded from coverage.

## Coordination

Requires the **configs#104** deploy (``9a9db88`` on ``neurobooth/configs`` main). Any environment still on pre-configs#104 YAMLs will fail to load Mouse after this merge — ``arg_parser: DeviceArgs()`` → base ``device_class()`` → ``NotImplementedError``.

## Test plan

- [x] ``test_device_pluggable.py`` + ``test_device_lifecycle.py`` + ``neurobooth_os/iout/tests/`` pass locally (74 tests)
- [x] ``py_compile`` clean on ``iphone.py`` and ``stim_param_reader.py``
- [x] No residual ``device_start_function`` references in production code (only the historical context line in the messaging doc, which is intentional)