### PR TITLE
Sync adding_a_device.md with section-5 create_streams changes

### DIFF
--- a/docs/arch/adding_a_device.md
+++ b/docs/arch/adding_a_device.md
@@ -276,12 +276,21 @@ acquisition:
       - your_device             # ← here
 ```
 
-Most devices go on an acquisition server. EyeLink and Mouse are the only ones
-that currently run on the presentation server. The control server has no
-devices.
+Most devices go on an acquisition service. In a typical multi-machine
+deployment there are *two* acquisition services — one on the dedicated ACQ
+host (cameras, iPhone, the main microphone, ACQ-side Mbients) and a
+secondary one on the STM host (the Mouse and the STM-side Mbients). The
+presentation service runs on the STM host too but carries only `Eyelink_1`
+and the `marker` stream; the control service has no devices at all. The
+single-machine `laptop` config collapses these so Mouse and marker land on
+the presentation service directly.
 
-`DeviceManager` reads this list at startup (`SERVER_ASSIGNMENTS` in
-`lsl_streamer.py`), and each server brings up only the devices assigned to it.
+`DeviceManager` reads its assigned list at startup (`SERVER_ASSIGNMENTS` in
+`lsl_streamer.py`), and each service brings up only the devices assigned to
+it. A device that is assigned to this service but not referenced by any
+task (the marker is the canonical example) is still brought up — its
+`DeviceArgs` come from `metadator.read_devices()` rather than from a
+task's device list.
 
 ## Worked example: `MouseStream`
 
@@ -394,10 +403,12 @@ Follow the patterns there when writing tests for your device:
 `DeviceManager` (in `lsl_streamer.py`) is device-agnostic. The code paths you'll
 touch indirectly:
 
-- **`create_streams(win, task_params)`** — iterates the unique `DeviceArgs`
-  across all tasks for the session, instantiates each via
-  `type(device_args).device_class()(device_args=device_args)`, and calls
-  `bring_up`.
+- **`create_streams(win, task_params)`** — iterates `self.assigned_devices`,
+  looks each `DeviceArgs` up in either the task-derived map (populated from
+  `task_params`) or the registry (`metadator.read_devices()`, used for
+  devices assigned to this server but not referenced by any task),
+  instantiates via `type(device_args).device_class()(device_args=device_args)`,
+  and calls `bring_up`.
 - **`start_recording_devices`** / **`stop_recording_devices`** — operate on
   devices with `RECORD_PER_TASK` in parallel.
 - **`reconnect_for_task`** — calls `on_task_reconnect()` on every Device-backed


### PR DESCRIPTION
## Summary

Two spots in ``docs/arch/adding_a_device.md`` drifted over time:

- **"Step 4: Assign the device to a service"** — previously said "EyeLink and Mouse are the only ones that currently run on the presentation server", which conflated *which service runs a device* with *which machine hosts the service*. In the production multi-machine configs (wang / merrimac / ctru / staging) the presentation service only runs ``Eyelink_1`` and ``marker``; Mouse and the two STM-side Mbients (``Mbient_LF_2``, ``Mbient_RF_2``) belong to a *secondary acquisition service* that happens to share the STM machine with presentation. The laptop config is the only place Mouse lands on the presentation service directly. Rewrote the paragraph to describe the actual service topology and added a note that a device assigned to a service but not referenced by any task is still brought up via ``metadator.read_devices()`` (that path is new in #719, and the marker is its canonical user).
- **"How DeviceManager dispatches"** — the ``create_streams`` bullet still said the method iterates the unique ``DeviceArgs`` across all tasks. Post-#719 it iterates ``self.assigned_devices`` and resolves each ``DeviceArgs`` from either the task-derived map or the registry. Rewrote the bullet.

Everything else in the doc (capability table, device catalog, abstract-method list, hooks table, Mouse worked example, ``bring_up`` default semantics, key-source-files table, test-file references) matches the code on master.

## Test plan

- [x] Manually diffed the doc's claims against ``device.py``, ``lsl_streamer.py``, ``stim_param_reader.py``, and ``marker.py`` on master.
- [x] Cross-checked the service/device topology against every environment YAML in ``configs/environments/*/neurobooth_os_config.yaml``.
- [x] No code or test changes; docs-only PR.