### PR TITLE
Gate session-level device discovery on a SESSION_LEVEL capability

### DIFF
--- a/docs/arch/adding_a_device.md
+++ b/docs/arch/adding_a_device.md
@@ -127,6 +127,7 @@ devices participate in each operation.
 | `WEARABLE`         | BLE/wireless; connection may drop and be re-established.       |
 | `CALIBRATABLE`     | Supports calibration (EyeLink).                                |
 | `RESETTABLE`       | Participates in the operator-triggered reset.                  |
+| `SESSION_LEVEL`    | Brought up regardless of whether any task references it (marker). |
 
 A safe default: forgetting to set `capabilities` on a subclass leaves it at
 `DeviceCapability(0)`, so the device is simply not matched by any query.
@@ -286,11 +287,14 @@ single-machine `laptop` config collapses these so Mouse and marker land on
 the presentation service directly.
 
 `DeviceManager` reads its assigned list at startup (`SERVER_ASSIGNMENTS` in
-`lsl_streamer.py`), and each service brings up only the devices assigned to
-it. A device that is assigned to this service but not referenced by any
-task (the marker is the canonical example) is still brought up — its
-`DeviceArgs` come from `metadator.read_devices()` rather than from a
-task's device list.
+`lsl_streamer.py`), and each service brings up only the devices that are
+both assigned to it and referenced by a selected task. A device assigned
+but not referenced by any task is skipped by default — unless it declares
+`DeviceCapability.SESSION_LEVEL`, in which case `DeviceManager` loads its
+`DeviceArgs` via `metadator.read_devices()` and brings it up anyway. The
+marker is the canonical `SESSION_LEVEL` device; most devices (cameras,
+wearables, etc.) rely on task-populated `sensor_array` state in their
+`__init__` and must stay task-driven.
 
 ## Worked example: `MouseStream`
 
@@ -396,7 +400,7 @@ Follow the patterns there when writing tests for your device:
 | Intel RealSense  | `VidRec_Intel`    | `RECORD \| RECORD_PER_TASK`                                |
 | iPhone           | `IPhone`          | `RECORD \| RECORD_PER_TASK \| CAMERA_PREVIEW`              |
 | EyeLink tracker  | `EyeTracker`      | `RECORD \| CALIBRATABLE`                                   |
-| Marker stream    | `MarkerStreamDevice` | `STREAM`                                                |
+| Marker stream    | `MarkerStreamDevice` | `STREAM \| SESSION_LEVEL`                               |
 
 ### How `DeviceManager` dispatches
 
@@ -404,11 +408,12 @@ Follow the patterns there when writing tests for your device:
 touch indirectly:
 
 - **`create_streams(win, task_params)`** — iterates `self.assigned_devices`,
-  looks each `DeviceArgs` up in either the task-derived map (populated from
-  `task_params`) or the registry (`metadator.read_devices()`, used for
-  devices assigned to this server but not referenced by any task),
-  instantiates via `type(device_args).device_class()(device_args=device_args)`,
-  and calls `bring_up`.
+  preferring the task-derived `DeviceArgs` map (populated from `task_params`);
+  for devices that are assigned but not task-referenced, loads their
+  `DeviceArgs` from the registry (`metadator.read_devices()`) **only if**
+  they declare `DeviceCapability.SESSION_LEVEL`. Instantiates each survivor
+  via `type(device_args).device_class()(device_args=device_args)` and calls
+  `bring_up`.
 - **`start_recording_devices`** / **`stop_recording_devices`** — operate on
   devices with `RECORD_PER_TASK` in parallel.
 - **`reconnect_for_task`** — calls `on_task_reconnect()` on every Device-backed

--- a/neurobooth_os/iout/device.py
+++ b/neurobooth_os/iout/device.py
@@ -24,6 +24,7 @@ class DeviceCapability(Flag):
     CALIBRATABLE = auto()     # Supports calibration (eyelink)
     RECORD_PER_TASK = auto()  # Recording is driven by the per-task lifecycle (cameras)
     RESETTABLE = auto()       # Participates in operator-triggered reset (mbient)
+    SESSION_LEVEL = auto()    # Brought up regardless of whether any task references it (marker)
 
 
 class DeviceState(Enum):

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -109,18 +109,37 @@ class DeviceManager:
         """
         context: Mapping[str, Any] = {"psychopy_window": win}
 
+        # Task-referenced devices come through with their sensor_array fully
+        # populated by metadator.build_task. Devices that are assigned to this
+        # server but not referenced by any selected task are only brought up
+        # if they opt in via DeviceCapability.SESSION_LEVEL — today the marker
+        # stream is the only such device. Pulling a registry entry whose
+        # __init__ derives state from sensor_array would crash here (the
+        # registry path does not populate it), so the opt-in is strict.
         task_device_args = DeviceManager._get_unique_devices(task_params)
         session_device_args: Dict[str, DeviceArgs] = {}
         missing = [d for d in self.assigned_devices if d not in task_device_args]
         if missing:
             registry = meta.read_devices()
             for device_id in missing:
-                if device_id in registry:
-                    session_device_args[device_id] = registry[device_id]
-                else:
+                if device_id not in registry:
                     self.logger.warning(
                         f'Device Manager: assigned device "{device_id}" has no YAML entry; skipping.'
                     )
+                    continue
+                dev_args = registry[device_id]
+                try:
+                    dev_class = type(dev_args).device_class()
+                except NotImplementedError:
+                    self.logger.warning(
+                        f'Device Manager: assigned device "{device_id}" has no device_class binding; skipping.'
+                    )
+                    continue
+                if DeviceCapability.SESSION_LEVEL in dev_class.capabilities:
+                    session_device_args[device_id] = dev_args
+                # Else: device isn't task-referenced and hasn't opted into
+                # session-level startup. Silently skip — matches pre-v0.88.0
+                # behaviour of "only bring up what a selected task asks for."
         all_device_args = {**task_device_args, **session_device_args}
 
         register_lock = threading.Lock()

--- a/neurobooth_os/iout/marker.py
+++ b/neurobooth_os/iout/marker.py
@@ -21,7 +21,7 @@ class MarkerStreamDevice(Device):
     ``marker_outlet`` that ``STMSession`` forwards from ``DeviceManager.streams``.
     """
 
-    capabilities = DeviceCapability.STREAM
+    capabilities = DeviceCapability.STREAM | DeviceCapability.SESSION_LEVEL
 
     _DEFAULT_DEVICE_ID = "marker"
 

--- a/tests/pytest/test_device_pluggable.py
+++ b/tests/pytest/test_device_pluggable.py
@@ -377,3 +377,27 @@ class TestResettableAssignment:
     def test_eyetracker_is_not_resettable(self):
         from neurobooth_os.iout.eyelink_tracker import EyeTracker
         assert DeviceCapability.RESETTABLE not in EyeTracker.capabilities
+
+
+class TestSessionLevelAssignment:
+    """Only MarkerStreamDevice declares SESSION_LEVEL — the capability gates
+    which assigned-but-not-task-referenced devices DeviceManager brings up.
+
+    Without this opt-in, registry-loaded DeviceArgs for devices like cameras
+    arrive without a populated sensor_array and crash on ``__init__``.
+    """
+
+    def test_marker_has_session_level(self):
+        from neurobooth_os.iout.marker import MarkerStreamDevice
+        assert DeviceCapability.SESSION_LEVEL in MarkerStreamDevice.capabilities
+
+    def test_cameras_are_not_session_level(self):
+        from neurobooth_os.iout.flir_cam import VidRec_Flir
+        from neurobooth_os.iout.webcam import VidRec_Webcam
+        from neurobooth_os.iout.camera_intel import VidRec_Intel
+        for cls in (VidRec_Flir, VidRec_Webcam, VidRec_Intel):
+            assert DeviceCapability.SESSION_LEVEL not in cls.capabilities
+
+    def test_mbient_is_not_session_level(self):
+        from neurobooth_os.iout.mbient import Mbient
+        assert DeviceCapability.SESSION_LEVEL not in Mbient.capabilities


### PR DESCRIPTION
## Symptom

Staging acquisition bring-up crashes on v0.88.0:

\`\`\`
File ".../neurobooth_os/iout/lsl_streamer.py", line 135, in start_and_register_device
    device = device_cls(device_args=device_args).bring_up(context)
File ".../neurobooth_os/iout/camera_intel.py", line 58, in __init__
    self.device_args.framesize()[0][0],
TypeError: 'NoneType' object is not subscriptable
\`\`\`

## Root cause

#719 (section 5 of #708) widened ``create_streams`` so a device assigned to a server but not referenced by any selected task would still be brought up, via ``metadator.read_devices()``. That unblocked the marker (which is never in a task's ``device_id_array``) but as a side effect it also brought up any *other* assigned device that happened not to be referenced by the selected tasks. Registry-loaded ``DeviceArgs`` don't have ``sensor_array`` populated (``metadator.build_task`` does that during task construction), and ``VidRec_Intel.__init__`` — like several other devices — dereferences ``sensor_array`` during construction.

Whenever an environment had a task set that didn't exercise every assigned camera (the case on staging), ``create_streams`` would try to bring up the unreferenced camera through the registry path and crash at ``__init__``.

## Fix

Gate the registry/session-level path on an explicit opt-in capability.

- **New ``DeviceCapability.SESSION_LEVEL``** — flag for devices that should be brought up regardless of task usage. Today only ``MarkerStreamDevice`` declares it.
- **``DeviceManager.create_streams``** — for an assigned-but-not-task-referenced device, only take the registry path if the resolved ``Device`` class has ``SESSION_LEVEL`` in its capabilities. Everything else is skipped (matches pre-v0.88.0 behaviour: "only bring up what a selected task asks for"). Also wrap the ``device_class()`` lookup in a ``try/except NotImplementedError`` so a stray YAML without a ``device_class`` binding logs and skips instead of crashing the server bring-up.
- **Tests** — three new assertions in ``TestSessionLevelAssignment``: marker declares ``SESSION_LEVEL``; cameras and Mbient don't. 79 total pass locally.
- **Docs** — capability catalog row, ``create_streams`` dispatch description, and "Step 4: Assign the device to a service" paragraph in ``adding_a_device.md`` all updated.

## Validation

Local smoke test on the laptop config:

- ``presentation`` assigned = ``[Mouse, marker]``. Mouse resolves to ``MouseStream`` (``session_level=False``) — task-driven. marker resolves to ``MarkerStreamDevice`` (``session_level=True``) — session-level path.
- ``acquisition_0`` assigned = ``[Mic_Yeti_dev_1, Mock_IPhone_dev_1]``. With no tasks, no opt-ins, no crashes.

## Test plan

- [x] ``test_device_pluggable.py`` + ``test_device_lifecycle.py`` + ``neurobooth_os/iout/tests/`` pass locally (79 tests)
- [ ] Deploy to staging — verify an ACQ that previously crashed now completes ``PrepareRequest`` cleanly