### PR TITLE
Phase 1: MockMbient — synthetic LSL samples without hardware

### DIFF
--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -789,15 +789,7 @@ class Mbient(Device):
         :returns: Whether the connection and setup was successful.
         """
         try:
-            self.prepare_scan()  # Wake up devices
-            self._ble_connect()
-            self.logger.debug(self.format_message(f'Device Model: {self.device_wrapper.model_name}'))
-            self.logger.debug(self.format_message(f'Wrapper Class: {self.device_wrapper.__class__.__name__}'))
-
-            # Perform a sensor reset and reconnect
-            self.reset()
-            sleep(self.retry_delay_sec)  # Wait a moment before trying to re-connect after the reset
-            self._ble_connect()
+            self._acquire_hardware()
 
             # Set up the device to stream acceleration and angular velocity
             if not DISABLE_LSL:
@@ -828,6 +820,24 @@ class Mbient(Device):
     def prepare(self) -> bool:
         """Backward-compatible alias for :meth:`connect`."""
         return self.connect()
+
+    def _acquire_hardware(self) -> None:
+        """BLE scan, connect, board reset, and reconnect.
+
+        Subclass hook: ``MockMbient`` overrides this to skip BLE and the
+        native reset cycle. Anything that touches the mbientlab SDK belongs
+        here, not in ``connect()``.
+        """
+        _require_mbientlab()
+        self.prepare_scan()  # Wake up devices
+        self._ble_connect()
+        self.logger.debug(self.format_message(f'Device Model: {self.device_wrapper.model_name}'))
+        self.logger.debug(self.format_message(f'Wrapper Class: {self.device_wrapper.__class__.__name__}'))
+
+        # Perform a sensor reset and reconnect
+        self.reset()
+        sleep(self.retry_delay_sec)  # Wait a moment before trying to re-connect after the reset
+        self._ble_connect()
 
     def _create_outlet(self) -> StreamOutlet:
         """Create an LSL outlet; helper for prepare."""
@@ -868,6 +878,23 @@ class Mbient(Device):
 
     def setup(self) -> None:
         """Configure the device (i.e., connection settings, sensor settings, data streaming callback)"""
+        self._attach_data_source()
+
+        txt = f"Mbient {self.dev_name} is connected"  # Send message to GUI terminal
+        self.send_status_msg(txt, "INFO")
+        self.logger.debug(self.format_message('Setup Completed'))
+
+    def _attach_data_source(self) -> None:
+        """Wire up the data source feeding ``_lsl_data_handler``.
+
+        Real path: configure connection/sensor settings, create the
+        accel+gyro fuser, and subscribe the C-level callback that calls
+        ``_callback`` (which dispatches to ``data_handlers``).
+
+        Subclass hook: ``MockMbient`` overrides this to spawn a synthetic
+        data thread that pushes samples directly through the data
+        handlers, with no native MetaWear/cbindings interaction.
+        """
         _require_mbientlab()
         self.device_wrapper.setup_connection_settings(self.connection_params)
         sensor_signals = self.device_wrapper.setup_sensor_settings(self.accel_params, self.gyro_params)
@@ -885,10 +912,6 @@ class Mbient(Device):
             self.data_handlers = [self._lsl_data_handler, *self.data_handlers]  # Make sure LSL is called first!
         libmetawear.mbl_mw_datasignal_subscribe(processor, None, self.callback)
         self.subscribed_signals.append(processor)
-
-        txt = f"Mbient {self.dev_name} is connected"  # Send message to GUI terminal
-        self.send_status_msg(txt, "INFO")
-        self.logger.debug(self.format_message('Setup Completed'))
 
     def log_battery_info(self) -> None:
         """

--- a/neurobooth_os/iout/mock/__init__.py
+++ b/neurobooth_os/iout/mock/__init__.py
@@ -1,0 +1,13 @@
+"""Hardware mocks for laptop/CI testing without real devices.
+
+Each mock module imports its corresponding real device module's top half
+(class definitions only — hardware imports are guarded in the real
+modules), subclasses the real ``Device``, and overrides hardware-touching
+hooks. The matching mock ``DeviceArgs`` subclass lives in
+``stim_param_reader.py`` and registers via
+:func:`neurobooth_os.iout.mock_substitution.register_mock` at import time.
+
+The package is intentionally separate from ``iout/mock_device.py``, which
+contains base-class testing scaffolding (``MockStreamDevice`` /
+``MockRecordingDevice``) for ``Device`` itself, not hardware mocks.
+"""

--- a/neurobooth_os/iout/mock/mock_mbient.py
+++ b/neurobooth_os/iout/mock/mock_mbient.py
@@ -1,0 +1,197 @@
+"""Synthetic Mbient that emits LSL samples without real hardware.
+
+Overrides the two hardware hooks on :class:`Mbient`
+(``_acquire_hardware`` and ``_attach_data_source``) plus the lifecycle
+methods that touch the native MetaWear/warble libraries
+(``start`` / ``stop`` / ``disconnect`` / ``close`` / ``reset`` /
+``attempt_reconnect`` / ``on_task_reconnect`` / ``reset_and_reconnect``).
+
+Synthetic samples are produced by a daemon thread that calls every
+registered data handler at the higher of the configured ``acc_hz`` /
+``gyro_hz`` rates.  The values are constants (1g down, zero rotation);
+downstream code only needs the LSL samples to flow at the right
+shape and rate, not to look like real motion.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, List, Optional
+
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mbient import BatteryState, Mbient
+
+
+class _MockSample:
+    """Minimal stand-in for the mbientlab acc/gyro vector.
+
+    Only ``.x`` / ``.y`` / ``.z`` are accessed by ``Mbient._lsl_data_handler``,
+    so that's all we need.
+    """
+
+    __slots__ = ("x", "y", "z")
+
+    def __init__(self, x: float, y: float, z: float) -> None:
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class _MockMetaWearWrapper:
+    """Stub satisfying the ``device_wrapper`` calls inherited from ``Mbient``.
+
+    Inherited code paths in ``Mbient.start`` / ``stop`` / ``disconnect``
+    / ``log_battery_info`` reach into ``device_wrapper``; without this
+    stub they would raise ``AttributeError`` on the mock.  Every method
+    is a no-op; ``is_connected`` reflects the most recent ``disconnect``
+    call so tests that inspect it see the expected transition.
+    """
+
+    def __init__(self, dev_name: str) -> None:
+        self.dev_name = dev_name
+        self.model_name = "MockMetaMotion"
+        self.is_connected = True
+        self.on_disconnect = lambda status: None
+
+    def setup_connection_settings(self, *_args, **_kwargs) -> None:
+        return None
+
+    def setup_sensor_settings(self, *_args, **_kwargs) -> None:
+        # Real return is a SensorSignals tuple consumed by the fuser; the
+        # mock skips that path in ``_attach_data_source`` so None is fine.
+        return None
+
+    def enable_inertial_sampling(self) -> None:
+        return None
+
+    def disable_inertial_sampling(self) -> None:
+        return None
+
+    def start_inertial_sampling(self) -> None:
+        return None
+
+    def stop_inertial_sampling(self) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        self.is_connected = False
+        self.on_disconnect(0)
+
+    def reset_device(self) -> None:
+        return None
+
+    def get_battery_state(self) -> BatteryState:
+        return BatteryState(voltage=4000.0, charge=100.0)
+
+
+class MockMbient(Mbient):
+    """Mock Mbient that emits synthetic LSL samples on a daemon thread."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._mock_thread: Optional[threading.Thread] = None
+        self._mock_stop_event = threading.Event()
+
+    def _acquire_hardware(self) -> None:
+        # Skip BLE scan / connect / reset.  Install a stub wrapper so the
+        # inherited start/stop/disconnect paths have something to call.
+        self.device_wrapper = _MockMetaWearWrapper(self.dev_name)
+        self.logger.info(self.format_message(
+            "MockMbient: skipped BLE acquire (no hardware)"))
+
+    def _attach_data_source(self) -> None:
+        # Match the real path's effect on ``data_handlers`` so LSL is
+        # called first, but skip the fuser/cbindings entirely.
+        from neurobooth_os.iout.mbient import DISABLE_LSL  # noqa: WPS433
+        if DISABLE_LSL:
+            self.logger.warning("LSL Disabled!")
+        else:
+            self.data_handlers = [self._lsl_data_handler, *self.data_handlers]
+        self.logger.info(self.format_message(
+            "MockMbient: synthetic data source attached"))
+
+    def start(self, filename: Optional[str] = None, buzz: bool = False) -> List[str]:
+        """Begin emitting synthetic samples on a background thread."""
+        self.streaming = True
+        self.state = DeviceState.STARTED
+        self._mock_stop_event.clear()
+        # Use the higher of the two rates: the real fuser emits one sample
+        # per matched (acc, gyro) pair which arrive at the higher rate.
+        rate_hz = max(self.acc_hz, self.gyro_hz)
+        self._mock_thread = threading.Thread(
+            target=self._synthetic_loop,
+            args=(rate_hz,),
+            daemon=True,
+            name=f"MockMbient-{self.dev_name}",
+        )
+        self._mock_thread.start()
+        return []
+
+    def stop(self) -> None:
+        """Halt the synthetic-sample thread."""
+        self._mock_stop_event.set()
+        if self._mock_thread is not None:
+            self._mock_thread.join(timeout=1.0)
+            self._mock_thread = None
+        self.streaming = False
+        self.state = DeviceState.STOPPED
+
+    def disconnect(self) -> None:
+        if self.device_wrapper is not None:
+            self.device_wrapper.disconnect()
+        self.state = DeviceState.DISCONNECTED
+
+    def close(self) -> None:
+        if self.streaming:
+            self.stop()
+        self.subscribed_signals.clear()
+        self.state = DeviceState.STOPPED
+        self.disconnect()
+
+    def reset(self, timeout_sec: float = 10) -> None:
+        # Real reset waits on a native disconnect callback; the mock
+        # bypasses both the reset and the wait.
+        return None
+
+    def attempt_reconnect(
+        self,
+        status: Optional[int] = None,
+        notify: bool = True,
+        n_attempts: int = 3,
+    ) -> None:
+        # No native BLE link to recover; surface a benign log so tests
+        # can assert the path was exercised without sending the
+        # MbientDisconnected message that real disconnect would.
+        self.logger.info(self.format_message(
+            "MockMbient: attempt_reconnect (no-op)"))
+
+    def on_task_reconnect(self) -> None:
+        # Bypass ``Mbient.task_start_reconnect``, which performs a BLE
+        # scan and gates retries on real hardware availability.
+        return None
+
+    def reset_and_reconnect(self, timeout_sec: float = 10) -> bool:
+        # Operator action; nothing to reset, always succeed.
+        self.logger.info(self.format_message(
+            "MockMbient: reset_and_reconnect (no-op)"))
+        return True
+
+    def _synthetic_loop(self, rate_hz: int) -> None:
+        """Emit acc+gyro samples until ``_mock_stop_event`` is set."""
+        period = 1.0 / float(rate_hz)
+        # Constant values: 1g down at rest, zero rotation.  Downstream
+        # consumers only need the LSL stream shape and cadence, not
+        # realistic motion.
+        acc = _MockSample(0.0, 0.0, 1.0)
+        gyro = _MockSample(0.0, 0.0, 0.0)
+        while not self._mock_stop_event.is_set():
+            self.n_samples_streamed += 1
+            epoch_ms = time.time() * 1000.0
+            for handler in list(self.data_handlers):
+                try:
+                    handler(epoch_ms, acc, gyro)
+                except Exception:  # pragma: no cover — defensive
+                    self.logger.exception(self.format_message(
+                        "MockMbient: data handler raised"))
+            self._mock_stop_event.wait(period)

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -423,6 +423,21 @@ class MbientDeviceArgs(DeviceArgs):
         return Mbient
 
 
+class MockMbientDeviceArgs(MbientDeviceArgs):
+    """DeviceArgs for :class:`MockMbient` — same fields, different device class.
+
+    Selected at runtime by the substitution registry when ``Mbient`` is in
+    ``NB_MOCK_DEVICES``; instances are built via Pydantic ``model_construct``,
+    so this subclass exists primarily to point ``device_class()`` at the
+    mock implementation.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_mbient import MockMbient
+        return MockMbient
+
+
 class MouseDeviceArgs(DeviceArgs):
     """DeviceArgs for the Mouse device.
 
@@ -684,3 +699,16 @@ class RawTaskParams(EnvArgs):
     instruction_id: Optional[str] = None
     device_id_array: List[str]
     arg_parser: str
+
+
+# ---------------------------------------------------------------------------
+# Mock-device registrations
+#
+# Done here (not in each mock module) so the registry is populated as soon as
+# this module is imported — which happens unconditionally during config load.
+# Without this, mocks would only register on demand and the first
+# ``apply_mock_substitution`` call would silently miss them.
+# ---------------------------------------------------------------------------
+from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
+
+register_mock(MbientDeviceArgs, MockMbientDeviceArgs)

--- a/tests/pytest/test_mock_mbient.py
+++ b/tests/pytest/test_mock_mbient.py
@@ -1,0 +1,222 @@
+"""Lifecycle tests for the synthetic Mbient mock.
+
+These tests exercise ``MockMbient`` end-to-end without a real BLE device or
+the mbientlab SDK installed.  They cover:
+
+- ``bring_up`` -> ``start`` -> ``stop`` -> ``close`` round-trip with
+  synthetic samples flowing.
+- ``attempt_reconnect`` / ``on_task_reconnect`` / ``on_session_reset`` are
+  no-ops on the mock and don't post the ``MbientDisconnected`` warning
+  the real path emits.
+- The substitution registry is populated by importing
+  ``stim_param_reader``.
+"""
+
+import time
+
+import pytest
+
+from neurobooth_os.iout import mbient as mbient_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_mbient import MockMbient
+from neurobooth_os.iout.stim_param_reader import (
+    MbientDeviceArgs,
+    MbientSensorArgs,
+    MockMbientDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 100
+SAMPLE_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockMbientDeviceArgs:
+    """Construct a ``MockMbientDeviceArgs`` with the minimum fields ``Mbient.__init__`` reads."""
+    acc_sensor = MbientSensorArgs.model_construct(
+        sensor_id="acc1",
+        sample_rate=SAMPLE_RATE_HZ,
+        data_range=8,
+    )
+    gyro_sensor = MbientSensorArgs.model_construct(
+        sensor_id="gyro1",
+        sample_rate=SAMPLE_RATE_HZ,
+        data_range=2000,
+    )
+    return MockMbientDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="Mbient_TestDevice_1",
+        sensor_ids=["acc1", "gyro1"],
+        sensor_array=[acc_sensor, gyro_sensor],
+        mac="AA:BB:CC:DD:EE:FF",
+        device_name="TestDevice",
+        arg_parser="iout.stim_param_reader.py::MockMbientDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockMbientDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _disable_lsl_and_messaging(monkeypatch):
+    """Skip LSL outlet creation and silence ``post_message`` so tests don't need
+    a real network/database. ``mbient.DISABLE_LSL`` gates outlet creation in
+    ``connect()`` and the ``_lsl_data_handler`` injection in
+    ``_attach_data_source``; ``post_message`` is reached via ``send_status_msg``
+    in ``setup()`` regardless of that flag.
+    """
+    monkeypatch.setattr(mbient_mod, "DISABLE_LSL", True)
+    monkeypatch.setattr(mbient_mod, "post_message", lambda msg: None)
+
+
+@pytest.fixture
+def captured_messages(monkeypatch):
+    """Replace ``mbient.post_message`` with a recorder so tests can assert on
+    what messages a code path emits.  Overrides the autouse fixture's
+    silencer for the test that uses it.
+    """
+    posted = []
+    monkeypatch.setattr(mbient_mod, "post_message", lambda msg: posted.append(msg))
+    return posted
+
+
+class TestMockMbientLifecycle:
+    """Bring up, run, and tear down a mock Mbient end-to-end."""
+
+    def test_bring_up_returns_self(self, mock_args):
+        device = MockMbient(mock_args)
+        try:
+            assert device.bring_up({}) is device
+            assert device.streaming is True
+            assert device.state == DeviceState.STARTED
+        finally:
+            device.close()
+
+    def test_synthetic_samples_flow_at_configured_rate(self, mock_args):
+        device = MockMbient(mock_args)
+        captured = []
+        device.register_data_handler(
+            lambda epoch, acc, gyro: captured.append((epoch, acc.x, gyro.x))
+        )
+        try:
+            device.bring_up({})
+            time.sleep(SAMPLE_WINDOW_SEC)
+            device.stop()
+        finally:
+            device.close()
+
+        # At 100 Hz over 300 ms we expect ~30 samples; allow generous slack
+        # for Windows scheduling jitter and CI variance.
+        assert len(captured) >= 5, (
+            f"Expected at least 5 synthetic samples; got {len(captured)}"
+        )
+        # n_samples_streamed is incremented inside the synthetic loop and
+        # should match (or exceed by 1 if a sample landed between the
+        # final handler-call and our assertion).
+        assert device.n_samples_streamed >= len(captured)
+
+    def test_close_without_start_does_not_raise(self, mock_args):
+        # If connect() succeeds but start() never runs (or
+        # bring_up() short-circuits), close() must still tear down cleanly.
+        device = MockMbient(mock_args)
+        device.connect()
+        device.close()
+        assert device.streaming is False
+        assert device._mock_thread is None
+
+    def test_close_after_start_joins_thread(self, mock_args):
+        device = MockMbient(mock_args)
+        device.bring_up({})
+        # Sanity-check the thread is actually running before we ask for stop.
+        assert device._mock_thread is not None
+        assert device._mock_thread.is_alive()
+        device.close()
+        assert device.streaming is False
+        assert device._mock_thread is None
+        assert device.state == DeviceState.DISCONNECTED
+
+    def test_stop_then_start_again(self, mock_args):
+        # Mocks should tolerate stop/start cycles within a session.
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            device.stop()
+            assert device.streaming is False
+            device.start()
+            assert device.streaming is True
+            assert device._mock_thread is not None
+            assert device._mock_thread.is_alive()
+        finally:
+            device.close()
+
+
+class TestMockMbientReconnectPaths:
+    """The mock should not pretend to disconnect/reconnect or notify operators."""
+
+    def test_attempt_reconnect_does_not_post_disconnect(
+        self, mock_args, captured_messages
+    ):
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            device.attempt_reconnect()  # default args mirror callback signature
+            assert device.streaming is True
+        finally:
+            device.close()
+        body_types = [
+            type(m.body).__name__ for m in captured_messages if hasattr(m, "body")
+        ]
+        assert "MbientDisconnected" not in body_types, (
+            f"MockMbient.attempt_reconnect must not post MbientDisconnected; "
+            f"got {body_types}"
+        )
+
+    def test_on_task_reconnect_is_no_op(self, mock_args, captured_messages):
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            device.on_task_reconnect()
+            assert device.streaming is True
+        finally:
+            device.close()
+
+    def test_on_session_reset_returns_true(self, mock_args):
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            assert device.on_session_reset() is True
+        finally:
+            device.close()
+
+
+class TestMockMbientRegistration:
+    """The substitution registry is populated as a side-effect of importing
+    ``stim_param_reader``; verify both the entry and the device-class hop.
+    """
+
+    def test_mock_mbient_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(MbientDeviceArgs) is MockMbientDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockMbientDeviceArgs.device_class() is MockMbient
+
+    def test_apply_substitution_swaps_class(self):
+        # Round-trip through apply_mock_substitution to confirm the registry
+        # entry resolves under the env-var-driven path that DeviceManager uses.
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = MbientDeviceArgs.model_construct(
+            ENV_devices={"Mbient_d_1": {"mac": "AA:BB"}},
+            device_id="Mbient_d_1",
+            sensor_ids=["acc1"],
+            mac="AA:BB",
+            device_name="d",
+            arg_parser="iout.stim_param_reader.py::MbientDeviceArgs()",
+            sensor_array=[],
+        )
+        result = apply_mock_substitution(real, active={"Mbient"})
+        assert isinstance(result, MockMbientDeviceArgs)
+        # Field values preserved (model_construct, not re-validation).
+        assert result.device_id == "Mbient_d_1"
+        assert result.mac == "AA:BB"


### PR DESCRIPTION
## Summary

`MockMbient` — a synthetic Mbient subclass that emits LSL samples at the configured rate without a real BLE device or the `mbientlab` SDK installed. Closes #728 once merged.

Stacked on top of #732 (Phase 0); review/land that first. Selected at runtime via `NB_MOCK_DEVICES=Mbient` (or `=all`) — does nothing for production use.

## Changes

- **`mbient.py`**: split `connect()` / `setup()` into two new hooks the mock can override.
  - `_acquire_hardware()` — BLE scan + connect + reset + reconnect cycle (everything that touches the `mbientlab` SDK).
  - `_attach_data_source()` — connection/sensor settings + accel+gyro fuser + native callback subscription (everything that touches `cbindings`).
  - Inherited call sites are unchanged in behaviour for real Mbients.
- **`mock/mock_mbient.py`** (new): `MockMbient` subclass overrides the two hooks with no-ops + a stub `MetaWearWrapper`, plus the lifecycle methods that touch native MetaWear/warble (`start` / `stop` / `disconnect` / `close` / `reset` / `attempt_reconnect` / `on_task_reconnect` / `reset_and_reconnect`). A daemon thread emits acc+gyro samples (1g down at rest, zero rotation) at the higher of `acc_hz` / `gyro_hz`, dispatching through the same `data_handlers` the real path uses.
- **`stim_param_reader.py`**: new `MockMbientDeviceArgs(MbientDeviceArgs)` whose `device_class()` returns `MockMbient`; `register_mock()` called at module import so the registry is populated as soon as config loads.
- **`tests/pytest/test_mock_mbient.py`**: 11 tests covering bring-up/start/stop/close round-trip, synthetic-sample flow, no-op reconnect paths (no `MbientDisconnected` emitted from the mock), and substitution-registry round-trip via `apply_mock_substitution`.

## Test plan

- [x] `python -m pytest tests/pytest/test_mock_mbient.py` → 11 passed
- [x] `python -m pytest tests/pytest/ neurobooth_os/iout/tests/` → 123 passed (112 prior + 11 new)
- [ ] Smoke test on a real laptop: set `NB_MOCK_DEVICES=Mbient`, run a session, confirm Mbient `bring_up` succeeds and synthetic samples flow through the stream