### PR TITLE
Retire legacy marker_stream() function (#708 item 4)

### DIFF
--- a/neurobooth_os/iout/__init__.py
+++ b/neurobooth_os/iout/__init__.py
@@ -1,1 +1,0 @@
-from .marker import marker_stream

--- a/neurobooth_os/iout/marker.py
+++ b/neurobooth_os/iout/marker.py
@@ -1,6 +1,5 @@
 import time
-import uuid
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Optional
 
 from pylsl import StreamInfo, StreamOutlet
 
@@ -8,52 +7,6 @@ from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.msg.messages import DeviceInitialization, Request
 import neurobooth_os.iout.metadator as meta
-
-
-def marker_stream(name="Marker", outlet_id=None):
-    """Create marker stream to be pushed when needed with a string format:
-        "%s_%d_%timestamp" aka code string, number, time
-
-    Parameters
-    ----------
-    name : str, optional
-        marker stream name, by default 'Marker'
-    outlet_id : str, optional
-        source_id of the stream, by default 'Marker'
-
-
-    Returns
-    -------
-    outlet_marker : stream outlet object
-        return the stream outlet object created by StreamOutlet
-    """
-
-    # Setup outlet stream infos
-    if outlet_id is None:
-        outlet_id = str(uuid.uuid4())
-    stream_info_marker = set_stream_description(
-        stream_info=StreamInfo(name, "Markers", 1, channel_format="string", source_id=outlet_id),
-        device_id='marker',
-        sensor_ids=['marker'],
-        data_version=DataVersion(1, 0),
-        columns=['Marker'],
-        column_desc={'Marker': 'Marker message string'}
-    )
-
-    # Create outlets
-    outlet_marker = StreamOutlet(stream_info_marker)
-    outlet_marker.outlet_id = outlet_id
-    outlet_marker.name = name
-    outlet_marker.push_sample([f"Stream-created_0_{time.time()}"])
-
-    msg_body = DeviceInitialization(stream_name=name, outlet_id=outlet_id)
-    message = Request(source="marker", destination='CTR', body=msg_body)
-    meta.post_message(message)
-
-    outlet_marker.stop = outlet_marker.__del__
-    outlet_marker.streaming = True
-
-    return outlet_marker
 
 
 class MarkerStreamDevice(Device):

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -5,9 +5,6 @@ Covers the new surfaces: ``Device.bring_up`` default, the lifecycle hooks
 ``DeviceManager`` hook dispatch, capability-based ``camera_frame_preview``
 gating, ``MarkerStreamDevice`` delegation, and each ``DeviceArgs`` subclass's
 ``device_class()`` wiring.
-
-The legacy ``marker_stream()`` function is intentionally not tested — it is
-scheduled for removal in #708.
 """
 
 import logging


### PR DESCRIPTION
## Summary

Closes out #708 item 4. Pure code cleanup — no config coupling.

- ``marker_stream()`` in ``neurobooth_os/iout/marker.py`` has had no production callers since #696 introduced ``MarkerStreamDevice``. Delete the function (and its newly-unused ``uuid`` import).
- Remove the ``from .marker import marker_stream`` re-export from ``neurobooth_os/iout/__init__.py``; the file becomes empty, which is fine for a package marker.
- Drop the now-stale "scheduled for removal in #708" line from the ``test_device_pluggable.py`` module docstring.

## Scope note

``docs/arch/video_filename_tracking.md`` still references ``marker_stream()`` in its description of the pre-#686 filename-routing architecture. That entire doc is already historical — the "current flow" it describes was replaced with direct DB coordination in #686. Refreshing or archiving it is out of scope for this PR; I've left it intact so anyone reading it sees a line-number reference to a function that no longer exists, which is at least a clear "go look at #686" signal.

## Test plan

- [x] ``test_device_pluggable.py`` + ``test_device_lifecycle.py`` + ``neurobooth_os/iout/tests/`` pass locally (74 tests)
- [x] No residual references to the ``marker_stream()`` function in production code; remaining matches are the DeviceManager ``marker_stream`` attribute (section 5) and an unrelated local function in ``neurobooth_os/tasks/test_timing/marker.py``