### PR TITLE
Phase 2: MockIPhone — in-process transport, no USBMux/socket

### DIFF
--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -193,16 +193,21 @@ class IPhone(Device):
     MESSAGE_TYPES = set(MESSAGE_TYPES)
     MESSAGE_KEYS = {"MessageType", "SessionID", "TimeStamp", "Message"}
 
-    def __init__(self, name="IPhoneFrameIndex", sess_id="", mock=False, device_args: IPhoneDeviceArgs = None, enable_timeout_exceptions=False):
+    def __init__(self, name="IPhoneFrameIndex", sess_id="", device_args: IPhoneDeviceArgs = None, enable_timeout_exceptions=False):
         super().__init__(device_args)
         self.connected = False
         self.tag = 0
         self.iphone_sessionID = sess_id
         self.name = name
-        self.mock = mock
         self.device_args = device_args
         self.enable_timeout_exceptions = enable_timeout_exceptions
         self.streamName = "IPhoneFrameIndex"
+
+        # Wire-level transport. The real path installs a socket from
+        # ``USBMux.connect`` in ``_handshake``; ``MockIPhone`` swaps in an
+        # in-process queue.  Anything socket-shaped (``send`` / ``recv`` /
+        # ``settimeout`` / ``close``) is acceptable here.
+        self.transport: Optional[Any] = None
 
         # --------------------------------------------------------------------------------
         # Lock-based threading objects and their associated protected data
@@ -351,7 +356,7 @@ class IPhone(Device):
         )
 
         try:
-            self.sock.send(packet)
+            self.transport.send(packet)
         except Exception as e:
             self.logger.error(f'iPhone: PANIC: {e}')
             raise IPhonePanic(f'Error occurred sending signal through the socket') from e
@@ -433,9 +438,9 @@ class IPhone(Device):
         :returns: (payload, version, type, tag): Payload is either a message dictionary (tag == 0) or byte string
             (tag == 1 or tag == 2).
         """
-        self.sock.settimeout(timeout_sec)
+        self.transport.settimeout(timeout_sec)
         try:
-            first_frame = self.sock.recv(16)
+            first_frame = self.transport.recv(16)
         except socket.timeout:
             raise IPhoneTimeout(f"Timeout for packet receive exceeded ({timeout_sec} sec)")
         except OSError as e:
@@ -451,10 +456,10 @@ class IPhone(Device):
                 MessageTag.DUMP_FILE_CHUNK,
                 MessageTag.DUMP_LAST_FILE_CHUNK
         ):
-            payload = IPhone.recvall(self.sock, payload_size)
+            payload = IPhone.recvall(self.transport, payload_size)
             return payload, version, type_, tag
         elif tag == MessageTag.NORMAL_MESSAGE:
-            payload = self.sock.recv(payload_size)
+            payload = self.transport.recv(payload_size)
             msg = IPhone._json_unwrap(payload)
             self._validate_message(msg)
             return msg, version, type_, tag
@@ -536,21 +541,14 @@ class IPhone(Device):
         """
         return self.prepare()
 
-    def prepare(self, mock: bool = False, config: Optional[CONFIG] = None) -> bool:
+    def prepare(self, config: Optional[CONFIG] = None) -> bool:
         """
         Called during a PREPARE message to the server (i.e., "Connect Devices").
         Connects to the iPhone and opens an LSL outlet.
 
-        :param mock: Whether to use a mock iPhone
         :param config: iPhone configuation options
         :returns: Whether the connection was successful
         """
-        if mock:
-            success = self._mock_handshake() and self.connected
-            if success:
-                self.state = DeviceState.CONNECTED
-            return success
-
         if config is None:
             config = {
                 "NOTIFYONFRAME": self.device_args.notifyonframe(),
@@ -593,7 +591,7 @@ class IPhone(Device):
 
         self.device = self.usbmux.devices[0]
         try:
-            self.sock = self.usbmux.connect(self.device, IPHONE_PORT)
+            self.transport = self.usbmux.connect(self.device, IPHONE_PORT)
             self._update_state('@HANDSHAKE')
         except Exception as e:
             self.logger.error(f'iPhone [state={self._state}]: Unable to connect; error={e}')
@@ -602,7 +600,6 @@ class IPhone(Device):
         # As soon as we're connected, start the parallel listening thread.
         self._listen_thread = IPhoneListeningThread(self)
         self._listen_thread.start()
-        # self.sock.setblocking(0)
         self.connected = True
 
         # Send the configuration to the iPhone and wait for a response
@@ -616,31 +613,6 @@ class IPhone(Device):
             return True
         except IPhonePanic as e:
             self.panic(e)
-            return False
-
-    def _mock_handshake(self) -> bool:
-        try:
-            HOST = "127.0.0.1"  # Symbolic name meaning the local host
-            PORT = 50009  # Arbitrary non-privileged port
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.connect((HOST, PORT))
-            self.connected = True
-
-            self._update_state('@HANDSHAKE')
-            self._update_state('@STANDBY')
-            self._update_state('@READY')
-            return True
-        except IPhonePanic as e:
-            if self.sock is not None:
-                self.sock.close()
-                self.sock = None
-            self.panic(e)
-            return False
-        except Exception as e:
-            if self.sock is not None:
-                self.sock.close()
-                self.sock = None
-            self.logger.error(f'iPhone [state={self._state}]: Unable to connect; error={e}')
             return False
 
     def _create_outlet(self) -> StreamOutlet:
@@ -865,7 +837,9 @@ class IPhone(Device):
 
         # Try to stop the listener thread
         self._listen_thread.stop()
-        self.sock.close()  # Closing the socket will force an error that will break the thread out of its wait
+        # Closing the transport will force an error that will break the
+        # listener thread out of its blocking ``recv``.
+        self.transport.close()
         if join_listener:
             self._listen_thread.join(timeout=3)
             if self._listen_thread.is_alive():

--- a/neurobooth_os/iout/mock/mock_iphone.py
+++ b/neurobooth_os/iout/mock/mock_iphone.py
@@ -1,0 +1,275 @@
+"""In-process mock of the iPhone device.
+
+``MockIPhone`` overrides :meth:`IPhone._handshake` to install a
+queue-backed in-process transport (:class:`_MockIPhoneTransport`)
+instead of opening a real ``USBMux`` socket.  The state-machine
+bookkeeping in ``_send_packet`` / ``_get_packet`` /
+``_process_received_message`` runs unchanged; the transport simulates
+the iOS app by consuming outgoing packets and queueing the appropriate
+responses.
+
+When the controller sends ``@START``, the transport spawns a daemon
+thread that emits ``@INPROGRESSTIMESTAMP`` messages at the configured
+FPS until ``@STOP`` is sent.  ``frame_preview()`` returns canned bytes
+without touching the camera.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import struct
+import threading
+import time
+from typing import List, Optional
+
+from neurobooth_os.iout.iphone import (
+    CONFIG,
+    IPhone,
+    IPhoneListeningThread,
+    IPhonePanic,
+    MessageTag,
+)
+
+
+# Placeholder bytes returned by ``frame_preview()``.  Not a valid PNG —
+# the iPhone code just hands the bytes back to the caller, so opaque
+# bytes are sufficient for the lifecycle.  Tests assert non-emptiness.
+_CANNED_PREVIEW_BYTES = b"MOCK_IPHONE_FRAME_PREVIEW_PLACEHOLDER"
+
+
+class _MockIPhoneTransport:
+    """Socket-like in-process transport that simulates iPhone app responses.
+
+    Implements the subset of :class:`socket.socket` used by ``IPhone``:
+    ``send`` / ``recv`` / ``settimeout`` / ``close``.
+
+    Each outgoing packet is parsed; the message type drives a small
+    table of canned responses that get queued for the listener thread to
+    pick up.  A separate daemon thread injects
+    ``@INPROGRESSTIMESTAMP`` messages between ``@STARTTIMESTAMP`` and
+    ``@STOPTIMESTAMP`` to mirror the real recording-progress stream.
+    """
+
+    def __init__(self, fps: int = 30, logger: Optional[logging.Logger] = None) -> None:
+        self._inbound: List[bytes] = []
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._timeout: Optional[float] = None
+        self._closed = False
+        self._fps = max(int(fps), 1)
+        self._frame_counter = 0
+        self._stream_thread: Optional[threading.Thread] = None
+        self._stop_streaming = threading.Event()
+        self.logger = logger
+
+    # ------------------------------------------------------------------
+    # socket-like interface
+    # ------------------------------------------------------------------
+    def send(self, data: bytes) -> int:
+        if len(data) < 16:
+            return len(data)
+        _version, _type, tag, _payload_size = struct.unpack("!IIII", data[:16])
+        if tag == MessageTag.NORMAL_MESSAGE:
+            try:
+                msg = IPhone._json_unwrap(data[16:])
+                self._handle_outgoing(msg)
+            except Exception:
+                if self.logger is not None:
+                    self.logger.exception(
+                        "MockIPhoneTransport: failed to parse outgoing packet")
+        return len(data)
+
+    def recv(self, n: int) -> bytes:
+        with self._cond:
+            deadline = (
+                time.monotonic() + self._timeout
+                if self._timeout is not None
+                else None
+            )
+            while True:
+                if self._inbound:
+                    head = self._inbound[0]
+                    if len(head) >= n:
+                        chunk = head[:n]
+                        if len(head) == n:
+                            self._inbound.pop(0)
+                        else:
+                            self._inbound[0] = head[n:]
+                        return chunk
+                    # Defensive: real packets are injected whole, so
+                    # this branch should not fire via the IPhone path.
+                    self._inbound.pop(0)
+                    return head
+                if self._closed:
+                    return b""
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise socket.timeout("recv timeout")
+                    self._cond.wait(remaining)
+                else:
+                    self._cond.wait()
+
+    def settimeout(self, t: Optional[float]) -> None:
+        self._timeout = t
+
+    def close(self) -> None:
+        self._stop_streaming.set()
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+        if self._stream_thread is not None and self._stream_thread.is_alive():
+            self._stream_thread.join(timeout=1.0)
+        self._stream_thread = None
+
+    # ------------------------------------------------------------------
+    # phone-side simulator
+    # ------------------------------------------------------------------
+    def _handle_outgoing(self, msg: dict) -> None:
+        msg_type = msg.get("MessageType", "")
+        if msg_type == "@STANDBY":
+            self._inject_message("@READY")
+        elif msg_type == "@START":
+            # @STARTTIMESTAMP first, then begin the synthetic stream.
+            # Order matters: IPhone's state machine requires @STARTTIMESTAMP
+            # to land before any @INPROGRESSTIMESTAMP.
+            self._inject_message(
+                "@STARTTIMESTAMP", timestamp=self._frame_timestamp())
+            self._begin_streaming()
+        elif msg_type == "@STOP":
+            self._end_streaming()
+            self._inject_message(
+                "@STOPTIMESTAMP", timestamp=self._frame_timestamp())
+        elif msg_type == "@PREVIEW":
+            self._inject_preview()
+        elif msg_type == "@DUMPALL":
+            # No files on the mock; drive the empty-list / error path.
+            self._inject_message("@ERROR", message="No files on mock device")
+        # @DUMP / @DUMPSUCCESS / @DISCONNECT — no responses required.
+
+    def _inject_message(
+        self,
+        msg_type: str,
+        timestamp: str = "",
+        message: str = "",
+    ) -> None:
+        msg = {
+            "MessageType": msg_type,
+            "SessionID": "",
+            "TimeStamp": timestamp,
+            "Message": message,
+        }
+        payload = ("####" + json.dumps(msg)).encode("utf-8")
+        header = struct.pack(
+            "!IIII", IPhone.VERSION, IPhone.TYPE_MESSAGE, 0, len(payload))
+        with self._cond:
+            self._inbound.append(header + payload)
+            self._cond.notify_all()
+
+    def _inject_preview(self) -> None:
+        png = _CANNED_PREVIEW_BYTES
+        header = struct.pack(
+            "!IIII",
+            IPhone.VERSION,
+            IPhone.TYPE_MESSAGE,
+            int(MessageTag.FRAME_PREVIEW),
+            len(png),
+        )
+        with self._cond:
+            self._inbound.append(header + png)
+            self._cond.notify_all()
+
+    def _begin_streaming(self) -> None:
+        self._stop_streaming.clear()
+        self._stream_thread = threading.Thread(
+            target=self._stream_loop,
+            name="MockIPhone-stream",
+            daemon=True,
+        )
+        self._stream_thread.start()
+
+    def _end_streaming(self) -> None:
+        self._stop_streaming.set()
+        if self._stream_thread is not None:
+            self._stream_thread.join(timeout=1.0)
+            self._stream_thread = None
+
+    def _stream_loop(self) -> None:
+        period = 1.0 / float(self._fps)
+        while not self._stop_streaming.is_set():
+            self._frame_counter += 1
+            self._inject_message(
+                "@INPROGRESSTIMESTAMP",
+                timestamp=self._frame_timestamp(),
+            )
+            self._stop_streaming.wait(period)
+
+    def _frame_timestamp(self) -> str:
+        # IPhone._lsl_push_sample uses ``eval`` to parse this back into a
+        # dict, so it must be a valid Python literal repr.
+        return repr({
+            "FrameNumber": self._frame_counter,
+            "Timestamp": time.time(),
+        })
+
+
+class MockIPhone(IPhone):
+    """Mock iPhone that runs the full state machine without a real device."""
+
+    def _handshake(self, config: CONFIG) -> bool:
+        if self._state != "#DISCONNECTED":
+            self.logger.error(
+                f"iPhone [state={self._state}]: "
+                "Mock handshake invoked in inappropriate state.")
+            return False
+        try:
+            fps = int(config.get("FPS", 30))
+        except (TypeError, ValueError):
+            fps = 30
+
+        self.transport = _MockIPhoneTransport(fps=fps, logger=self.logger)
+        try:
+            self._update_state("@HANDSHAKE")
+        except IPhonePanic as e:
+            self.panic(e)
+            return False
+
+        self._listen_thread = IPhoneListeningThread(self)
+        self._listen_thread.start()
+        self.connected = True
+
+        msg_camera_config = {"Message": json.dumps(config)}
+        try:
+            self._send_and_wait_for_response(
+                "@STANDBY",
+                msg_contents=msg_camera_config,
+                wait_on=list(self.STATE_TRANSITIONS["#STANDBY"].keys()),
+            )
+            return True
+        except IPhonePanic as e:
+            self.panic(e)
+            return False
+
+    def disconnect(self, join_listener: bool = True) -> bool:
+        """Skip the 4-second handshake-cooldown the real iPhone needs."""
+        if self._state == "#DISCONNECTED":
+            self.logger.debug("MockIPhone: already disconnected")
+            return False
+        self.logger.debug(
+            f"MockIPhone [state={self._state}]: Disconnecting")
+        self._update_state("@DISCONNECT")
+        self._listen_thread.stop()
+        self.transport.close()
+        if join_listener:
+            self._listen_thread.join(timeout=2)
+            # Don't raise on a stuck listener — the mock's transport.close()
+            # is reliable enough that this should never happen, and a
+            # late teardown shouldn't fail tests.
+            if self._listen_thread.is_alive():
+                self.logger.warning(
+                    "MockIPhone: listener thread did not exit cleanly")
+        self.connected = False
+        self.streaming = False
+        return True

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -264,6 +264,21 @@ class IPhoneDeviceArgs(DeviceArgs):
         return IPhone
 
 
+class MockIPhoneDeviceArgs(IPhoneDeviceArgs):
+    """DeviceArgs for :class:`MockIPhone` — same fields, different device class.
+
+    Selected at runtime by the substitution registry when ``IPhone`` is in
+    ``NB_MOCK_DEVICES``; instances are built via Pydantic ``model_construct``,
+    so this subclass exists primarily to point ``device_class()`` at the
+    mock implementation.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_iphone import MockIPhone
+        return MockIPhone
+
+
 class FlirDeviceArgs(DeviceArgs):
     """
     FLIR device arguments
@@ -712,3 +727,4 @@ class RawTaskParams(EnvArgs):
 from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
 
 register_mock(MbientDeviceArgs, MockMbientDeviceArgs)
+register_mock(IPhoneDeviceArgs, MockIPhoneDeviceArgs)

--- a/tests/pytest/test_mock_iphone.py
+++ b/tests/pytest/test_mock_iphone.py
@@ -1,0 +1,202 @@
+"""Lifecycle tests for the synthetic iPhone mock.
+
+These tests exercise ``MockIPhone`` end-to-end without any USB / socket
+infrastructure or running iOS app.  Coverage:
+
+- Handshake takes the device from ``#DISCONNECTED`` to ``#READY`` via the
+  in-process transport (no ``USBMux``, no real socket).
+- ``start`` -> recording -> ``stop`` -> ``ensure_stopped`` cycles through
+  the state machine end-to-end.
+- LSL ``_lsl_push_sample`` sees ``@STARTTIMESTAMP``, several
+  ``@INPROGRESSTIMESTAMP``, then ``@STOPTIMESTAMP``.
+- ``frame_preview()`` returns the canned bytes the mock transport
+  injects.
+- The substitution registry is populated by importing
+  ``stim_param_reader``.
+"""
+
+import time
+
+import pytest
+
+from neurobooth_os.iout import iphone as iphone_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_iphone import (
+    _CANNED_PREVIEW_BYTES,
+    MockIPhone,
+)
+from neurobooth_os.iout.stim_param_reader import (
+    IPhoneDeviceArgs,
+    IPhoneSensorArgs,
+    MockIPhoneDeviceArgs,
+)
+
+
+SAMPLE_FPS = 30
+RECORDING_WINDOW_SEC = 0.5
+
+
+def _build_mock_args() -> MockIPhoneDeviceArgs:
+    """Construct a ``MockIPhoneDeviceArgs`` with the minimum fields ``IPhone`` reads."""
+    sensor = IPhoneSensorArgs.model_construct(
+        sensor_id="iphone_sens_1",
+        sample_rate=SAMPLE_FPS,
+        notifyonframe=1,
+        videoquality="high",
+        usecamerafacing="back",
+        brightness=50,
+        lenspos=0.5,
+    )
+    return MockIPhoneDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="IPhone_dev_1",
+        sensor_ids=["iphone_sens_1"],
+        sensor_array=[sensor],
+        arg_parser="iout.stim_param_reader.py::MockIPhoneDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockIPhoneDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _disable_lsl_and_messaging(monkeypatch):
+    """Skip LSL outlet creation and silence ``post_message`` so tests don't need
+    a real LSL or database backend.  ``IPhone`` uses ``DISABLE_LSL`` to
+    bypass ``_create_outlet`` (which posts ``DeviceInitialization``) and to
+    short-circuit ``_lsl_push_sample``; ``post_message`` is also reached
+    via ``send_status_msg`` and ``panic``.
+    """
+    monkeypatch.setattr(iphone_mod, "DISABLE_LSL", True)
+    monkeypatch.setattr(iphone_mod, "post_message", lambda msg: None)
+
+
+class TestMockIPhoneLifecycle:
+
+    def test_handshake_lands_in_ready(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        try:
+            assert device.connect() is True
+            assert device.connected is True
+            assert device.state == DeviceState.CONNECTED
+            assert device._state == "#READY"
+        finally:
+            device.close()
+
+    def test_start_stop_cycle(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        try:
+            assert device.connect() is True
+            files = device.start("/tmp/task_obs_1")
+            # IPhone.start strips the directory and appends "_IPhone".
+            assert files == ["task_obs_1_IPhone.mov", "task_obs_1_IPhone.json"]
+            assert device.streaming is True
+            assert device._state == "#RECORDING"
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+            assert device._state == "#READY"
+            assert device.streaming is False
+        finally:
+            device.close()
+
+    def test_close_drives_state_to_disconnected(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        device.connect()
+        device.close()
+        assert device.state == DeviceState.DISCONNECTED
+        assert device._state == "#DISCONNECTED"
+        assert device.connected is False
+        assert device.streaming is False
+
+    def test_close_after_recording_stops_stream_thread(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        device.connect()
+        device.start("/tmp/task_a")
+        # Verify the transport's synthetic-stream thread is running.
+        assert device.transport._stream_thread is not None
+        assert device.transport._stream_thread.is_alive()
+        device.close()
+        # close() drains the thread via transport.close().
+        assert (
+            device.transport._stream_thread is None
+            or not device.transport._stream_thread.is_alive()
+        )
+
+
+class TestMockIPhoneLSLFlow:
+
+    def test_lsl_push_sample_sees_full_recording_sequence(
+        self, mock_args, monkeypatch
+    ):
+        """During a recording the mock should drive @STARTTIMESTAMP,
+        a stream of @INPROGRESSTIMESTAMP at the configured FPS, and
+        @STOPTIMESTAMP — in that order — through ``_lsl_push_sample``.
+        """
+        device = MockIPhone(device_args=mock_args)
+        captured_types = []
+
+        def recorder(message):
+            mt = message.get("MessageType", "")
+            if mt in ("@STARTTIMESTAMP", "@INPROGRESSTIMESTAMP", "@STOPTIMESTAMP"):
+                captured_types.append(mt)
+
+        monkeypatch.setattr(device, "_lsl_push_sample", recorder)
+
+        try:
+            device.connect()
+            device.start("/tmp/task_a")
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+        finally:
+            device.close()
+
+        assert captured_types, "Expected at least one timestamp sample"
+        assert captured_types[0] == "@STARTTIMESTAMP"
+        # @STOPTIMESTAMP is the last frame-related message; trailing
+        # @INPROGRESSTIMESTAMP from the streaming thread shouldn't sneak
+        # in after stop() because the transport's _end_streaming joins
+        # the stream thread before queueing @STOPTIMESTAMP.
+        assert "@STOPTIMESTAMP" in captured_types
+        in_progress = sum(1 for t in captured_types if t == "@INPROGRESSTIMESTAMP")
+        # 30 FPS * 0.5s = ~15; allow generous slack for jitter.
+        assert in_progress >= 3, (
+            f"Expected several @INPROGRESSTIMESTAMP messages; got {in_progress}"
+        )
+
+    def test_frame_preview_returns_canned_bytes(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        try:
+            device.connect()
+            preview = device.frame_preview()
+            assert preview == _CANNED_PREVIEW_BYTES
+            assert len(preview) > 0
+        finally:
+            device.close()
+
+
+class TestMockIPhoneRegistration:
+    """Verify the substitution registry is wired up for IPhone."""
+
+    def test_mock_iphone_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(IPhoneDeviceArgs) is MockIPhoneDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockIPhoneDeviceArgs.device_class() is MockIPhone
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = IPhoneDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="IPhone_dev_1",
+            sensor_ids=["iphone_sens_1"],
+            sensor_array=[],
+            arg_parser="iout.stim_param_reader.py::IPhoneDeviceArgs()",
+        )
+        result = apply_mock_substitution(real, active={"IPhone"})
+        assert isinstance(result, MockIPhoneDeviceArgs)
+        assert result.device_id == "IPhone_dev_1"


### PR DESCRIPTION
## Summary

`MockIPhone` — a synthetic iPhone subclass that runs the full IPhone state machine without USBMux, sockets, or a running iOS app. Closes #729 once merged.

Stacked on top of #733 (Phase 1) and #732 (Phase 0). Selected at runtime via `NB_MOCK_DEVICES=IPhone` (or `=all`).

## Changes

- **`iphone.py`**: replace `self.sock` with `self.transport` — a duck-typed socket-like that the real path still gets from `USBMux.connect`. Drop the dead `_mock_handshake` (which tried to open a real TCP socket to `127.0.0.1:50009` with no listener on the other end) and the unreferenced `mock=False` parameter on `__init__` / `prepare`. State-machine bookkeeping in `_send_packet` / `_get_packet` / `_process_received_message` is unchanged.
- **`mock/mock_iphone.py`** (new): `_MockIPhoneTransport` is a queue-backed socket-like that parses outgoing packets and drives a small response table:
  - `@STANDBY` → `@READY`
  - `@START` → `@STARTTIMESTAMP` + a daemon thread that emits `@INPROGRESSTIMESTAMP` at the configured FPS
  - `@STOP` → `@STOPTIMESTAMP` (joining the streaming thread first)
  - `@PREVIEW` → a canned `FRAME_PREVIEW` packet with placeholder bytes
  
  `MockIPhone` overrides `_handshake` to install the transport and `disconnect` to skip the real path's 4-second iOS-cooldown sleep.
- **`stim_param_reader.py`**: new `MockIPhoneDeviceArgs(IPhoneDeviceArgs)` whose `device_class()` returns `MockIPhone`; `register_mock()` called at module import alongside the Mbient registration.
- **`tests/pytest/test_mock_iphone.py`**: 9 tests covering handshake → `#READY`, `start`/`stop`/`ensure_stopped` cycles, the LSL push-sample sequence (`@STARTTIMESTAMP`, several `@INPROGRESSTIMESTAMP`, `@STOPTIMESTAMP`), `frame_preview` canned bytes, and substitution-registry round-trip via `apply_mock_substitution`.

## Companion configs PR

A small configs-repo PR will remove the dangling `Mock_IPhone_dev_1` reference from `configs/environments/laptop/neurobooth_os_config.yaml` — the env-var-driven path makes that YAML reference unnecessary. (Tracked separately; nothing in this PR depends on that change.)

## Test plan

- [x] `python -m pytest tests/pytest/test_mock_iphone.py` → 9 passed
- [x] `python -m pytest tests/pytest/ neurobooth_os/iout/tests/` → 132 passed (123 prior + 9 new)
- [ ] Smoke test on a real laptop: set `NB_MOCK_DEVICES=IPhone`, run a session, confirm the handshake completes, a task records, and the LSL stream sees frame samples