### PR TITLE
Make the marker a config-driven Device (#708 item 5)

### DIFF
--- a/docs/arch/adding_a_device.md
+++ b/docs/arch/adding_a_device.md
@@ -420,11 +420,3 @@ touch indirectly:
 | `neurobooth_os/iout/mock_device.py`       | Mock implementations for testing                        |
 | `tests/pytest/test_device_lifecycle.py`   | Base-class lifecycle tests                              |
 | `tests/pytest/test_device_pluggable.py`   | `bring_up`, hooks, capability dispatch, registry tests  |
-
-## Known open items
-
-- **Marker stream is presentation-node-only.** `DeviceManager.create_streams`
-  still hard-codes the marker stream at the presentation node instead of
-  flowing it through a YAML like every other device. If you're curious or
-  want to pick it up, see the tracking issue for
-  [pluggable-device cleanup](https://github.com/neurobooth/neurobooth-os/issues/708).

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -87,8 +87,6 @@ class DeviceManager:
         self.assigned_devices = SERVER_ASSIGNMENTS[node_name]
         self.logger.debug(f'Devices assigned to {node_name}: {self.assigned_devices}')
 
-        self.marker_stream = node_name in ['presentation']
-
     def create_streams(self, win=None, task_params=None) -> None:
         """Initialize devices and LSL streams for this node's assigned devices.
 
@@ -97,6 +95,13 @@ class DeviceManager:
         ``Device`` class from the ``DeviceArgs`` subclass, instantiates it,
         and hands it a shared ``context`` dict.
 
+        Most devices are task-referenced, so their fully-populated
+        ``DeviceArgs`` (with ``sensor_array`` filled in by ``build_task``)
+        come via ``task_params``. Session-level devices that no task
+        references — e.g. the marker — are discovered through
+        ``metadator.read_devices`` and brought up with whatever their YAML
+        declares.
+
         Args:
             win: PsychoPy window (required for EyeTracker on the presentation node).
             task_params: Mapping of task IDs to TaskArgs. Used to determine which
@@ -104,13 +109,19 @@ class DeviceManager:
         """
         context: Mapping[str, Any] = {"psychopy_window": win}
 
-        if self.marker_stream:
-            from neurobooth_os.iout.marker import MarkerStreamDevice
-            self.logger.debug('Device Manager Starting: marker')
-            marker = MarkerStreamDevice()
-            marker.connect()
-            marker.start()
-            self.streams[MarkerStreamDevice.DEVICE_ID] = marker
+        task_device_args = DeviceManager._get_unique_devices(task_params)
+        session_device_args: Dict[str, DeviceArgs] = {}
+        missing = [d for d in self.assigned_devices if d not in task_device_args]
+        if missing:
+            registry = meta.read_devices()
+            for device_id in missing:
+                if device_id in registry:
+                    session_device_args[device_id] = registry[device_id]
+                else:
+                    self.logger.warning(
+                        f'Device Manager: assigned device "{device_id}" has no YAML entry; skipping.'
+                    )
+        all_device_args = {**task_device_args, **session_device_args}
 
         register_lock = threading.Lock()
 
@@ -130,11 +141,11 @@ class DeviceManager:
 
         with ThreadPoolExecutor(max_workers=N_ASYNC_THREADS) as executor:
             futures = []
-            kwargs: Dict[str, DeviceArgs] = DeviceManager._get_unique_devices(task_params)
-            for device_key, device_args in kwargs.items():
-                if device_key not in self.assigned_devices:
+            for device_id in self.assigned_devices:
+                if device_id not in all_device_args:
                     continue
-                if device_key in ASYNC_STARTUP:
+                device_args = all_device_args[device_id]
+                if device_id in ASYNC_STARTUP:
                     futures.append(executor.submit(start_and_register_device, device_args))
                 else:  # Run sequentially if not specified as async
                     start_and_register_device(device_args)

--- a/neurobooth_os/iout/marker.py
+++ b/neurobooth_os/iout/marker.py
@@ -5,6 +5,7 @@ from typing import Any, List, Mapping, Optional
 from pylsl import StreamInfo, StreamOutlet
 
 from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
+from neurobooth_os.iout.stim_param_reader import DeviceArgs
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.msg.messages import DeviceInitialization, Request
 import neurobooth_os.iout.metadator as meta
@@ -59,10 +60,9 @@ def marker_stream(name="Marker", outlet_id=None):
 class MarkerStreamDevice(Device):
     """Device wrapper around the LSL marker outlet.
 
-    The marker outlet has no hardware, sensors, or YAML config — it exists to
-    let tasks annotate the data stream. Wrapping it in a ``Device`` lets
-    ``DeviceManager`` treat it like any other stream instead of special-casing
-    the presentation node.
+    The marker outlet has no hardware — it exists to let tasks annotate the
+    data stream. Wrapping it in a ``Device`` lets ``DeviceManager`` treat it
+    like any other config-driven stream.
 
     Tasks call ``push_sample()`` directly on this object via the
     ``marker_outlet`` that ``STMSession`` forwards from ``DeviceManager.streams``.
@@ -70,15 +70,15 @@ class MarkerStreamDevice(Device):
 
     capabilities = DeviceCapability.STREAM
 
-    DEVICE_ID = "marker"
+    _DEFAULT_DEVICE_ID = "marker"
 
-    def __init__(self, name: str = "Marker", outlet_id: Optional[str] = None) -> None:
-        super().__init__(device_args=None)
-        self.device_id = self.DEVICE_ID
-        self.sensor_ids = [self.DEVICE_ID]
+    def __init__(self, device_args: Optional[DeviceArgs] = None,
+                 name: str = "Marker") -> None:
+        super().__init__(device_args)
+        if self.device_id is None:
+            self.device_id = self._DEFAULT_DEVICE_ID
+            self.sensor_ids = [self._DEFAULT_DEVICE_ID]
         self.name = name
-        if outlet_id is not None:
-            self.outlet_id = outlet_id
 
     def connect(self) -> None:
         stream_info = set_stream_description(

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -436,6 +436,20 @@ class MouseDeviceArgs(DeviceArgs):
         return MouseStream
 
 
+class MarkerDeviceArgs(DeviceArgs):
+    """DeviceArgs for the LSL marker stream.
+
+    The marker has no hardware; this subclass exists solely to let the
+    marker stream flow through the same config-driven path as every other
+    device, instead of being hard-coded in ``DeviceManager.create_streams``.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+        return MarkerStreamDevice
+
+
 class InstructionArgs(EnvArgs):
     """
         Arguments controlling psychopy instructions

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -41,7 +41,6 @@ def dm():
     manager.logger = logging.getLogger('test_device_pluggable')
     manager.streams = {}
     manager.assigned_devices = []
-    manager.marker_stream = False
     return manager
 
 
@@ -211,13 +210,25 @@ class TestCameraFramePreviewGating:
 
 
 class TestMarkerStreamDevice:
-    def test_identity(self):
+    def test_identity_default(self):
+        """Without device_args, MarkerStreamDevice falls back to 'marker' for id and sensor."""
         from neurobooth_os.iout.marker import MarkerStreamDevice
 
         device = MarkerStreamDevice()
-        assert device.device_id == MarkerStreamDevice.DEVICE_ID == 'marker'
+        assert device.device_id == 'marker'
         assert device.sensor_ids == ['marker']
         assert device.has_capability(DeviceCapability.STREAM)
+
+    def test_identity_from_device_args(self):
+        """With device_args, MarkerStreamDevice takes device_id and sensor_ids from them."""
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+
+        args = MagicMock()
+        args.device_id = 'marker_X'
+        args.sensor_ids = ['marker_sensor_X']
+        device = MarkerStreamDevice(device_args=args)
+        assert device.device_id == 'marker_X'
+        assert device.sensor_ids == ['marker_sensor_X']
 
     def test_push_sample_forwards_to_outlet(self):
         from neurobooth_os.iout.marker import MarkerStreamDevice
@@ -309,6 +320,11 @@ class TestDeviceArgsClassRegistry:
         from neurobooth_os.iout.stim_param_reader import MouseDeviceArgs
         from neurobooth_os.iout.mouse_tracker import MouseStream
         assert MouseDeviceArgs.device_class() is MouseStream
+
+    def test_marker_args(self):
+        from neurobooth_os.iout.stim_param_reader import MarkerDeviceArgs
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+        assert MarkerDeviceArgs.device_class() is MarkerStreamDevice
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Retires the presentation-node special case in ``DeviceManager.create_streams``. The marker now flows through the same YAML + ``DeviceArgs`` + ``device_class()`` path as every other device.

- ``stim_param_reader.py`` — add ``MarkerDeviceArgs(DeviceArgs)`` with a ``device_class()`` override.
- ``iout/marker.py`` — ``MarkerStreamDevice.__init__`` now accepts a ``DeviceArgs`` (optional — a direct ``MarkerStreamDevice()`` still works via an internal ``_DEFAULT_DEVICE_ID`` fallback, which the base-class tests and any legacy callers rely on). Drop the public ``DEVICE_ID`` class constant.
- ``iout/lsl_streamer.py`` — delete the ``self.marker_stream`` flag and the ``if self.marker_stream:`` block; extend ``create_streams`` to also bring up devices that are assigned to this server but not referenced by any task (session-level devices). Their ``DeviceArgs`` come from ``metadator.read_devices`` rather than ``task_params``.
- ``tests/pytest/test_device_pluggable.py`` — test both constructors (default and ``device_args``-driven); add a ``TestDeviceArgsClassRegistry.test_marker_args`` alongside the others; drop the ``manager.marker_stream`` attr from the ``dm`` fixture.
- ``docs/arch/adding_a_device.md`` — delete the "Known open items" section (the marker hard-code was its only entry).

## Companion configs PR

Requires [configs#105](https://github.com/neurobooth/configs/pull/105): adds ``shared/devices/marker.yml`` and the ``marker`` entry in each environment's presentation ``devices:`` list. Code in this PR will fail to find ``marker`` in the device registry if deployed ahead of the configs update.

## Notes

- ``create_streams`` now iterates ``self.assigned_devices`` rather than the task-derived device set. Devices assigned to the current server but referenced by no task are brought up anyway — that's the discovery path that makes the marker work. It also makes the overall logic clearer: "bring up what this server is supposed to run," not "bring up the intersection of task-requested and server-assigned."
- Smoke-tested locally (laptop env) — ``meta.read_devices()`` returns ``MarkerDeviceArgs``, ``device_class()`` resolves to ``MarkerStreamDevice``, and ``marker`` appears in the presentation devices list.

## Test plan

- [x] ``test_device_pluggable.py`` + ``test_device_lifecycle.py`` + ``neurobooth_os/iout/tests/`` pass locally (76 tests)
- [ ] Run on staging with the configs#105 companion deployed — verify tasks still get a working ``self.marker`` and push samples successfully