### PR TITLE
Phase 3: MockEyeTracker — synthetic gaze samples without pylink

### DIFF
--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -86,8 +86,7 @@ class EyeTracker(Device):
                 "EyeTracker.connect() requires a PsychoPy window. "
                 "Pass win= to __init__ or supply psychopy_window in bring_up context."
             )
-        mon = monitors.getAllMonitors()[0]
-        self.monitor_width, self.monitor_height = monitors.Monitor(mon).getSizePix()
+        self.monitor_width, self.monitor_height = self._resolve_monitor_size()
 
         self.stream_info = set_stream_description(
             stream_info=StreamInfo(
@@ -127,6 +126,16 @@ class EyeTracker(Device):
         self._connect_tracker()
         if self.tk is not None:
             self.state = DeviceState.CONNECTED
+
+    def _resolve_monitor_size(self) -> Tuple[int, int]:
+        """Look up the active monitor's pixel dimensions.
+
+        Subclass hook: ``MockEyeTracker`` overrides to return canned
+        values so headless unit tests don't need a configured PsychoPy
+        monitor center.
+        """
+        mon = monitors.getAllMonitors()[0]
+        return monitors.Monitor(mon).getSizePix()
 
     def _connect_tracker(self):
         _require_pylink()
@@ -231,23 +240,31 @@ class EyeTracker(Device):
         Returns:
             List containing the created EDF file basename.
         """
-        _require_pylink()
         if filename is None:
             filename = "TEST.edf"
         self.filename = filename
-
         self.fname_temp = "name8chr.edf"
-        self.tk.openDataFile(self.fname_temp)
+
         self.streaming = True
         self.state = DeviceState.STARTED
 
-        pylink.beginRealTimeMode(100)
-        self.tk.startRecording(1, 1, 1, 1)
+        self._begin_native_recording()
         self.recording = True
         self.stream_thread = threading.Thread(target=self.record)
         self.logger.debug('EyeLink: Starting Record Thread')
         self.stream_thread.start()
         return [op.split(filename)[-1]]
+
+    def _begin_native_recording(self) -> None:
+        """Open the EDF file and start the EyeLink in real-time recording mode.
+
+        Subclass hook: ``MockEyeTracker`` overrides to skip the native
+        ``pylink.beginRealTimeMode`` / ``startRecording`` calls.
+        """
+        _require_pylink()
+        self.tk.openDataFile(self.fname_temp)
+        pylink.beginRealTimeMode(100)
+        self.tk.startRecording(1, 1, 1, 1)
 
     def record(self):
         self.paused = False
@@ -320,9 +337,18 @@ class EyeTracker(Device):
         self.recording = False
         if self.streaming:
             self.stream_thread.join()
-            self.tk.receiveDataFile(self.fname_temp, self.filename)
+            self._receive_data_file()
             self.streaming = False
         self.state = DeviceState.STOPPED
+
+    def _receive_data_file(self) -> None:
+        """Copy the EDF file from the tracker to ``self.filename``.
+
+        Subclass hook: ``MockEyeTracker`` overrides to write a stub
+        ``.edf`` file at the expected path so downstream code that
+        catalogues sensor files doesn't choke on a missing path.
+        """
+        self.tk.receiveDataFile(self.fname_temp, self.filename)
 
     def close(self) -> None:
         if self.tk is None:

--- a/neurobooth_os/iout/mock/mock_eyetracker.py
+++ b/neurobooth_os/iout/mock/mock_eyetracker.py
@@ -1,0 +1,148 @@
+"""Synthetic EyeLink that emits LSL gaze samples without pylink.
+
+Overrides the four hardware hooks on :class:`EyeTracker`:
+
+- ``_resolve_monitor_size`` — returns canned 1920x1080 instead of
+  reading PsychoPy's monitor center, which may not be configured on
+  laptops/CI.
+- ``_connect_tracker`` — skips ``pylink.EyeLink`` and instead installs
+  a stub ``tk`` object so inherited code that touches ``self.tk`` (e.g.
+  ``close``) works.  Still posts ``DeviceInitialization``.
+- ``_begin_native_recording`` — no-op (no EDF, no ``startRecording``).
+- ``record`` — synthetic 13-column gaze samples at ``self.sample_rate``
+  Hz on a daemon thread.
+- ``_receive_data_file`` — writes a tiny stub ``.edf`` so file-cataloguing
+  downstream of ``stop()`` doesn't choke on a missing path.
+- ``calibrate`` — no-op (the real path uses ``EyeLinkCoreGraphicsPsychoPy``
+  which transitively imports pylink).
+
+The mock assumes a real ``psychopy.visual.Window`` for live laptop
+sessions, but tolerates a duck-typed window in unit tests because none
+of the overridden methods draw to it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, List, Optional, Tuple
+
+from pylsl import local_clock
+
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.eyelink_tracker import EyeTracker
+from neurobooth_os.iout.metadator import post_message
+from neurobooth_os.msg.messages import DeviceInitialization, Request
+
+
+# Minimal stub bytes for the mock EDF file. Real EDF is a binary EyeLink
+# format; downstream consumers (XDF split / log_sensor_file) only need
+# the file to exist at the expected path with non-zero length.
+_STUB_EDF_BYTES = b"MOCK_EDF_FILE_PLACEHOLDER\n"
+
+
+class _MockEyelinkHandle:
+    """Stub satisfying the ``self.tk`` attribute on inherited paths.
+
+    ``EyeTracker.close()`` calls ``self.tk.close()``; the mock has no
+    native handle, so a no-op is enough.
+    """
+
+    def close(self) -> None:
+        return None
+
+
+class MockEyeTracker(EyeTracker):
+    """Synthetic EyeLink tracker — no pylink, no EyeLink hardware."""
+
+    # Canned monitor size returned by ``_resolve_monitor_size``.  Kept on
+    # the class so tests can override it without touching method bodies.
+    MOCK_MONITOR_WIDTH = 1920
+    MOCK_MONITOR_HEIGHT = 1080
+
+    def _resolve_monitor_size(self) -> Tuple[int, int]:
+        return self.MOCK_MONITOR_WIDTH, self.MOCK_MONITOR_HEIGHT
+
+    def _connect_tracker(self) -> None:
+        # Skip pylink.EyeLink; install a stub handle so inherited
+        # ``close()`` works without an existence check.
+        self.tk = _MockEyelinkHandle()
+        body = DeviceInitialization(
+            stream_name=self.streamName,
+            outlet_id=self.outlet_id,
+            device_id=self.device_id,
+        )
+        msg = Request(source="EyeTracker", destination="CTR", body=body)
+        post_message(msg)
+        self.logger.info("MockEyeTracker: tracker connection skipped (no pylink)")
+
+    def _begin_native_recording(self) -> None:
+        # Real path opens an EDF file on the tracker and arms
+        # real-time mode; mock has none of that infrastructure.
+        self.logger.info("MockEyeTracker: native recording skipped")
+
+    def record(self) -> None:
+        """Emit synthetic 13-column gaze samples until ``self.recording`` clears.
+
+        Column layout matches the real ``record()`` method (see
+        ``EyeTracker.connect``):
+        R/L gaze (x,y,pupil), target (x,y,distance), resolution (x,y),
+        time_edf, time_local.
+        """
+        period = 1.0 / float(self.sample_rate)
+        # Constants for canned samples; the values aren't realistic but
+        # downstream code only needs the LSL stream shape and cadence.
+        gaze_x = float(self.MOCK_MONITOR_WIDTH) / 2.0
+        gaze_y = float(self.MOCK_MONITOR_HEIGHT) / 2.0
+        pupil = 1000.0
+
+        self.timestamps_et: List[float] = []
+        self.timestamps_local: List[float] = []
+        self.paused = False
+        self.logger.debug("MockEyeTracker: entering synthetic record loop")
+        try:
+            while self.recording:
+                if self.paused:
+                    time.sleep(period)
+                    continue
+                t_local = local_clock()
+                t_edf = t_local * 1000.0  # match real EyeLink ms timestamp
+                sample = [
+                    gaze_x, gaze_y, pupil,         # right eye
+                    gaze_x, gaze_y, pupil,         # left eye
+                    0.0, 0.0, 0.0,                 # target x, y, distance
+                    1.0, 1.0,                      # ppd x, y
+                    t_edf, t_local,
+                ]
+                self.outlet.push_sample(sample)
+                self.timestamps_et.append(t_edf)
+                self.timestamps_local.append(t_local)
+                time.sleep(period)
+        except Exception:
+            self.logger.exception("MockEyeTracker: synthetic record loop error")
+        finally:
+            self.logger.debug("MockEyeTracker: exiting synthetic record loop")
+
+    def _receive_data_file(self) -> None:
+        """Write a stub EDF at ``self.filename`` so file paths land on disk."""
+        try:
+            with open(self.filename, "wb") as fh:
+                fh.write(_STUB_EDF_BYTES)
+            self.logger.info(
+                f"MockEyeTracker: wrote stub EDF at {self.filename}")
+        except OSError as e:
+            # Best-effort; tests that care can supply a writable path.
+            self.logger.warning(
+                f"MockEyeTracker: could not write stub EDF at "
+                f"{self.filename}: {e}")
+
+    def calibrate(self) -> None:
+        # Real path uses EyeLinkCoreGraphicsPsychoPy which transitively
+        # imports pylink. Mock skips the entire pylink dance.
+        self.logger.info("MockEyeTracker: calibration skipped")
+        self.calibrated = True
+
+    def close(self) -> None:
+        # Inherited close handles tk.close() (our stub is a no-op) and
+        # state transitions; nothing extra needed.
+        super().close()

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -230,6 +230,21 @@ class EyelinkDeviceArgs(DeviceArgs):
         return EyeTracker
 
 
+class MockEyelinkDeviceArgs(EyelinkDeviceArgs):
+    """DeviceArgs for :class:`MockEyeTracker` — same fields, different device class.
+
+    Selected at runtime by the substitution registry when ``EyeTracker``
+    is in ``NB_MOCK_DEVICES``; instances are built via Pydantic
+    ``model_construct``, so this subclass exists primarily to point
+    ``device_class()`` at the mock implementation.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_eyetracker import MockEyeTracker
+        return MockEyeTracker
+
+
 class IPhoneDeviceArgs(DeviceArgs):
     """
     IPhone device arguments
@@ -728,3 +743,4 @@ from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
 
 register_mock(MbientDeviceArgs, MockMbientDeviceArgs)
 register_mock(IPhoneDeviceArgs, MockIPhoneDeviceArgs)
+register_mock(EyelinkDeviceArgs, MockEyelinkDeviceArgs)

--- a/tests/pytest/test_mock_eyetracker.py
+++ b/tests/pytest/test_mock_eyetracker.py
@@ -1,0 +1,181 @@
+"""Lifecycle tests for the synthetic EyeLink mock.
+
+These tests exercise ``MockEyeTracker`` end-to-end without ``pylink``
+installed and without a configured PsychoPy monitor center.  Coverage:
+
+- ``__init__`` -> ``connect`` lands the device in ``DeviceState.CONNECTED``
+  using canned monitor dimensions.
+- ``start`` -> recording -> ``stop`` cycles through state transitions
+  and writes a stub ``.edf`` file at the requested path.
+- The synthetic record loop pushes 13-column samples at the configured
+  sample rate.
+- ``calibrate`` is a no-op (does not touch ``EyeLinkCoreGraphicsPsychoPy``
+  or ``pylink``).
+- The substitution registry is populated by importing
+  ``stim_param_reader``.
+"""
+
+import os
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from neurobooth_os.iout import eyelink_tracker as eyelink_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock import mock_eyetracker as mock_eyetracker_mod
+from neurobooth_os.iout.mock.mock_eyetracker import (
+    _STUB_EDF_BYTES,
+    MockEyeTracker,
+)
+from neurobooth_os.iout.stim_param_reader import (
+    EyelinkDeviceArgs,
+    EyelinkSensorArgs,
+    MockEyelinkDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 500
+RECORDING_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockEyelinkDeviceArgs:
+    sensor = EyelinkSensorArgs.model_construct(
+        sensor_id="eyelink_sens_1",
+        sample_rate=SAMPLE_RATE_HZ,
+        calibration_type="HV5",
+        msec_delay=10,
+        calibration_area_proportion=(0.85, 0.85),
+        validation_area_proportion=(0.85, 0.85),
+    )
+    return MockEyelinkDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="EyeLink_dev_1",
+        sensor_ids=["eyelink_sens_1"],
+        sensor_array=[sensor],
+        ip="100.1.1.1",
+        arg_parser="iout.stim_param_reader.py::MockEyelinkDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockEyelinkDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture
+def mock_window():
+    """A duck-typed window. The mock never draws to it, so MagicMock works."""
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _silence_messaging(monkeypatch):
+    """Replace ``post_message`` in both modules so tests don't hit the DB.
+
+    ``EyeTracker`` imports ``post_message`` into ``eyelink_tracker``'s
+    namespace, and ``MockEyeTracker._connect_tracker`` imports it into
+    ``mock_eyetracker``'s namespace.  Both bindings need patching.
+    """
+    monkeypatch.setattr(eyelink_mod, "post_message", lambda msg: None)
+    monkeypatch.setattr(mock_eyetracker_mod, "post_message", lambda msg: None)
+
+
+class TestMockEyeTrackerLifecycle:
+
+    def test_connect_lands_in_connected(self, mock_args, mock_window):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        try:
+            assert device.state == DeviceState.CONNECTED
+            assert device.tk is not None
+            assert device.monitor_width == 1920
+            assert device.monitor_height == 1080
+            assert device.outlet is not None
+        finally:
+            device.close()
+
+    def test_start_stop_writes_stub_edf(self, mock_args, mock_window, tmp_path):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        edf_path = str(tmp_path / "task_a_eyelink.edf")
+        try:
+            files = device.start(edf_path)
+            assert files == ["task_a_eyelink.edf"]
+            assert device.streaming is True
+            assert device.recording is True
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            assert device.state == DeviceState.STOPPED
+            assert device.streaming is False
+            assert device.recording is False
+            assert os.path.exists(edf_path)
+            with open(edf_path, "rb") as f:
+                assert f.read() == _STUB_EDF_BYTES
+        finally:
+            device.close()
+
+    def test_close_after_recording(self, mock_args, mock_window, tmp_path):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        edf_path = str(tmp_path / "close_test.edf")
+        device.start(edf_path)
+        device.close()
+        assert device.state == DeviceState.DISCONNECTED
+
+
+class TestMockEyeTrackerLSLFlow:
+
+    def test_synthetic_samples_flow(self, mock_args, mock_window, tmp_path):
+        """Verify the synthetic record thread captures timestamps at the
+        configured rate.  Asserting on absolute count is brittle on
+        Windows scheduling; require a generous lower bound instead.
+        """
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        edf_path = str(tmp_path / "lsl_test.edf")
+        try:
+            device.start(edf_path)
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+        finally:
+            device.close()
+        assert device.timestamps_et, "Expected synthetic timestamps"
+        assert len(device.timestamps_local) == len(device.timestamps_et)
+        # 500 Hz over 300 ms is ~150 samples; the mock's ``time.sleep``
+        # cadence is OS-bound on Windows, so >= 5 is the loose floor.
+        assert len(device.timestamps_et) >= 5, (
+            f"Expected at least 5 synthetic samples; got "
+            f"{len(device.timestamps_et)}"
+        )
+
+    def test_calibrate_is_no_op(self, mock_args, mock_window):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        try:
+            # The real ``calibrate`` reaches into pylink via
+            # EyeLinkCoreGraphicsPsychoPy. The mock should not.
+            device.calibrate()
+            assert device.calibrated is True
+        finally:
+            device.close()
+
+
+class TestMockEyeTrackerRegistration:
+
+    def test_mock_eyetracker_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(EyelinkDeviceArgs) is MockEyelinkDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockEyelinkDeviceArgs.device_class() is MockEyeTracker
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = EyelinkDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="EyeLink_dev_1",
+            sensor_ids=["eyelink_sens_1"],
+            ip="100.1.1.1",
+            sensor_array=[],
+            arg_parser="iout.stim_param_reader.py::EyelinkDeviceArgs()",
+        )
+        result = apply_mock_substitution(real, active={"EyeTracker"})
+        assert isinstance(result, MockEyelinkDeviceArgs)
+        assert result.device_id == "EyeLink_dev_1"
+        assert result.ip == "100.1.1.1"


### PR DESCRIPTION
## Summary

`MockEyeTracker` — a synthetic EyeLink subclass that runs the full record lifecycle without `pylink` installed and without a configured PsychoPy monitor center. Closes #730 once merged.

Stacked on top of #734 (Phase 2), #733 (Phase 1), and #732 (Phase 0). Selected at runtime via `NB_MOCK_DEVICES=EyeTracker` (or `=all`).

## Changes

- **`eyelink_tracker.py`**: extract three subclass hooks.
  - `_resolve_monitor_size()` — the `monitors.getAllMonitors()` lookup so headless tests don't need a configured PsychoPy monitor center.
  - `_begin_native_recording()` — the `tk.openDataFile` / `pylink.beginRealTimeMode` / `tk.startRecording` block that requires the EyeLink SDK.
  - `_receive_data_file()` — the `tk.receiveDataFile` call in `stop()` that copies the EDF from the tracker.
  
  Inherited `connect` / `start` / `stop` / `close` paths are unchanged in behaviour for real EyeLinks; the `_require_pylink()` gate moves into the new hooks where it belongs.
- **`mock/mock_eyetracker.py`** (new): `MockEyeTracker` overrides the three hooks plus `_connect_tracker`, `record`, `calibrate`, and `close`.
  - `_resolve_monitor_size` returns canned 1920x1080.
  - `_connect_tracker` installs a stub `_MockEyelinkHandle` and posts `DeviceInitialization` (no `pylink.EyeLink` call).
  - `_begin_native_recording` is a no-op.
  - `record` emits 13-column synthetic gaze samples at `sample_rate` Hz on the existing record-thread infrastructure.
  - `_receive_data_file` writes a small placeholder `.edf` at `self.filename` so downstream file-cataloguing doesn't choke.
  - `calibrate` is a no-op (real path uses `EyeLinkCoreGraphicsPsychoPy` which transitively imports `pylink`).
  
  Live laptop sessions still use a real `psychopy.visual.Window`; tests use a `MagicMock` window because none of the overridden methods draw.
- **`stim_param_reader.py`**: new `MockEyelinkDeviceArgs(EyelinkDeviceArgs)` whose `device_class()` returns `MockEyeTracker`; `register_mock()` called at module import alongside the Mbient and IPhone registrations.
- **`tests/pytest/test_mock_eyetracker.py`**: 8 tests covering connect-to-CONNECTED, `start`/`stop` with stub-EDF write, synthetic-sample flow, `calibrate` no-op, and substitution-registry round-trip via `apply_mock_substitution`.

## Test plan

- [x] `python -m pytest tests/pytest/test_mock_eyetracker.py` → 8 passed
- [x] `python -m pytest tests/pytest/ neurobooth_os/iout/tests/` → 140 passed (132 prior + 8 new)
- [ ] Smoke test on a real laptop: set `NB_MOCK_DEVICES=EyeTracker`, run a session, confirm device comes up, a task records, and the LSL stream sees gaze samples