### PR TITLE
Retire DeviceArgs.instance_device_class (#708 item 3)

### DIFF
--- a/docs/arch/adding_a_device.md
+++ b/docs/arch/adding_a_device.md
@@ -396,7 +396,8 @@ touch indirectly:
 
 - **`create_streams(win, task_params)`** — iterates the unique `DeviceArgs`
   across all tasks for the session, instantiates each via
-  `device_args.instance_device_class()(device_args)`, and calls `bring_up`.
+  `type(device_args).device_class()(device_args=device_args)`, and calls
+  `bring_up`.
 - **`start_recording_devices`** / **`stop_recording_devices`** — operate on
   devices with `RECORD_PER_TASK` in parallel.
 - **`reconnect_for_task`** — calls `on_task_reconnect()` on every Device-backed

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -118,7 +118,7 @@ class DeviceManager:
             device_id = device_args.device_id
             self.logger.debug(f'Device Manager Starting: {device_id}')
             self.logger.debug(f'Device Manager Starting with args: {device_args}')
-            device_cls: Type[Device] = device_args.instance_device_class()
+            device_cls: Type[Device] = type(device_args).device_class()
             # Pass device_args as a keyword so Device subclasses with extra
             # positional parameters (e.g. IPhone's name) still bind correctly.
             device = device_cls(device_args=device_args).bring_up(context)

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -169,10 +169,6 @@ class DeviceArgs(EnvArgs):
             "Define a DeviceArgs subclass that overrides device_class()."
         )
 
-    def instance_device_class(self) -> Type["Device"]:
-        """Resolve the Device class for this instance via :meth:`device_class`."""
-        return type(self).device_class()
-
 
 class MicYetiDeviceArgs(DeviceArgs):
 


### PR DESCRIPTION
## Summary

Closes out #708 item 3.

- **``stim_param_reader.py``** — delete the ``instance_device_class`` method on the base ``DeviceArgs``. After #716 it was a one-line delegator to ``type(self).device_class()``; nothing else it carried (the mouse string-match fallback) survived that merge.
- **``lsl_streamer.py``** — update the single caller in ``DeviceManager.create_streams.start_and_register_device`` to call ``type(device_args).device_class()`` directly.
- **``docs/arch/adding_a_device.md``** — refresh the ``DeviceManager`` dispatch description to match the new call site.

## On item 3d

"Make ``DeviceArgs.device_class()`` raise ``NotImplementedError`` instead of returning a fallback" is already the state of the code — ``device_class()`` has raised ``NotImplementedError`` on the base class since #696. The "fallback" always lived in ``instance_device_class``, not ``device_class``, so item 3d was never really outstanding. I'll mark it done on the issue when I merge this PR.

## Test plan

- [x] ``test_device_pluggable.py`` + ``test_device_lifecycle.py`` + ``neurobooth_os/iout/tests/`` pass locally (74 tests)
- [x] No residual references to ``instance_device_class`` anywhere in the repo