### PR TITLE
Phase 0: mock-device substitution + lazy hardware imports

### DIFF
--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -104,6 +104,13 @@ class NeuroboothConfig(BaseModel):
     machines: Dict[str, MachineSpec]
     database: DatabaseSpec
     screen: ScreenSpec
+    # Persistent mock-device opt-in. Comma-separated device-class names
+    # (e.g. ["Mbient", "IPhone"]) or the special value ["all"]. Overridden
+    # by the NB_MOCK_DEVICES environment variable when set. Devices listed
+    # here are substituted with their registered mock counterpart at
+    # DeviceManager startup. See docs/arch/adding_a_device.md → "Running
+    # with mocks".
+    mock_devices: Optional[List[str]] = None
 
     _acquisition_specs: List[ServiceSpec] = PrivateAttr(default_factory=list)
     _presentation_spec: Optional[ServiceSpec] = PrivateAttr(default=None)

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -659,6 +659,24 @@ def gui(logger):
     logger.info(f"Neurobooth application version = {state.release_version}")
     logger.info(f"Neurobooth config version = {state.config_version}")
 
+    # Defensive: surface mock-device substitution clearly so a forgotten
+    # NB_MOCK_DEVICES env var or stray mock_devices config field cannot
+    # silently corrupt a real recording. Logged at CRITICAL so it shows in
+    # session logs; a popup is shown so the operator sees it before any
+    # session starts.
+    from neurobooth_os.iout.mock_substitution import active_mock_targets
+    _mock_targets = active_mock_targets()
+    if _mock_targets:
+        _banner = ("MOCK DEVICES ACTIVE — this session will NOT record real "
+                   f"hardware data. Active targets: {sorted(_mock_targets)}")
+        logger.critical(_banner)
+        try:
+            sg.popup_ok(_banner, title="Mock devices active",
+                        background_color="#ffe6e6", text_color="#660000")
+        except Exception:
+            # Popup is best-effort; the log line is the source of truth.
+            pass
+
     nodes = get_nodes()
 
     system_resource_logger = SystemResourceLogger(machine_name='CTR')

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -5,7 +5,27 @@ from typing import Any, List, Mapping, Optional, Tuple
 
 import numpy as np
 
-import pylink
+# Hardware import — guarded so this module is importable on a hardware-less
+# laptop. Real EyeTracker code paths still require pylink and will fail
+# loudly when called without it.
+try:
+    import pylink
+    _HAS_PYLINK = True
+except ImportError:
+    pylink = None  # type: ignore[assignment]
+    _HAS_PYLINK = False
+
+
+def _require_pylink() -> None:
+    """Raise a clear error if real-EyeLink code is reached without pylink."""
+    if not _HAS_PYLINK:
+        raise RuntimeError(
+            "EyeLink hardware code path invoked but pylink is not installed. "
+            "Install the EyeLink SDK (pylink) to use a real EyeLink, or use "
+            "MockEyeTracker via NB_MOCK_DEVICES=EyeTracker for hardware-less testing."
+        )
+
+
 from psychopy import visual, monitors
 from pylsl import StreamInfo, StreamOutlet, local_clock
 
@@ -13,9 +33,6 @@ from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.metadator import post_message
 from neurobooth_os.iout.stim_param_reader import EyelinkDeviceArgs
 from neurobooth_os.msg.messages import NoEyetracker, Request, DeviceInitialization
-from neurobooth_os.tasks.smooth_pursuit.EyeLinkCoreGraphicsPsychoPy import (
-    EyeLinkCoreGraphicsPsychoPy,
-)
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.log_manager import APP_LOG_NAME
 
@@ -112,6 +129,7 @@ class EyeTracker(Device):
             self.state = DeviceState.CONNECTED
 
     def _connect_tracker(self):
+        _require_pylink()
         try:
             self.tk = pylink.EyeLink(self.IP)
         except RuntimeError:
@@ -176,6 +194,14 @@ class EyeTracker(Device):
         post_message(msg)
 
     def calibrate(self):
+        # Imported here rather than at module top so eyelink_tracker.py loads
+        # cleanly on a hardware-less laptop. EyeLinkCoreGraphicsPsychoPy chains
+        # through to pylink at import time; calibrate() is only ever called
+        # against a real (or appropriately mocked) hardware path.
+        _require_pylink()
+        from neurobooth_os.tasks.smooth_pursuit.EyeLinkCoreGraphicsPsychoPy import (
+            EyeLinkCoreGraphicsPsychoPy,
+        )
         self.logger.debug('EyeLink: Performing Calibration')
         calib_prompt = "You will see dots on the screen, please gaze at them"
         calib_msg = visual.TextStim(
@@ -205,6 +231,7 @@ class EyeTracker(Device):
         Returns:
             List containing the created EDF file basename.
         """
+        _require_pylink()
         if filename is None:
             filename = "TEST.edf"
         self.filename = filename

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -11,6 +11,9 @@ import neurobooth_os.iout.metadator as meta
 from neurobooth_os.iout.device import (
     Device, DeviceCapability, CameraPreviewException,
 )
+from neurobooth_os.iout.mock_substitution import (
+    active_mock_targets, apply_mock_substitution,
+)
 from neurobooth_os.msg.messages import DeviceInitialization, Request
 
 
@@ -117,6 +120,27 @@ class DeviceManager:
         # __init__ derives state from sensor_array would crash here (the
         # registry path does not populate it), so the opt-in is strict.
         task_device_args = DeviceManager._get_unique_devices(task_params)
+
+        # Mock-device substitution. NB_MOCK_DEVICES env var or the
+        # NeuroboothConfig.mock_devices field can swap real DeviceArgs for
+        # mock counterparts before device_class() is resolved. See
+        # neurobooth_os/iout/mock_substitution.py.
+        active_mocks = active_mock_targets()
+        if active_mocks:
+            self.logger.info(
+                f'Device Manager: mock targets active = {sorted(active_mocks)}'
+            )
+            substituted = {}
+            for dev_id, dev_args in task_device_args.items():
+                new_args = apply_mock_substitution(dev_args, active_mocks)
+                if new_args is not dev_args:
+                    self.logger.info(
+                        f'Device Manager: mocking {dev_id} '
+                        f'({type(dev_args).__name__} -> {type(new_args).__name__})'
+                    )
+                substituted[dev_id] = new_args
+            task_device_args = substituted
+
         session_device_args: Dict[str, DeviceArgs] = {}
         missing = [d for d in self.assigned_devices if d not in task_device_args]
         if missing:
@@ -128,6 +152,14 @@ class DeviceManager:
                     )
                     continue
                 dev_args = registry[device_id]
+                if active_mocks:
+                    new_args = apply_mock_substitution(dev_args, active_mocks)
+                    if new_args is not dev_args:
+                        self.logger.info(
+                            f'Device Manager: mocking {device_id} '
+                            f'({type(dev_args).__name__} -> {type(new_args).__name__})'
+                        )
+                        dev_args = new_args
                 try:
                     dev_class = type(dev_args).device_class()
                 except NotImplementedError:

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import argparse
 import threading
@@ -9,8 +11,36 @@ from typing import Any, Dict, List, Callable, Mapping, NamedTuple, Optional
 from abc import ABC, abstractmethod
 from enum import IntEnum
 
-from mbientlab.warble import BleScanner
-from mbientlab.metawear import MetaWear, libmetawear, parse_value, cbindings, Module, Model
+# Hardware imports — guarded so this module is importable on a hardware-less
+# laptop (the mock subclass loads the parent without needing mbientlab).
+# Real device code paths still require these and will fail loudly when called
+# without the SDK installed.
+try:
+    from mbientlab.warble import BleScanner
+    from mbientlab.metawear import (
+        MetaWear, libmetawear, parse_value, cbindings, Module, Model,
+    )
+    _HAS_MBIENTLAB = True
+except ImportError:
+    BleScanner = None  # type: ignore[assignment]
+    MetaWear = None  # type: ignore[assignment]
+    libmetawear = None  # type: ignore[assignment]
+    parse_value = None  # type: ignore[assignment]
+    cbindings = None  # type: ignore[assignment]
+    Module = None  # type: ignore[assignment]
+    Model = None  # type: ignore[assignment]
+    _HAS_MBIENTLAB = False
+
+
+def _require_mbientlab() -> None:
+    """Raise a clear error if real-Mbient code is reached without the SDK."""
+    if not _HAS_MBIENTLAB:
+        raise RuntimeError(
+            "Mbient hardware code path invoked but the mbientlab SDK is not "
+            "installed. Install mbientlab to use real Mbient devices, or use "
+            "MockMbient via NB_MOCK_DEVICES=Mbient for hardware-less testing."
+        )
+
 
 from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.metadator import post_message, get_database_connection
@@ -207,14 +237,19 @@ class MetaWearWrapper(ABC):
     """
     A wrapper around a MetaWear object that provices an additional layer of abstraction.
     """
-    SUPPORTED_DEVICE_MODELS = [  # Should be the models with both accelerometer and gyroscope
-        Model.METAMOTION_S,
-        Model.METAMOTION_R,
-        Model.METAMOTION_RL,
-        Model.METAMOTION_C,
-        Model.METAWEAR_RG,
-        Model.METAWEAR_RPRO
-    ]
+
+    @classmethod
+    def supported_device_models(cls):
+        """Return the list of supported device-model constants (lazy: requires mbientlab)."""
+        _require_mbientlab()
+        return [
+            Model.METAMOTION_S,
+            Model.METAMOTION_R,
+            Model.METAMOTION_RL,
+            Model.METAMOTION_C,
+            Model.METAWEAR_RG,
+            Model.METAWEAR_RPRO,
+        ]
 
     @staticmethod
     def create_wrapper(device: MetaWear) -> 'MetaWearWrapper':
@@ -224,9 +259,10 @@ class MetaWearWrapper(ABC):
         :param device: The MetaWear object to wrap.
         :returns: An appropriate wrapper selected based on the board's configuration.
         """
+        _require_mbientlab()
         board = device.board
         model = libmetawear.mbl_mw_metawearboard_get_model(board)
-        if model not in MetaWearWrapper.SUPPORTED_DEVICE_MODELS:
+        if model not in MetaWearWrapper.supported_device_models():
             model_name = libmetawear.mbl_mw_metawearboard_get_model_name(board).decode()
             raise UnsupportedDevice(f'Unsupported Device Model: {model_name}')
 
@@ -509,8 +545,12 @@ class Mbient(Device):
         self.data_handlers: List['Mbient.DATA_HANDLER'] = []
         self._auto_reconnect_failures: int = 0
 
-        # Streaming-related variables
-        self.callback = cbindings.FnVoid_VoidP_DataP(self._callback)
+        # Streaming-related variables. The C-level callback binding is created
+        # lazily in setup() (where it's actually subscribed) so that
+        # constructing an Mbient instance does not require the mbientlab SDK
+        # to be installed — the mock subclass can call super().__init__
+        # without triggering the cbindings dereference.
+        self.callback = None
         self.n_samples_streamed = 0
 
         self.logger.debug(self.format_message(f'acc={self.accel_params}; gyro={self.gyro_params}'))
@@ -828,6 +868,7 @@ class Mbient(Device):
 
     def setup(self) -> None:
         """Configure the device (i.e., connection settings, sensor settings, data streaming callback)"""
+        _require_mbientlab()
         self.device_wrapper.setup_connection_settings(self.connection_params)
         sensor_signals = self.device_wrapper.setup_sensor_settings(self.accel_params, self.gyro_params)
 
@@ -835,6 +876,8 @@ class Mbient(Device):
         # (As opposed to an anonymous lambda or function-scoped variable.)
         # If not, then the program will silently fail when the callback gets triggered.
         # Speculation: Python can garbage collect variables that the C bindings expect to exist => memory access error.
+        if self.callback is None:
+            self.callback = cbindings.FnVoid_VoidP_DataP(self._callback)
         processor = MetaWearWrapper.create_data_fusion_processor(sensor_signals)
         if DISABLE_LSL:
             self.logger.warning('LSL Disabled!')

--- a/neurobooth_os/iout/mock_substitution.py
+++ b/neurobooth_os/iout/mock_substitution.py
@@ -1,0 +1,129 @@
+"""Mock-device substitution registry and resolution helpers.
+
+Mocks register themselves at import time via :func:`register_mock`, mapping a
+real ``DeviceArgs`` subclass to a mock counterpart. ``DeviceManager`` consults
+:func:`active_mock_targets` and :func:`apply_mock_substitution` during
+``create_streams`` to swap real device args for mock ones before
+``device_class()`` resolution runs.
+
+The active set comes from two sources, in priority order:
+
+1. ``NB_MOCK_DEVICES`` environment variable — comma-separated device-class
+   names (``Mbient,IPhone,EyeTracker``) or the special value ``all``.
+2. ``NeuroboothConfig.mock_devices`` field — same shape, persisted in
+   ``neurobooth_os_config.yaml``.
+
+The env var wins when both are set so a developer can always force-disable
+or force-enable mocks for a single run without editing config files.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Set, Type, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from neurobooth_os.iout.stim_param_reader import DeviceArgs
+
+
+# real DeviceArgs subclass -> mock DeviceArgs subclass
+MOCK_REGISTRY: Dict[Type["DeviceArgs"], Type["DeviceArgs"]] = {}
+
+# Sentinel that means "every registered mock target is active".
+_ALL = "all"
+
+ENV_VAR = "NB_MOCK_DEVICES"
+
+
+def register_mock(real_cls: Type["DeviceArgs"],
+                  mock_cls: Type["DeviceArgs"]) -> None:
+    """Register a mock DeviceArgs subclass as a substitute for a real one.
+
+    Called at module-import time from each mock module. ``mock_cls`` must
+    be a subclass of ``real_cls`` so all of ``real_cls``'s field validation
+    still applies; this is enforced at registration time.
+    """
+    if not issubclass(mock_cls, real_cls):
+        raise TypeError(
+            f"{mock_cls.__name__} must be a subclass of {real_cls.__name__} "
+            "to register as its mock"
+        )
+    MOCK_REGISTRY[real_cls] = mock_cls
+
+
+def _parse_target_list(raw: Optional[str]) -> Set[str]:
+    """Parse ``"Mbient,IPhone"`` or ``"all"`` into a normalised set."""
+    if not raw:
+        return set()
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def active_mock_targets() -> Set[str]:
+    """Return the set of mock-target names active for this run.
+
+    Sources, in priority order: ``NB_MOCK_DEVICES`` env var, then
+    ``NeuroboothConfig.mock_devices``. The result contains *device-class
+    names* (e.g. ``"Mbient"``, ``"IPhone"``, ``"EyeTracker"``) — not
+    device IDs — and may contain the literal ``"all"`` sentinel.
+
+    Returns an empty set when neither source is set or the config has not
+    been loaded.
+    """
+    env_raw = os.environ.get(ENV_VAR)
+    if env_raw is not None:
+        return _parse_target_list(env_raw)
+
+    # Fallback to the config field. Config may not be loaded yet (e.g. unit
+    # tests that import this module before calling load_config); treat that
+    # as "no config-driven targets".
+    try:
+        from neurobooth_os import config as cfg
+        targets = getattr(cfg.neurobooth_config, "mock_devices", None)
+    except Exception:
+        return set()
+    if not targets:
+        return set()
+    return {t.strip() for t in targets if t and t.strip()}
+
+
+def _is_target_active(real_cls: Type["DeviceArgs"], active: Set[str]) -> bool:
+    """Whether the mock for ``real_cls`` should be substituted in this run."""
+    if not active:
+        return False
+    if _ALL in active:
+        return True
+    # Match against the resolved Device class name. We use the Device class
+    # (not the DeviceArgs class name) so a user writes
+    # NB_MOCK_DEVICES=Mbient rather than NB_MOCK_DEVICES=MbientDeviceArgs.
+    try:
+        device_cls_name = real_cls.device_class().__name__
+    except (NotImplementedError, ImportError, Exception):
+        return False
+    return device_cls_name in active
+
+
+def apply_mock_substitution(device_args: "DeviceArgs",
+                            active: Optional[Set[str]] = None) -> "DeviceArgs":
+    """Return a mock-substituted ``DeviceArgs`` instance, or the original.
+
+    Field values from ``device_args`` are preserved on the substituted
+    instance via Pydantic ``model_construct`` — no re-validation runs, so
+    fields like ``ENV_devices`` that the original loader populated stay
+    intact.
+    """
+    if active is None:
+        active = active_mock_targets()
+    if not active:
+        return device_args
+
+    real_cls = type(device_args)
+    if real_cls not in MOCK_REGISTRY:
+        return device_args
+    if not _is_target_active(real_cls, active):
+        return device_args
+
+    mock_cls = MOCK_REGISTRY[real_cls]
+    # Reuse the validated field values from the real instance. model_construct
+    # skips re-validation, which is what we want — the YAML already validated
+    # them once.
+    return mock_cls.model_construct(**device_args.model_dump())

--- a/tests/pytest/test_mock_substitution.py
+++ b/tests/pytest/test_mock_substitution.py
@@ -1,0 +1,225 @@
+"""Tests for the mock-device substitution mechanism.
+
+Covers:
+- ``register_mock`` registry behaviour and the subclass-of guard.
+- ``active_mock_targets`` source priority (env var > config field).
+- ``apply_mock_substitution`` returns the original instance when no
+  substitution applies, and a mock instance when it does.
+- The lazy hardware imports in ``mbient.py`` and ``eyelink_tracker.py``
+  do not require the underlying SDKs to be installed at import time.
+"""
+
+import builtins
+import importlib
+import os
+import sys
+from typing import Type
+from unittest.mock import patch
+
+import pytest
+
+from neurobooth_os.iout import mock_substitution as ms
+from neurobooth_os.iout.stim_param_reader import DeviceArgs
+
+
+# ---------------------------------------------------------------------------
+# Test-only DeviceArgs subclasses (don't pollute the real registry).
+# ---------------------------------------------------------------------------
+
+class _RealForTest(DeviceArgs):
+    @classmethod
+    def device_class(cls):
+        # Returns a stand-in class whose __name__ controls active-target
+        # matching. Tests can monkeypatch this.
+        return _RealDeviceCls
+
+
+class _MockForTest(_RealForTest):
+    @classmethod
+    def device_class(cls):
+        return _MockDeviceCls
+
+
+class _RealDeviceCls:
+    pass
+
+
+class _MockDeviceCls:
+    pass
+
+
+def _make_real(env_devices=None) -> _RealForTest:
+    """Build a _RealForTest instance with the minimum fields populated."""
+    return _RealForTest(
+        ENV_devices=env_devices or {"d1": {}},
+        device_id="d1",
+        arg_parser="iout.stim_param_reader.py::_RealForTest()",
+        sensor_ids=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: keep the global registry clean between tests.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    saved = dict(ms.MOCK_REGISTRY)
+    ms.MOCK_REGISTRY.clear()
+    yield
+    ms.MOCK_REGISTRY.clear()
+    ms.MOCK_REGISTRY.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(ms.ENV_VAR, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Registry behaviour
+# ---------------------------------------------------------------------------
+
+class TestRegister:
+    def test_register_then_lookup(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        assert ms.MOCK_REGISTRY[_RealForTest] is _MockForTest
+
+    def test_subclass_guard_rejects_non_subclass(self):
+        class _Unrelated(DeviceArgs):
+            pass
+        with pytest.raises(TypeError, match="must be a subclass"):
+            ms.register_mock(_RealForTest, _Unrelated)
+
+
+# ---------------------------------------------------------------------------
+# active_mock_targets parsing + priority
+# ---------------------------------------------------------------------------
+
+class TestActiveMockTargets:
+    def test_unset_returns_empty(self):
+        assert ms.active_mock_targets() == set()
+
+    def test_env_var_single(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, "Mbient")
+        assert ms.active_mock_targets() == {"Mbient"}
+
+    def test_env_var_multi_with_whitespace(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, " Mbient , IPhone , EyeTracker ")
+        assert ms.active_mock_targets() == {"Mbient", "IPhone", "EyeTracker"}
+
+    def test_env_var_all_sentinel(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, "all")
+        assert ms.active_mock_targets() == {"all"}
+
+    def test_env_var_empty_string_is_empty(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, "")
+        # Empty string means "set but empty"; treat as no targets.
+        assert ms.active_mock_targets() == set()
+
+    def test_config_fallback_when_env_unset(self, monkeypatch):
+        from neurobooth_os import config as cfg
+        # Inject a fake neurobooth_config exposing mock_devices.
+        class _Stub:
+            mock_devices = ["IPhone"]
+        monkeypatch.setattr(cfg, "neurobooth_config", _Stub())
+        assert ms.active_mock_targets() == {"IPhone"}
+
+    def test_env_var_wins_over_config(self, monkeypatch):
+        from neurobooth_os import config as cfg
+        class _Stub:
+            mock_devices = ["IPhone"]
+        monkeypatch.setattr(cfg, "neurobooth_config", _Stub())
+        monkeypatch.setenv(ms.ENV_VAR, "Mbient")
+        assert ms.active_mock_targets() == {"Mbient"}
+
+    def test_unloaded_config_returns_empty(self, monkeypatch):
+        from neurobooth_os import config as cfg
+        # Simulate config not yet loaded — neurobooth_config is None.
+        monkeypatch.setattr(cfg, "neurobooth_config", None)
+        assert ms.active_mock_targets() == set()
+
+
+# ---------------------------------------------------------------------------
+# apply_mock_substitution
+# ---------------------------------------------------------------------------
+
+class TestApplySubstitution:
+    def test_no_active_returns_original(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active=set())
+        assert result is real
+
+    def test_unregistered_class_returns_original(self):
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active={"_RealDeviceCls"})
+        assert result is real
+
+    def test_registered_and_active_returns_mock(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active={"_RealDeviceCls"})
+        assert isinstance(result, _MockForTest)
+        # Field values preserved via model_construct.
+        assert result.device_id == "d1"
+
+    def test_all_sentinel_substitutes(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active={"all"})
+        assert isinstance(result, _MockForTest)
+
+    def test_active_set_for_other_class_skips_substitution(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(
+            real, active={"SomeOtherDeviceCls"})
+        assert result is real
+
+
+# ---------------------------------------------------------------------------
+# Hardware-less import smoke tests for the lazy imports added in Phase 0a.
+# ---------------------------------------------------------------------------
+
+def _import_module_without(*blocked: str) -> object:
+    """Re-import target modules with certain top-level imports blocked.
+
+    Returns the freshly-imported module(s).
+    """
+    blocked_set = set(blocked)
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        for b in blocked_set:
+            if name == b or name.startswith(b + "."):
+                raise ImportError(f"simulated absence of {name}")
+        return orig_import(name, *args, **kwargs)
+
+    builtins.__import__ = fake_import
+    try:
+        for k in list(sys.modules):
+            if k in blocked_set or k.startswith(tuple(b + "." for b in blocked_set)):
+                del sys.modules[k]
+        # Drop the cached module so it re-imports under the patched __import__.
+        for cached in list(sys.modules):
+            if "iout.mbient" in cached or "iout.eyelink_tracker" in cached:
+                del sys.modules[cached]
+        import neurobooth_os.iout.mbient as mbient_mod
+        import neurobooth_os.iout.eyelink_tracker as eyelink_mod
+        return mbient_mod, eyelink_mod
+    finally:
+        builtins.__import__ = orig_import
+
+
+class TestLazyHardwareImports:
+    def test_mbient_imports_without_mbientlab(self):
+        mbient_mod, _ = _import_module_without("mbientlab")
+        assert mbient_mod._HAS_MBIENTLAB is False
+        # The Mbient class must be defined (so MockMbient can subclass it).
+        assert mbient_mod.Mbient is not None
+
+    def test_eyelink_imports_without_pylink(self):
+        _, eyelink_mod = _import_module_without("pylink")
+        assert eyelink_mod._HAS_PYLINK is False
+        assert eyelink_mod.EyeTracker is not None


### PR DESCRIPTION
## Summary

Foundation for hardware-less laptop testing of neurobooth (issues #727 / #728 / #729 / #730 / #731). No mock implementations yet — those land in subsequent phases.

This PR is self-contained and low-risk: real device behaviour is unchanged when `NB_MOCK_DEVICES` is unset and `NeuroboothConfig.mock_devices` is empty (the default).

## Changes

- **Lazy hardware imports** in `mbient.py` and `eyelink_tracker.py`. Wrap `mbientlab` / `pylink` imports in try/except so the modules import cleanly without the SDKs installed. Hardware access is gated by `_require_mbientlab()` / `_require_pylink()` helpers raised lazily in connect/setup paths. The `EyeLinkCoreGraphicsPsychoPy` import was moved into `calibrate()` to avoid pulling pylink transitively at module load.
- **Substitution mechanism** in new `iout/mock_substitution.py`:
  - `MOCK_REGISTRY` keyed by real `DeviceArgs` class → mock `DeviceArgs` class.
  - `register_mock(real, mock)` enforces that `mock` is a subclass of `real`.
  - `active_mock_targets()` returns the active set — `NB_MOCK_DEVICES` env var wins, with `NeuroboothConfig.mock_devices` as fallback. Special value `all` means "every registered mock".
  - `apply_mock_substitution(device_args)` swaps in the mock class using Pydantic `model_construct` so YAML-validated field values are preserved without re-validation.
- **`lsl_streamer.py`** applies substitution in `create_streams` before the two `device_class()` resolution sites, logging each swap at INFO.
- **`config.py`** — optional `mock_devices: Optional[List[str]]` field on `NeuroboothConfig` as a persistent fallback when the env var is unset.
- **`gui.py`** — critical-level log + popup banner at GUI startup whenever `active_mock_targets()` is non-empty. Defensive: a forgotten env var must not silently corrupt a real recording.
- **`tests/pytest/test_mock_substitution.py`** — 17 tests covering registry behaviour, env-vs-config priority, substitution outcomes, and that `mbient.py` / `eyelink_tracker.py` import without their hardware SDKs present.

## Plan reference

This is **PR 1** of the four-phase plan tracked under #727. Subsequent phases:
- Phase 1: `MockMbient` (#728)
- Phase 2: `MockIPhone` (#729) + companion configs PR removing the dangling `Mock_IPhone_dev_1` reference
- Phase 3: `MockEyeTracker` (#730)
- Phase 4: docs + release polish (#731)

## Test plan

- [x] `python -m pytest tests/pytest/ neurobooth_os/iout/tests/` → 112 passed (95 prior + 17 new)
- [x] `mbient.py` imports cleanly with `mbientlab` simulated absent (verified by `TestLazyHardwareImports::test_mbient_imports_without_mbientlab`)
- [x] `eyelink_tracker.py` imports cleanly with `pylink` simulated absent (verified by `TestLazyHardwareImports::test_eyelink_imports_without_pylink`)
- [ ] Smoke test on a real STCE / staging machine — confirm no regression with mock targets unset (env var unset, no `mock_devices` in config)