### PR TITLE
Mock-device infrastructure: hardware-less testing for Mbient, iPhone, EyeLink

### DIFF
--- a/docs/arch/adding_a_device.md
+++ b/docs/arch/adding_a_device.md
@@ -433,6 +433,102 @@ touch indirectly:
 | `neurobooth_os/iout/device.py`            | `Device`, `DeviceCapability`, `DeviceState`, `CameraPreviewException` |
 | `neurobooth_os/iout/stim_param_reader.py` | `DeviceArgs` and every subclass                         |
 | `neurobooth_os/iout/lsl_streamer.py`      | `DeviceManager`                                         |
-| `neurobooth_os/iout/mock_device.py`       | Mock implementations for testing                        |
+| `neurobooth_os/iout/mock_device.py`       | `Device` base-class testing scaffolding (`MockStreamDevice`, `MockRecordingDevice`) |
+| `neurobooth_os/iout/mock/`                | Hardware mocks (`MockMbient`, `MockIPhone`, `MockEyeTracker`) |
+| `neurobooth_os/iout/mock_substitution.py` | Substitution registry + env/config plumbing             |
 | `tests/pytest/test_device_lifecycle.py`   | Base-class lifecycle tests                              |
 | `tests/pytest/test_device_pluggable.py`   | `bring_up`, hooks, capability dispatch, registry tests  |
+| `tests/pytest/test_mock_substitution.py`  | Substitution mechanism + lazy-import smoke tests        |
+| `tests/pytest/test_mock_*.py`             | Per-device mock lifecycle tests                         |
+
+## Running with mocks
+
+Neurobooth supports a single-laptop "mock everything" mode for development
+and demos: each real hardware-touching `Device` has a sibling mock subclass
+that runs the full lifecycle (`bring_up` → `start` → `stop` → `close`,
+plus `frame_preview` / `calibrate` / `on_task_reconnect` / `on_session_reset`)
+without any BLE radio, USB iPhone, or EyeLink box attached. The selection
+happens at `device_class()` resolution time inside
+`DeviceManager.create_streams`, so YAML configs and per-task device lists
+stay identical to a real-hardware run.
+
+### Activating mocks
+
+Two opt-in sources, in priority order:
+
+1. **`NB_MOCK_DEVICES` environment variable** (wins when set):
+   ```bash
+   # Mock just the Mbients for this run; everything else uses real hardware
+   NB_MOCK_DEVICES=Mbient python -m neurobooth_os.gui
+
+   # Multiple devices (whitespace-tolerant)
+   NB_MOCK_DEVICES="Mbient, IPhone, EyeTracker" python -m neurobooth_os.gui
+
+   # Mock every registered device
+   NB_MOCK_DEVICES=all python -m neurobooth_os.gui
+   ```
+2. **`mock_devices` field in `neurobooth_os_config.yaml`** (persistent
+   fallback; overridden by the env var):
+   ```yaml
+   mock_devices: ["Mbient", "IPhone", "EyeTracker"]
+   ```
+
+Targets are **device-class names** (`Mbient`, `IPhone`, `EyeTracker`),
+not device-IDs. So `NB_MOCK_DEVICES=Mbient` mocks every Mbient in the
+assigned set.
+
+When at least one mock is active, the GUI logs a CRITICAL banner and
+opens a dialog at startup so a forgotten env var can't silently corrupt
+a real recording.
+
+### What each mock does
+
+| Mock              | Hardware bypass              | Synthetic output                                                   |
+|-------------------|------------------------------|--------------------------------------------------------------------|
+| `MockMbient`      | No BLE / `mbientlab` SDK     | Daemon thread emits acc+gyro samples (1g down, zero rotation) at the higher of `acc_hz` / `gyro_hz` |
+| `MockIPhone`      | No `USBMux` / socket         | In-process queue runs the state machine; daemon thread emits `@INPROGRESSTIMESTAMP` between `@STARTTIMESTAMP` and `@STOPTIMESTAMP` at the configured FPS; `frame_preview()` returns canned bytes |
+| `MockEyeTracker`  | No `pylink` / EyeLink box    | Daemon thread emits 13-column synthetic gaze samples at `sample_rate` Hz; writes a stub `.edf` at the requested path; `calibrate()` is a no-op |
+
+All mocks live in `neurobooth_os/iout/mock/` and register their
+`MockXxxDeviceArgs` subclass via
+`mock_substitution.register_mock(real_cls, mock_cls)` at module-import
+time (called from `stim_param_reader.py`).
+
+### Adding a mock for a new device
+
+The pluggable-device design only requires three things from a new mock:
+
+1. **A subclass of the real `DeviceArgs`** in `stim_param_reader.py` whose
+   `device_class()` returns your mock device class:
+   ```python
+   class MockFooDeviceArgs(FooDeviceArgs):
+       @classmethod
+       def device_class(cls) -> Type["Device"]:
+           from neurobooth_os.iout.mock.mock_foo import MockFoo
+           return MockFoo
+   ```
+2. **A subclass of the real `Device`** in `neurobooth_os/iout/mock/mock_foo.py`
+   that overrides only the methods that touch hardware. Prefer extracting
+   small subclass hooks in the real device class (e.g. `_acquire_hardware`,
+   `_attach_data_source`) and overriding those, rather than re-implementing
+   `connect()` / `start()` wholesale.
+3. **A `register_mock` call** at the bottom of `stim_param_reader.py`:
+   ```python
+   register_mock(FooDeviceArgs, MockFooDeviceArgs)
+   ```
+
+If the real device's module imports a hardware SDK at the top level
+(e.g. `import mbientlab`), wrap that import in a `try / except ImportError`
+and gate hardware code paths behind a `_require_<sdk>()` helper — see
+`mbient.py` and `eyelink_tracker.py` for the pattern. Without that
+guard, the mock can't import on a hardware-less laptop.
+
+### Live laptop vs unit tests
+
+- **Live laptop** sessions assume a real `psychopy.visual.Window`, a real
+  LSL backend, and a real database. Mocks bypass only hardware, not LSL
+  or messaging.
+- **Unit tests** (`tests/pytest/test_mock_*.py`) run with `DISABLE_LSL`
+  and a stubbed `post_message`, so they don't need any networking or
+  database. The `MockEyeTracker` tests pass a `MagicMock` window because
+  none of the overridden methods draw to it.

--- a/docs/arch/credential_management.md
+++ b/docs/arch/credential_management.md
@@ -1,101 +1,158 @@
-# Credential Management
+# Credential Management Design
 
-## Overview
+## Current State
 
-Credentials are stored in `secrets.yaml`, located in the config folder alongside
-`neurobooth_os_config.yaml` (`NB_CONFIG`). At startup,
+### How credentials work today
+
+All credentials live in `secrets.yaml`, keyed by environment name. At startup,
 `config.load_neurobooth_config()` deep-merges `secrets.yaml` into the base config
-and constructs a single `NeuroboothConfig` model.
+and constructs a single `NeuroboothConfig` Pydantic model that includes every server
+definition, regardless of which process is loading it.
 
-Each machine only needs the credentials it actually uses — the database password,
-plus (on the CTR machine only) the Windows passwords needed to remotely manage
-the ACQ/STM machines.
+```yaml
+# secrets.yaml (current structure)
+production:
+  database:
+    password: "db_password_here"
+  acquisition:
+    - password: "acq0_windows_password"
+    - password: "acq1_windows_password"
+  presentation:
+    password: "stm_windows_password"
+  control:
+    password: "ctr_windows_password"
+```
 
-## Schema
+### Problems
 
-Credentials live on two Pydantic models in `neurobooth_os/config.py`:
+1. **Every machine needs every password.** `ServerSpec.password` is a required field
+   with no default. Pydantic validates the entire model at startup, so even an ACQ
+   server that never uses the control password will fail to start if it is missing.
+
+2. **Over-distribution of credentials.** To satisfy validation, every machine gets a
+   copy of `secrets.yaml` containing passwords for all servers. ACQ and STM machines
+   end up with Windows remote-management passwords they never use.
+
+3. **Only CTR uses service passwords.** The `ServerSpec.password` fields are consumed
+   exclusively by `netcomm/client.py` for remote process management (`tasklist`,
+   `taskkill`, `SCHTASKS`, `WMIC`). Only the CTR process calls these functions.
+
+4. **CTR does not need its own service password.** The `control.password` field is
+   never read at runtime. CTR uses the acquisition and presentation passwords to
+   manage remote servers, but nobody manages CTR remotely.
+
+5. **The control password field is dead weight.** It must be present to pass validation
+   but serves no purpose.
+
+## Requirements
+
+- ACQ and STM machines should only need the database password.
+- CTR should have the database password plus the service passwords for the machines
+  it manages.
+- No machine should receive credentials it does not use.
+- The solution should not require maintaining multiple config files per environment.
+- Operational burden should be minimal — the current single `secrets.yaml` per
+  machine approach is desirable for its simplicity.
+
+## Proposed Design
+
+### Make service passwords optional
+
+Change `ServerSpec.password` from required to optional with a `None` default:
 
 ```python
-class DatabaseSpec(BaseModel):
-    ...
-    password: SecretStr   # required — every process needs DB access
-
-class MachineSpec(BaseModel):
-    """A physical or logical host."""
+class ServerSpec(BaseModel):
+    name: str
     user: str
-    password: Optional[SecretStr] = None   # optional — only CTR uses these
+    password: Optional[SecretStr] = None  # Only needed by CTR for remote management
     local_data_dir: str
-    local_log_dir: Optional[str] = None
+    bat: Optional[str] = None
+    task_name: Optional[str] = None
+    devices: List[str] = []
 ```
 
-`ResolvedService` (returned by `NeuroboothConfig.server_by_name()`) inherits the
-`password` field from its `MachineSpec` via `_resolve_service`. The same physical
-machine can host multiple services, and the password is per-machine, not
-per-service.
+This is the minimal change. Config loading succeeds regardless of which passwords are
+present. No structural changes to `secrets.yaml` or `NeuroboothConfig`.
 
-## secrets.yaml
+### Validate at point of use, not at load time
 
-Keyed by environment name (e.g. `production`, `staging`); the active environment
-is selected by the `environment` field in `neurobooth_os_config.yaml`. Within
-each environment, secrets are deep-merged into the corresponding sections of the
-base config — so `machines.<name>.password` in `secrets.yaml` populates the
-`password` field of the matching `MachineSpec`.
-
-### CTR machine
-
-```yaml
-production:
-  database:
-    password: "db_password"
-  machines:
-    acq-prod:
-      password: "acq_windows_password"
-    stm-prod:
-      password: "stm_windows_password"
-```
-
-### ACQ and STM machines
-
-```yaml
-production:
-  database:
-    password: "db_password"
-```
-
-Each machine gets only the secrets it actually uses. The control machine itself
-does not need (or have) a Windows password in `secrets.yaml` — nothing manages
-CTR remotely.
-
-## Validation
-
-`MachineSpec.password` being optional means config loading succeeds regardless of
-which Windows passwords are present. Validation happens at the point of use
-rather than at load time:
+Add a check in `netcomm/client.py` where the password is actually consumed:
 
 ```python
-# neurobooth_os/netcomm/client.py
-s = cfg.neurobooth_config.server_by_name(node_name)
-if s.password is None:
-    raise cfg.ConfigException(
-        f"Cannot start remote server '{node_name}': no password configured. "
-        f"Service passwords are required in secrets.yaml on the control machine."
-    )
+def start_server(s: ServerSpec, ...):
+    if s.password is None:
+        raise ConfigException(
+            f"Cannot start remote server '{s.name}': no password configured. "
+            f"Service passwords are required in secrets.yaml on the control machine."
+        )
+    password = s.password.get_secret_value()
+    ...
 ```
 
-The same guard exists in `kill_remote_pid()`. Any consumer that tries to use a
-missing password gets a clear, actionable error rather than a startup-time
-Pydantic failure on every machine that doesn't need that credential.
+This gives a clear error message if CTR is missing a needed password, rather than a
+generic Pydantic validation error at startup.
+
+### Per-machine secrets files
+
+With the above change, each machine gets a minimal `secrets.yaml`:
+
+**ACQ and STM machines:**
+```yaml
+production:
+  database:
+    password: "db_password_here"
+```
+
+**CTR machine:**
+```yaml
+production:
+  database:
+    password: "db_password_here"
+  acquisition:
+    - password: "acq0_windows_password"
+    - password: "acq1_windows_password"
+  presentation:
+    password: "stm_windows_password"
+```
+
+No `control.password` entry anywhere — it is never used.
+
+## Implementation
+
+The change touches three files:
+
+1. **`config.py`** — Change `ServerSpec.password` to `Optional[SecretStr] = None`.
+
+2. **`netcomm/client.py`** — Add a guard at the top of `start_server()` and
+   `kill_remote_pid()` that raises `ConfigException` if `s.password is None`.
+   This replaces the implicit Pydantic validation with an explicit, actionable error.
+
+3. **`docs/arch/system_configuration.md`** — Document which secrets each machine
+   needs.
+
+### What does not change
+
+- `secrets.yaml` format (still YAML, still keyed by environment).
+- `_deep_merge` logic (still merges by index for lists).
+- `_load_secrets` resolution order (still checks `NB_SECRETS` env var first).
+- `DatabaseSpec.password` remains required — every process needs it.
+- Existing deployments with full `secrets.yaml` on every machine continue to work
+  unchanged.
+
+## Migration
+
+This is backward-compatible. Existing `secrets.yaml` files with all passwords
+continue to work. Machines can be migrated to minimal secrets files one at a time.
+No coordinated rollout is needed.
 
 ## Credential inventory
+
+After migration, the credential requirements per machine are:
 
 | Credential | Purpose | CTR | ACQ | STM |
 |------------|---------|-----|-----|-----|
 | `database.password` | PostgreSQL auth | Required | Required | Required |
-| `machines.<acq-host>.password` | Remote process management of ACQ | Required | - | - |
-| `machines.<stm-host>.password` | Remote process management of STM | Required | - | - |
+| `acquisition[N].password` | Remote process mgmt | Required | - | - |
+| `presentation.password` | Remote process mgmt | Required | - | - |
+| `control.password` | (unused) | - | - | - |
 | SSH key (`~/.ssh/id_rsa`) | SSH tunnel to DB | Required | Required | Required |
-
-The SSH tunnel key path is currently hardcoded to `~/.ssh/id_rsa` in
-`metadator.get_database_connection()`. Whether a tunnel is actually opened
-depends on `database.ssh_tunnel` and whether `database.host` is `127.0.0.1` /
-`localhost` — see `metadator.py` for the gating.

--- a/docs/arch/credential_management.md
+++ b/docs/arch/credential_management.md
@@ -1,158 +1,101 @@
-# Credential Management Design
+# Credential Management
 
-## Current State
+## Overview
 
-### How credentials work today
-
-All credentials live in `secrets.yaml`, keyed by environment name. At startup,
+Credentials are stored in `secrets.yaml`, located in the config folder alongside
+`neurobooth_os_config.yaml` (`NB_CONFIG`). At startup,
 `config.load_neurobooth_config()` deep-merges `secrets.yaml` into the base config
-and constructs a single `NeuroboothConfig` Pydantic model that includes every server
-definition, regardless of which process is loading it.
+and constructs a single `NeuroboothConfig` model.
 
-```yaml
-# secrets.yaml (current structure)
-production:
-  database:
-    password: "db_password_here"
-  acquisition:
-    - password: "acq0_windows_password"
-    - password: "acq1_windows_password"
-  presentation:
-    password: "stm_windows_password"
-  control:
-    password: "ctr_windows_password"
-```
+Each machine only needs the credentials it actually uses — the database password,
+plus (on the CTR machine only) the Windows passwords needed to remotely manage
+the ACQ/STM machines.
 
-### Problems
+## Schema
 
-1. **Every machine needs every password.** `ServerSpec.password` is a required field
-   with no default. Pydantic validates the entire model at startup, so even an ACQ
-   server that never uses the control password will fail to start if it is missing.
-
-2. **Over-distribution of credentials.** To satisfy validation, every machine gets a
-   copy of `secrets.yaml` containing passwords for all servers. ACQ and STM machines
-   end up with Windows remote-management passwords they never use.
-
-3. **Only CTR uses service passwords.** The `ServerSpec.password` fields are consumed
-   exclusively by `netcomm/client.py` for remote process management (`tasklist`,
-   `taskkill`, `SCHTASKS`, `WMIC`). Only the CTR process calls these functions.
-
-4. **CTR does not need its own service password.** The `control.password` field is
-   never read at runtime. CTR uses the acquisition and presentation passwords to
-   manage remote servers, but nobody manages CTR remotely.
-
-5. **The control password field is dead weight.** It must be present to pass validation
-   but serves no purpose.
-
-## Requirements
-
-- ACQ and STM machines should only need the database password.
-- CTR should have the database password plus the service passwords for the machines
-  it manages.
-- No machine should receive credentials it does not use.
-- The solution should not require maintaining multiple config files per environment.
-- Operational burden should be minimal — the current single `secrets.yaml` per
-  machine approach is desirable for its simplicity.
-
-## Proposed Design
-
-### Make service passwords optional
-
-Change `ServerSpec.password` from required to optional with a `None` default:
+Credentials live on two Pydantic models in `neurobooth_os/config.py`:
 
 ```python
-class ServerSpec(BaseModel):
-    name: str
-    user: str
-    password: Optional[SecretStr] = None  # Only needed by CTR for remote management
-    local_data_dir: str
-    bat: Optional[str] = None
-    task_name: Optional[str] = None
-    devices: List[str] = []
-```
-
-This is the minimal change. Config loading succeeds regardless of which passwords are
-present. No structural changes to `secrets.yaml` or `NeuroboothConfig`.
-
-### Validate at point of use, not at load time
-
-Add a check in `netcomm/client.py` where the password is actually consumed:
-
-```python
-def start_server(s: ServerSpec, ...):
-    if s.password is None:
-        raise ConfigException(
-            f"Cannot start remote server '{s.name}': no password configured. "
-            f"Service passwords are required in secrets.yaml on the control machine."
-        )
-    password = s.password.get_secret_value()
+class DatabaseSpec(BaseModel):
     ...
+    password: SecretStr   # required — every process needs DB access
+
+class MachineSpec(BaseModel):
+    """A physical or logical host."""
+    user: str
+    password: Optional[SecretStr] = None   # optional — only CTR uses these
+    local_data_dir: str
+    local_log_dir: Optional[str] = None
 ```
 
-This gives a clear error message if CTR is missing a needed password, rather than a
-generic Pydantic validation error at startup.
+`ResolvedService` (returned by `NeuroboothConfig.server_by_name()`) inherits the
+`password` field from its `MachineSpec` via `_resolve_service`. The same physical
+machine can host multiple services, and the password is per-machine, not
+per-service.
 
-### Per-machine secrets files
+## secrets.yaml
 
-With the above change, each machine gets a minimal `secrets.yaml`:
+Keyed by environment name (e.g. `production`, `staging`); the active environment
+is selected by the `environment` field in `neurobooth_os_config.yaml`. Within
+each environment, secrets are deep-merged into the corresponding sections of the
+base config — so `machines.<name>.password` in `secrets.yaml` populates the
+`password` field of the matching `MachineSpec`.
 
-**ACQ and STM machines:**
+### CTR machine
+
 ```yaml
 production:
   database:
-    password: "db_password_here"
+    password: "db_password"
+  machines:
+    acq-prod:
+      password: "acq_windows_password"
+    stm-prod:
+      password: "stm_windows_password"
 ```
 
-**CTR machine:**
+### ACQ and STM machines
+
 ```yaml
 production:
   database:
-    password: "db_password_here"
-  acquisition:
-    - password: "acq0_windows_password"
-    - password: "acq1_windows_password"
-  presentation:
-    password: "stm_windows_password"
+    password: "db_password"
 ```
 
-No `control.password` entry anywhere — it is never used.
+Each machine gets only the secrets it actually uses. The control machine itself
+does not need (or have) a Windows password in `secrets.yaml` — nothing manages
+CTR remotely.
 
-## Implementation
+## Validation
 
-The change touches three files:
+`MachineSpec.password` being optional means config loading succeeds regardless of
+which Windows passwords are present. Validation happens at the point of use
+rather than at load time:
 
-1. **`config.py`** — Change `ServerSpec.password` to `Optional[SecretStr] = None`.
+```python
+# neurobooth_os/netcomm/client.py
+s = cfg.neurobooth_config.server_by_name(node_name)
+if s.password is None:
+    raise cfg.ConfigException(
+        f"Cannot start remote server '{node_name}': no password configured. "
+        f"Service passwords are required in secrets.yaml on the control machine."
+    )
+```
 
-2. **`netcomm/client.py`** — Add a guard at the top of `start_server()` and
-   `kill_remote_pid()` that raises `ConfigException` if `s.password is None`.
-   This replaces the implicit Pydantic validation with an explicit, actionable error.
-
-3. **`docs/arch/system_configuration.md`** — Document which secrets each machine
-   needs.
-
-### What does not change
-
-- `secrets.yaml` format (still YAML, still keyed by environment).
-- `_deep_merge` logic (still merges by index for lists).
-- `_load_secrets` resolution order (still checks `NB_SECRETS` env var first).
-- `DatabaseSpec.password` remains required — every process needs it.
-- Existing deployments with full `secrets.yaml` on every machine continue to work
-  unchanged.
-
-## Migration
-
-This is backward-compatible. Existing `secrets.yaml` files with all passwords
-continue to work. Machines can be migrated to minimal secrets files one at a time.
-No coordinated rollout is needed.
+The same guard exists in `kill_remote_pid()`. Any consumer that tries to use a
+missing password gets a clear, actionable error rather than a startup-time
+Pydantic failure on every machine that doesn't need that credential.
 
 ## Credential inventory
-
-After migration, the credential requirements per machine are:
 
 | Credential | Purpose | CTR | ACQ | STM |
 |------------|---------|-----|-----|-----|
 | `database.password` | PostgreSQL auth | Required | Required | Required |
-| `acquisition[N].password` | Remote process mgmt | Required | - | - |
-| `presentation.password` | Remote process mgmt | Required | - | - |
-| `control.password` | (unused) | - | - | - |
+| `machines.<acq-host>.password` | Remote process management of ACQ | Required | - | - |
+| `machines.<stm-host>.password` | Remote process management of STM | Required | - | - |
 | SSH key (`~/.ssh/id_rsa`) | SSH tunnel to DB | Required | Required | Required |
+
+The SSH tunnel key path is currently hardcoded to `~/.ssh/id_rsa` in
+`metadator.get_database_connection()`. Whether a tunnel is actually opened
+depends on `database.ssh_tunnel` and whether `database.host` is `127.0.0.1` /
+`localhost` — see `metadator.py` for the gating.

--- a/docs/testing_with_mocks.md
+++ b/docs/testing_with_mocks.md
@@ -85,6 +85,83 @@ follows the real lifecycle path.
   so file-cataloguing downstream doesn't choke on a missing file.
   `calibrate()` is a no-op.
 
+### Multiple instances of the same device
+
+Substitution is **per-device-instance**, not per-class. A collection
+that assigns five Mbients (`Mbient_BK_1`, `Mbient_LF_2`,
+`Mbient_LH_2`, `Mbient_RF_2`, `Mbient_RH_2` — the mvp-30 layout)
+gets five independent `MockMbient` instances when
+`NB_MOCK_DEVICES=Mbient` is set. Each one:
+
+- Is built via `model_construct(**original_args.model_dump())`, so it
+  keeps its own field values (`mac`, `device_name`, `acc_hz`,
+  `gyro_hz`) from the YAML.
+- Has its own daemon thread emitting samples.
+- Pushes to its own LSL outlet under the same `mbient_<dev_name>`
+  stream name the real device would have used.
+
+`MockIPhone` and `MockEyeTracker` are typically deployed as a single
+instance, but the same per-instance rule applies if your collection
+assigns more than one.
+
+## What is *not* mocked
+
+`apply_mock_substitution` only swaps a `DeviceArgs` class if it appears
+in `MOCK_REGISTRY`. Three devices currently have registered mocks:
+`MbientDeviceArgs`, `IPhoneDeviceArgs`, `EyelinkDeviceArgs`. Every
+other device class in the assigned set passes through to its real
+implementation **regardless of `NB_MOCK_DEVICES=all`** — `all` means
+"every registered mock target", not "every device".
+
+This matters in two distinct ways:
+
+### Devices that work fine without a mock
+
+- **Mouse** — `MouseDeviceArgs` has no mock and doesn't need one. The
+  real `Mouse` class reads OS-level mouse events; on a laptop with a
+  trackpad it captures trackpad events. `NB_MOCK_DEVICES=all` does
+  **not** replace it.
+- **Marker** (`MarkerStreamDevice`) — pure-Python LSL marker producer;
+  no hardware to mock.
+
+### Devices that *do* need hardware (and don't have mocks yet)
+
+- **Intel RealSense camera** (`VidRec_Intel` in `camera_intel.py`)
+- **FLIR camera** (`VidRec_Flir` in `flir_cam.py`)
+- **Yeti microphone** (`MicStream` in `microphone.py`)
+- **Webcam** (`VidRec_Webcam` in `webcam.py`)
+
+These modules still have **eager** top-level SDK imports
+(`import pyrealsense2`, `import PySpin`, `import pyaudio`) — Phase 0's
+lazy-import treatment only covered `mbient.py` and `eyelink_tracker.py`.
+Two consequences for a hardware-less laptop:
+
+1. If the SDK isn't installed, `device_class()` resolution raises
+   `ImportError` when `DeviceManager.create_streams` tries to load the
+   module, and the entire startup fails. The mocks for the other
+   devices won't help.
+2. If the SDK *is* installed but no real camera/mic is attached, the
+   class loads but `bring_up()` fails. It returns `None` and
+   `DeviceManager` skips the device — the rest of the session still
+   runs.
+
+If your collection requires any of these (mvp-30 includes Intel + FLIR
++ Yeti), you have three options:
+
+- **(a) Install the SDKs even without the hardware.** Lets the modules
+  import; bring_up will fail per-device but the session continues
+  without those streams.
+- **(b) Use a reduced collection** like `test_no_eyelink` (in
+  `examples/`) that strips out the missing-hardware devices. This is
+  the path documented in `single_machine_testing.md`.
+- **(c) Trim the laptop env's `acquisition.devices` list** in
+  `neurobooth_os_config.yaml` so no unmocked-and-unavailable devices
+  are assigned to begin with.
+
+A full hardware-less mvp-30 run on a laptop would require extending
+the lazy-import + mock pattern to those four modules — a follow-up
+beyond the scope of #732 / #733 / #734 / #735.
+
 ## What stays real
 
 Mocks bypass **only** hardware. Everything else runs as in production:
@@ -114,11 +191,17 @@ python -m neurobooth_os.gui
 Confirm:
 
 1. The startup banner names the active mocks.
-2. Each device's `bring_up` succeeds (logs show
+2. Each *mocked* device's `bring_up` succeeds (logs show
    `Device Manager Substituting MockXxx for Xxx`).
 3. A short task runs end-to-end; `log_sensor_file` rows appear with the
    expected `device_id` / `sensor_id` and stub file paths.
 4. XDF split succeeds.
+
+This currently works only if the laptop env's `acquisition.devices`
+list contains nothing beyond Mouse, Marker, Mbient, IPhone, and EyeLink
+(see [What is *not* mocked](#what-is-not-mocked)). Collections that
+also assign Intel / FLIR / mic devices need one of the workarounds in
+that section.
 
 ### Hardware-less unit tests
 
@@ -170,6 +253,12 @@ There are several signals depending on what you're checking:
 
 ## Pitfalls
 
+- **`all` only mocks what has a registered mock.** Setting
+  `NB_MOCK_DEVICES=all` does **not** try to mock the Mouse, Marker,
+  Intel camera, FLIR, or microphone — only Mbient / IPhone / EyeLink
+  (the three classes in `MOCK_REGISTRY` today). Devices without a
+  registered mock pass through to their real implementations
+  unchanged, so a working trackpad keeps working under `=all`.
 - **Targets are class names, not device IDs.** `NB_MOCK_DEVICES=Mbient`
   mocks every Mbient. `NB_MOCK_DEVICES=Mbient_dev_1` mocks **nothing** —
   there's no class by that name. The env-var-driven path was designed

--- a/docs/testing_with_mocks.md
+++ b/docs/testing_with_mocks.md
@@ -42,14 +42,52 @@ silently corrupt a real recording.
 
 ### Persistent fallback (config file)
 
-Mock targets can also live in `neurobooth_os_config.yaml`:
+Mock targets can also live in `neurobooth_os_config.yaml`. The
+`mock_devices` entry is a **top-level field** on the config — peer to
+`environment`, `screen`, `machines`, `acquisition`, `presentation`,
+`control`, and `database`. YAML doesn't care about ordering, but
+placing it near `environment:` reads naturally since both flag what
+kind of run this is:
 
 ```yaml
-mock_devices: ["Mbient", "IPhone", "EyeTracker"]
+environment: local
+mock_devices: ["Mbient", "IPhone", "EyeTracker"]   # ← here
+remote_data_dir: C:/data/
+...
+
+screen:
+  ...
+
+machines:
+  laptop:
+    ...
+
+acquisition:
+  - machine: laptop
+    devices:
+      - Mic_Yeti_dev_1
 ```
+
+Equivalent shorthand forms YAML accepts:
+
+```yaml
+mock_devices: [Mbient, IPhone, EyeTracker]   # flow style
+mock_devices:                                # block style
+  - Mbient
+  - IPhone
+  - EyeTracker
+mock_devices: ["all"]                        # the "all" sentinel
+```
+
+Omit the field entirely (or set `mock_devices: null`) for production
+envs — that's the default and means no mocks.
 
 The env var **wins** when both are set, so a developer can always
 force-enable or force-disable mocks for one run without editing config.
+For example, on a laptop env that sets `mock_devices: ["all"]` in the
+file, running with `set NB_MOCK_DEVICES=` (empty string) gives a
+one-off real-hardware run without touching the YAML.
+
 A laptop dev environment typically sets `mock_devices` in the file;
 production environments leave it unset.
 

--- a/docs/testing_with_mocks.md
+++ b/docs/testing_with_mocks.md
@@ -1,0 +1,215 @@
+# Testing with Mock Devices
+
+Neurobooth ships mock implementations of every hardware device so you can
+run a full session — or write a fast unit test — without an Mbient,
+iPhone, or EyeLink connected. The mocks live alongside the real devices
+in `neurobooth_os/iout/mock/` and are activated at runtime via an
+environment variable or a config field. No YAML changes are required;
+the same task collection that runs in production runs against mocks.
+
+For the developer-side architecture (subclass hooks, registry,
+adding a mock for a new device), see
+[arch/adding_a_device.md → Running with mocks](arch/adding_a_device.md#running-with-mocks).
+This document is the operator/tester quick reference.
+
+## Quick start
+
+Pick one or more device-class names — `Mbient`, `IPhone`, `EyeTracker` —
+and pass them in `NB_MOCK_DEVICES`:
+
+```bash
+# Mock every Mbient in the assigned set, leave iPhone/EyeLink real
+NB_MOCK_DEVICES=Mbient python -m neurobooth_os.gui
+
+# Mock several devices at once (whitespace-tolerant)
+NB_MOCK_DEVICES="Mbient, IPhone, EyeTracker" python -m neurobooth_os.gui
+
+# Mock everything that has a registered mock
+NB_MOCK_DEVICES=all python -m neurobooth_os.gui
+```
+
+Targets are device-class names, **not device IDs**, so
+`NB_MOCK_DEVICES=Mbient` mocks every Mbient regardless of how many are
+assigned.
+
+When at least one mock is active you'll see:
+
+- A `CRITICAL` log entry naming the active targets at GUI startup.
+- A red modal dialog listing the active mocks before the main UI opens.
+
+Both are intentional safeguards — a forgotten env var must not
+silently corrupt a real recording.
+
+### Persistent fallback (config file)
+
+Mock targets can also live in `neurobooth_os_config.yaml`:
+
+```yaml
+mock_devices: ["Mbient", "IPhone", "EyeTracker"]
+```
+
+The env var **wins** when both are set, so a developer can always
+force-enable or force-disable mocks for one run without editing config.
+A laptop dev environment typically sets `mock_devices` in the file;
+production environments leave it unset.
+
+## What gets mocked
+
+| Device           | Mock class         | Hardware bypassed                |
+|------------------|--------------------|----------------------------------|
+| Mbient wearable  | `MockMbient`       | BLE radio, `mbientlab` SDK       |
+| iPhone (camera)  | `MockIPhone`       | USB / `usbmux` / iOS app socket  |
+| EyeLink tracker  | `MockEyeTracker`   | EyeLink box, `pylink`, `.edf` capture |
+
+The substitution happens inside `DeviceManager.create_streams` at
+`device_class()` resolution time — so by the time `bring_up()` runs,
+the device instance is already the mock subclass. Operator-facing
+behavior (the GUI, log messages, task transitions, file registration)
+follows the real lifecycle path.
+
+### What each mock produces
+
+- **`MockMbient`** — a daemon thread emits constant-value accel and gyro
+  samples (1g down at rest, zero rotation) at the higher of the
+  configured `acc_hz` / `gyro_hz`. The LSL stream shape and cadence
+  match the real device; values are not realistic motion.
+- **`MockIPhone`** — an in-process queue runs the iOS-app state machine
+  end-to-end (`@HANDSHAKE` → `#CONNECTED` → `#STANDBY` → `#READY` →
+  `#RECORDING` → ...). A daemon thread emits `@INPROGRESSTIMESTAMP`
+  messages between `@STARTTIMESTAMP` and `@STOPTIMESTAMP` at the
+  configured FPS so the LSL frame index advances. `frame_preview()`
+  returns a canned bytes blob (not a real PNG).
+- **`MockEyeTracker`** — a daemon thread emits 13-column synthetic gaze
+  samples at `sample_rate` Hz (centred gaze, fixed pupil size). On
+  `stop()` it writes a small placeholder `.edf` at the requested path
+  so file-cataloguing downstream doesn't choke on a missing file.
+  `calibrate()` is a no-op.
+
+## What stays real
+
+Mocks bypass **only** hardware. Everything else runs as in production:
+
+- LSL outlets are real (samples are pushed onto the LSL network).
+- The Postgres database is real (mocks call `post_message`,
+  `log_sensor_file`, etc.).
+- The GUI, PsychoPy window, task code, file registration, XDF split,
+  and `DeviceManager` lifecycle are unchanged.
+
+This is intentional: a mocked session exercises the same control plane
+and data plumbing as a real one, so most production bugs reproduce on
+the mock path.
+
+## Common scenarios
+
+### Single-laptop demo or smoke test
+
+Goal: run a full session GUI-to-XDF without hardware, on the laptop env
+config.
+
+```bash
+set NB_MOCK_DEVICES=all   # PowerShell: $env:NB_MOCK_DEVICES = "all"
+python -m neurobooth_os.gui
+```
+
+Confirm:
+
+1. The startup banner names the active mocks.
+2. Each device's `bring_up` succeeds (logs show
+   `Device Manager Substituting MockXxx for Xxx`).
+3. A short task runs end-to-end; `log_sensor_file` rows appear with the
+   expected `device_id` / `sensor_id` and stub file paths.
+4. XDF split succeeds.
+
+### Hardware-less unit tests
+
+Each mock has a sibling test module under `tests/pytest/`:
+
+- `test_mock_substitution.py` — registry, env-var parsing, lazy imports.
+- `test_mock_mbient.py` — bring-up / start / stop / close round-trip.
+- `test_mock_iphone.py` — handshake, recording state cycle, frame preview.
+- `test_mock_eyetracker.py` — connect, synthetic samples, stub EDF write.
+
+These tests run on a hardware-less laptop without `mbientlab`, `pylink`,
+`pyrealsense2`, or `PySpin` installed:
+
+```bash
+python -m pytest tests/pytest/test_mock_*.py
+```
+
+The test files are also a useful reference if you're writing a new test
+that needs a device — they show the standard pattern for building a
+`MockXxxDeviceArgs` via `model_construct` and silencing `post_message`
+so the test doesn't hit the database.
+
+### CI / containerised environments
+
+The Phase 0 import refactor means `mbient.py` and `eyelink_tracker.py`
+import cleanly without their hardware SDKs installed (the SDKs are
+wrapped in `try / except ImportError`). So a CI image with just `pylsl`
+and `psychopy` installed can run the full mock suite.
+
+If your CI environment does not have a configured PsychoPy monitor
+center (`monitors.getAllMonitors()` returns an empty list), the
+`MockEyeTracker` test fixture passes a `MagicMock` window and the mock
+overrides `_resolve_monitor_size` to return canned 1920x1080, so the
+tests don't need one.
+
+## Verifying mocks are active
+
+There are several signals depending on what you're checking:
+
+- **GUI** — the red modal at startup lists active targets. No modal
+  means no mocks.
+- **Logs** — search for `MOCK DEVICES ACTIVE` (CRITICAL) at GUI
+  startup, and `Substituting Mock` (INFO) per device in
+  `DeviceManager.create_streams`.
+- **From Python** — `from neurobooth_os.iout.mock_substitution import
+  active_mock_targets; active_mock_targets()` returns the resolved set.
+- **Tests** — `MOCK_REGISTRY` (in the same module) lists every
+  registered real → mock pairing.
+
+## Pitfalls
+
+- **Targets are class names, not device IDs.** `NB_MOCK_DEVICES=Mbient`
+  mocks every Mbient. `NB_MOCK_DEVICES=Mbient_dev_1` mocks **nothing** —
+  there's no class by that name. The env-var-driven path was designed
+  this way so a single laptop env config doesn't need a per-device
+  YAML override.
+- **Empty / unrecognised env var values are silently ignored.**
+  `NB_MOCK_DEVICES=` and `NB_MOCK_DEVICES=Foo` both produce zero mocks.
+  If you expected a mock and don't see the banner, check the value.
+- **`mock_devices` config field is overridden by the env var.** Setting
+  `mock_devices: []` in the YAML does not override
+  `NB_MOCK_DEVICES=all`. Unset the env var (or `unset NB_MOCK_DEVICES`
+  on Unix / `Remove-Item Env:NB_MOCK_DEVICES` on PowerShell) to fall
+  back to the config field.
+- **Mocks don't simulate hardware failures.** A `MockMbient` doesn't
+  drop its connection; `MockIPhone.attempt_reconnect` is a no-op. If
+  you're testing recovery code, you'll need to inject the failure
+  yourself rather than relying on synthetic flakiness.
+- **The mock `.edf` is not a valid EDF file.** Downstream code that
+  catalogues sensor files works (the path exists, length is non-zero)
+  but anything that opens and parses the EDF will fail. If you need a
+  parseable EDF for a downstream test, supply your own fixture.
+
+## Adding a mock for a new device
+
+See [arch/adding_a_device.md → Running with mocks → Adding a mock for
+a new device](arch/adding_a_device.md#adding-a-mock-for-a-new-device).
+The short version: subclass the real `DeviceArgs`, subclass the real
+`Device`, and call `register_mock(real_cls, mock_cls)` at the bottom
+of `stim_param_reader.py`.
+
+## See also
+
+- [arch/adding_a_device.md](arch/adding_a_device.md) — full developer
+  guide; the "Running with mocks" section is the architectural
+  reference.
+- [single_machine_testing.md](single_machine_testing.md) — how to run
+  the multi-process server stack on one laptop. Predates the mock work
+  and references a `test_no_eyelink` collection that's no longer the
+  only mock-friendly option — any task collection now runs on a fully
+  mocked single-laptop setup.
+- `neurobooth_os/iout/mock_substitution.py` — the substitution
+  registry and env/config plumbing.
+- `neurobooth_os/iout/mock/` — the three mock implementations.

--- a/neurobooth_os/config.py
+++ b/neurobooth_os/config.py
@@ -104,6 +104,13 @@ class NeuroboothConfig(BaseModel):
     machines: Dict[str, MachineSpec]
     database: DatabaseSpec
     screen: ScreenSpec
+    # Persistent mock-device opt-in. Comma-separated device-class names
+    # (e.g. ["Mbient", "IPhone"]) or the special value ["all"]. Overridden
+    # by the NB_MOCK_DEVICES environment variable when set. Devices listed
+    # here are substituted with their registered mock counterpart at
+    # DeviceManager startup. See docs/arch/adding_a_device.md → "Running
+    # with mocks".
+    mock_devices: Optional[List[str]] = None
 
     _acquisition_specs: List[ServiceSpec] = PrivateAttr(default_factory=list)
     _presentation_spec: Optional[ServiceSpec] = PrivateAttr(default=None)

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -659,6 +659,24 @@ def gui(logger):
     logger.info(f"Neurobooth application version = {state.release_version}")
     logger.info(f"Neurobooth config version = {state.config_version}")
 
+    # Defensive: surface mock-device substitution clearly so a forgotten
+    # NB_MOCK_DEVICES env var or stray mock_devices config field cannot
+    # silently corrupt a real recording. Logged at CRITICAL so it shows in
+    # session logs; a popup is shown so the operator sees it before any
+    # session starts.
+    from neurobooth_os.iout.mock_substitution import active_mock_targets
+    _mock_targets = active_mock_targets()
+    if _mock_targets:
+        _banner = ("MOCK DEVICES ACTIVE — this session will NOT record real "
+                   f"hardware data. Active targets: {sorted(_mock_targets)}")
+        logger.critical(_banner)
+        try:
+            sg.popup_ok(_banner, title="Mock devices active",
+                        background_color="#ffe6e6", text_color="#660000")
+        except Exception:
+            # Popup is best-effort; the log line is the source of truth.
+            pass
+
     nodes = get_nodes()
 
     system_resource_logger = SystemResourceLogger(machine_name='CTR')

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -5,7 +5,27 @@ from typing import Any, List, Mapping, Optional, Tuple
 
 import numpy as np
 
-import pylink
+# Hardware import — guarded so this module is importable on a hardware-less
+# laptop. Real EyeTracker code paths still require pylink and will fail
+# loudly when called without it.
+try:
+    import pylink
+    _HAS_PYLINK = True
+except ImportError:
+    pylink = None  # type: ignore[assignment]
+    _HAS_PYLINK = False
+
+
+def _require_pylink() -> None:
+    """Raise a clear error if real-EyeLink code is reached without pylink."""
+    if not _HAS_PYLINK:
+        raise RuntimeError(
+            "EyeLink hardware code path invoked but pylink is not installed. "
+            "Install the EyeLink SDK (pylink) to use a real EyeLink, or use "
+            "MockEyeTracker via NB_MOCK_DEVICES=EyeTracker for hardware-less testing."
+        )
+
+
 from psychopy import visual, monitors
 from pylsl import StreamInfo, StreamOutlet, local_clock
 
@@ -13,9 +33,6 @@ from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.metadator import post_message
 from neurobooth_os.iout.stim_param_reader import EyelinkDeviceArgs
 from neurobooth_os.msg.messages import NoEyetracker, Request, DeviceInitialization
-from neurobooth_os.tasks.smooth_pursuit.EyeLinkCoreGraphicsPsychoPy import (
-    EyeLinkCoreGraphicsPsychoPy,
-)
 from neurobooth_os.iout.stream_utils import DataVersion, set_stream_description
 from neurobooth_os.log_manager import APP_LOG_NAME
 
@@ -112,6 +129,7 @@ class EyeTracker(Device):
             self.state = DeviceState.CONNECTED
 
     def _connect_tracker(self):
+        _require_pylink()
         try:
             self.tk = pylink.EyeLink(self.IP)
         except RuntimeError:
@@ -176,6 +194,14 @@ class EyeTracker(Device):
         post_message(msg)
 
     def calibrate(self):
+        # Imported here rather than at module top so eyelink_tracker.py loads
+        # cleanly on a hardware-less laptop. EyeLinkCoreGraphicsPsychoPy chains
+        # through to pylink at import time; calibrate() is only ever called
+        # against a real (or appropriately mocked) hardware path.
+        _require_pylink()
+        from neurobooth_os.tasks.smooth_pursuit.EyeLinkCoreGraphicsPsychoPy import (
+            EyeLinkCoreGraphicsPsychoPy,
+        )
         self.logger.debug('EyeLink: Performing Calibration')
         calib_prompt = "You will see dots on the screen, please gaze at them"
         calib_msg = visual.TextStim(
@@ -205,6 +231,7 @@ class EyeTracker(Device):
         Returns:
             List containing the created EDF file basename.
         """
+        _require_pylink()
         if filename is None:
             filename = "TEST.edf"
         self.filename = filename

--- a/neurobooth_os/iout/eyelink_tracker.py
+++ b/neurobooth_os/iout/eyelink_tracker.py
@@ -86,8 +86,7 @@ class EyeTracker(Device):
                 "EyeTracker.connect() requires a PsychoPy window. "
                 "Pass win= to __init__ or supply psychopy_window in bring_up context."
             )
-        mon = monitors.getAllMonitors()[0]
-        self.monitor_width, self.monitor_height = monitors.Monitor(mon).getSizePix()
+        self.monitor_width, self.monitor_height = self._resolve_monitor_size()
 
         self.stream_info = set_stream_description(
             stream_info=StreamInfo(
@@ -127,6 +126,16 @@ class EyeTracker(Device):
         self._connect_tracker()
         if self.tk is not None:
             self.state = DeviceState.CONNECTED
+
+    def _resolve_monitor_size(self) -> Tuple[int, int]:
+        """Look up the active monitor's pixel dimensions.
+
+        Subclass hook: ``MockEyeTracker`` overrides to return canned
+        values so headless unit tests don't need a configured PsychoPy
+        monitor center.
+        """
+        mon = monitors.getAllMonitors()[0]
+        return monitors.Monitor(mon).getSizePix()
 
     def _connect_tracker(self):
         _require_pylink()
@@ -231,23 +240,31 @@ class EyeTracker(Device):
         Returns:
             List containing the created EDF file basename.
         """
-        _require_pylink()
         if filename is None:
             filename = "TEST.edf"
         self.filename = filename
-
         self.fname_temp = "name8chr.edf"
-        self.tk.openDataFile(self.fname_temp)
+
         self.streaming = True
         self.state = DeviceState.STARTED
 
-        pylink.beginRealTimeMode(100)
-        self.tk.startRecording(1, 1, 1, 1)
+        self._begin_native_recording()
         self.recording = True
         self.stream_thread = threading.Thread(target=self.record)
         self.logger.debug('EyeLink: Starting Record Thread')
         self.stream_thread.start()
         return [op.split(filename)[-1]]
+
+    def _begin_native_recording(self) -> None:
+        """Open the EDF file and start the EyeLink in real-time recording mode.
+
+        Subclass hook: ``MockEyeTracker`` overrides to skip the native
+        ``pylink.beginRealTimeMode`` / ``startRecording`` calls.
+        """
+        _require_pylink()
+        self.tk.openDataFile(self.fname_temp)
+        pylink.beginRealTimeMode(100)
+        self.tk.startRecording(1, 1, 1, 1)
 
     def record(self):
         self.paused = False
@@ -320,9 +337,18 @@ class EyeTracker(Device):
         self.recording = False
         if self.streaming:
             self.stream_thread.join()
-            self.tk.receiveDataFile(self.fname_temp, self.filename)
+            self._receive_data_file()
             self.streaming = False
         self.state = DeviceState.STOPPED
+
+    def _receive_data_file(self) -> None:
+        """Copy the EDF file from the tracker to ``self.filename``.
+
+        Subclass hook: ``MockEyeTracker`` overrides to write a stub
+        ``.edf`` file at the expected path so downstream code that
+        catalogues sensor files doesn't choke on a missing path.
+        """
+        self.tk.receiveDataFile(self.fname_temp, self.filename)
 
     def close(self) -> None:
         if self.tk is None:

--- a/neurobooth_os/iout/iphone.py
+++ b/neurobooth_os/iout/iphone.py
@@ -193,16 +193,21 @@ class IPhone(Device):
     MESSAGE_TYPES = set(MESSAGE_TYPES)
     MESSAGE_KEYS = {"MessageType", "SessionID", "TimeStamp", "Message"}
 
-    def __init__(self, name="IPhoneFrameIndex", sess_id="", mock=False, device_args: IPhoneDeviceArgs = None, enable_timeout_exceptions=False):
+    def __init__(self, name="IPhoneFrameIndex", sess_id="", device_args: IPhoneDeviceArgs = None, enable_timeout_exceptions=False):
         super().__init__(device_args)
         self.connected = False
         self.tag = 0
         self.iphone_sessionID = sess_id
         self.name = name
-        self.mock = mock
         self.device_args = device_args
         self.enable_timeout_exceptions = enable_timeout_exceptions
         self.streamName = "IPhoneFrameIndex"
+
+        # Wire-level transport. The real path installs a socket from
+        # ``USBMux.connect`` in ``_handshake``; ``MockIPhone`` swaps in an
+        # in-process queue.  Anything socket-shaped (``send`` / ``recv`` /
+        # ``settimeout`` / ``close``) is acceptable here.
+        self.transport: Optional[Any] = None
 
         # --------------------------------------------------------------------------------
         # Lock-based threading objects and their associated protected data
@@ -351,7 +356,7 @@ class IPhone(Device):
         )
 
         try:
-            self.sock.send(packet)
+            self.transport.send(packet)
         except Exception as e:
             self.logger.error(f'iPhone: PANIC: {e}')
             raise IPhonePanic(f'Error occurred sending signal through the socket') from e
@@ -433,9 +438,9 @@ class IPhone(Device):
         :returns: (payload, version, type, tag): Payload is either a message dictionary (tag == 0) or byte string
             (tag == 1 or tag == 2).
         """
-        self.sock.settimeout(timeout_sec)
+        self.transport.settimeout(timeout_sec)
         try:
-            first_frame = self.sock.recv(16)
+            first_frame = self.transport.recv(16)
         except socket.timeout:
             raise IPhoneTimeout(f"Timeout for packet receive exceeded ({timeout_sec} sec)")
         except OSError as e:
@@ -451,10 +456,10 @@ class IPhone(Device):
                 MessageTag.DUMP_FILE_CHUNK,
                 MessageTag.DUMP_LAST_FILE_CHUNK
         ):
-            payload = IPhone.recvall(self.sock, payload_size)
+            payload = IPhone.recvall(self.transport, payload_size)
             return payload, version, type_, tag
         elif tag == MessageTag.NORMAL_MESSAGE:
-            payload = self.sock.recv(payload_size)
+            payload = self.transport.recv(payload_size)
             msg = IPhone._json_unwrap(payload)
             self._validate_message(msg)
             return msg, version, type_, tag
@@ -536,21 +541,14 @@ class IPhone(Device):
         """
         return self.prepare()
 
-    def prepare(self, mock: bool = False, config: Optional[CONFIG] = None) -> bool:
+    def prepare(self, config: Optional[CONFIG] = None) -> bool:
         """
         Called during a PREPARE message to the server (i.e., "Connect Devices").
         Connects to the iPhone and opens an LSL outlet.
 
-        :param mock: Whether to use a mock iPhone
         :param config: iPhone configuation options
         :returns: Whether the connection was successful
         """
-        if mock:
-            success = self._mock_handshake() and self.connected
-            if success:
-                self.state = DeviceState.CONNECTED
-            return success
-
         if config is None:
             config = {
                 "NOTIFYONFRAME": self.device_args.notifyonframe(),
@@ -593,7 +591,7 @@ class IPhone(Device):
 
         self.device = self.usbmux.devices[0]
         try:
-            self.sock = self.usbmux.connect(self.device, IPHONE_PORT)
+            self.transport = self.usbmux.connect(self.device, IPHONE_PORT)
             self._update_state('@HANDSHAKE')
         except Exception as e:
             self.logger.error(f'iPhone [state={self._state}]: Unable to connect; error={e}')
@@ -602,7 +600,6 @@ class IPhone(Device):
         # As soon as we're connected, start the parallel listening thread.
         self._listen_thread = IPhoneListeningThread(self)
         self._listen_thread.start()
-        # self.sock.setblocking(0)
         self.connected = True
 
         # Send the configuration to the iPhone and wait for a response
@@ -616,31 +613,6 @@ class IPhone(Device):
             return True
         except IPhonePanic as e:
             self.panic(e)
-            return False
-
-    def _mock_handshake(self) -> bool:
-        try:
-            HOST = "127.0.0.1"  # Symbolic name meaning the local host
-            PORT = 50009  # Arbitrary non-privileged port
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.connect((HOST, PORT))
-            self.connected = True
-
-            self._update_state('@HANDSHAKE')
-            self._update_state('@STANDBY')
-            self._update_state('@READY')
-            return True
-        except IPhonePanic as e:
-            if self.sock is not None:
-                self.sock.close()
-                self.sock = None
-            self.panic(e)
-            return False
-        except Exception as e:
-            if self.sock is not None:
-                self.sock.close()
-                self.sock = None
-            self.logger.error(f'iPhone [state={self._state}]: Unable to connect; error={e}')
             return False
 
     def _create_outlet(self) -> StreamOutlet:
@@ -865,7 +837,9 @@ class IPhone(Device):
 
         # Try to stop the listener thread
         self._listen_thread.stop()
-        self.sock.close()  # Closing the socket will force an error that will break the thread out of its wait
+        # Closing the transport will force an error that will break the
+        # listener thread out of its blocking ``recv``.
+        self.transport.close()
         if join_listener:
             self._listen_thread.join(timeout=3)
             if self._listen_thread.is_alive():

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -11,6 +11,9 @@ import neurobooth_os.iout.metadator as meta
 from neurobooth_os.iout.device import (
     Device, DeviceCapability, CameraPreviewException,
 )
+from neurobooth_os.iout.mock_substitution import (
+    active_mock_targets, apply_mock_substitution,
+)
 from neurobooth_os.msg.messages import DeviceInitialization, Request
 
 
@@ -117,6 +120,27 @@ class DeviceManager:
         # __init__ derives state from sensor_array would crash here (the
         # registry path does not populate it), so the opt-in is strict.
         task_device_args = DeviceManager._get_unique_devices(task_params)
+
+        # Mock-device substitution. NB_MOCK_DEVICES env var or the
+        # NeuroboothConfig.mock_devices field can swap real DeviceArgs for
+        # mock counterparts before device_class() is resolved. See
+        # neurobooth_os/iout/mock_substitution.py.
+        active_mocks = active_mock_targets()
+        if active_mocks:
+            self.logger.info(
+                f'Device Manager: mock targets active = {sorted(active_mocks)}'
+            )
+            substituted = {}
+            for dev_id, dev_args in task_device_args.items():
+                new_args = apply_mock_substitution(dev_args, active_mocks)
+                if new_args is not dev_args:
+                    self.logger.info(
+                        f'Device Manager: mocking {dev_id} '
+                        f'({type(dev_args).__name__} -> {type(new_args).__name__})'
+                    )
+                substituted[dev_id] = new_args
+            task_device_args = substituted
+
         session_device_args: Dict[str, DeviceArgs] = {}
         missing = [d for d in self.assigned_devices if d not in task_device_args]
         if missing:
@@ -128,6 +152,14 @@ class DeviceManager:
                     )
                     continue
                 dev_args = registry[device_id]
+                if active_mocks:
+                    new_args = apply_mock_substitution(dev_args, active_mocks)
+                    if new_args is not dev_args:
+                        self.logger.info(
+                            f'Device Manager: mocking {device_id} '
+                            f'({type(dev_args).__name__} -> {type(new_args).__name__})'
+                        )
+                        dev_args = new_args
                 try:
                     dev_class = type(dev_args).device_class()
                 except NotImplementedError:

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -789,15 +789,7 @@ class Mbient(Device):
         :returns: Whether the connection and setup was successful.
         """
         try:
-            self.prepare_scan()  # Wake up devices
-            self._ble_connect()
-            self.logger.debug(self.format_message(f'Device Model: {self.device_wrapper.model_name}'))
-            self.logger.debug(self.format_message(f'Wrapper Class: {self.device_wrapper.__class__.__name__}'))
-
-            # Perform a sensor reset and reconnect
-            self.reset()
-            sleep(self.retry_delay_sec)  # Wait a moment before trying to re-connect after the reset
-            self._ble_connect()
+            self._acquire_hardware()
 
             # Set up the device to stream acceleration and angular velocity
             if not DISABLE_LSL:
@@ -828,6 +820,24 @@ class Mbient(Device):
     def prepare(self) -> bool:
         """Backward-compatible alias for :meth:`connect`."""
         return self.connect()
+
+    def _acquire_hardware(self) -> None:
+        """BLE scan, connect, board reset, and reconnect.
+
+        Subclass hook: ``MockMbient`` overrides this to skip BLE and the
+        native reset cycle. Anything that touches the mbientlab SDK belongs
+        here, not in ``connect()``.
+        """
+        _require_mbientlab()
+        self.prepare_scan()  # Wake up devices
+        self._ble_connect()
+        self.logger.debug(self.format_message(f'Device Model: {self.device_wrapper.model_name}'))
+        self.logger.debug(self.format_message(f'Wrapper Class: {self.device_wrapper.__class__.__name__}'))
+
+        # Perform a sensor reset and reconnect
+        self.reset()
+        sleep(self.retry_delay_sec)  # Wait a moment before trying to re-connect after the reset
+        self._ble_connect()
 
     def _create_outlet(self) -> StreamOutlet:
         """Create an LSL outlet; helper for prepare."""
@@ -868,6 +878,23 @@ class Mbient(Device):
 
     def setup(self) -> None:
         """Configure the device (i.e., connection settings, sensor settings, data streaming callback)"""
+        self._attach_data_source()
+
+        txt = f"Mbient {self.dev_name} is connected"  # Send message to GUI terminal
+        self.send_status_msg(txt, "INFO")
+        self.logger.debug(self.format_message('Setup Completed'))
+
+    def _attach_data_source(self) -> None:
+        """Wire up the data source feeding ``_lsl_data_handler``.
+
+        Real path: configure connection/sensor settings, create the
+        accel+gyro fuser, and subscribe the C-level callback that calls
+        ``_callback`` (which dispatches to ``data_handlers``).
+
+        Subclass hook: ``MockMbient`` overrides this to spawn a synthetic
+        data thread that pushes samples directly through the data
+        handlers, with no native MetaWear/cbindings interaction.
+        """
         _require_mbientlab()
         self.device_wrapper.setup_connection_settings(self.connection_params)
         sensor_signals = self.device_wrapper.setup_sensor_settings(self.accel_params, self.gyro_params)
@@ -885,10 +912,6 @@ class Mbient(Device):
             self.data_handlers = [self._lsl_data_handler, *self.data_handlers]  # Make sure LSL is called first!
         libmetawear.mbl_mw_datasignal_subscribe(processor, None, self.callback)
         self.subscribed_signals.append(processor)
-
-        txt = f"Mbient {self.dev_name} is connected"  # Send message to GUI terminal
-        self.send_status_msg(txt, "INFO")
-        self.logger.debug(self.format_message('Setup Completed'))
 
     def log_battery_info(self) -> None:
         """

--- a/neurobooth_os/iout/mbient.py
+++ b/neurobooth_os/iout/mbient.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import argparse
 import threading
@@ -9,8 +11,36 @@ from typing import Any, Dict, List, Callable, Mapping, NamedTuple, Optional
 from abc import ABC, abstractmethod
 from enum import IntEnum
 
-from mbientlab.warble import BleScanner
-from mbientlab.metawear import MetaWear, libmetawear, parse_value, cbindings, Module, Model
+# Hardware imports — guarded so this module is importable on a hardware-less
+# laptop (the mock subclass loads the parent without needing mbientlab).
+# Real device code paths still require these and will fail loudly when called
+# without the SDK installed.
+try:
+    from mbientlab.warble import BleScanner
+    from mbientlab.metawear import (
+        MetaWear, libmetawear, parse_value, cbindings, Module, Model,
+    )
+    _HAS_MBIENTLAB = True
+except ImportError:
+    BleScanner = None  # type: ignore[assignment]
+    MetaWear = None  # type: ignore[assignment]
+    libmetawear = None  # type: ignore[assignment]
+    parse_value = None  # type: ignore[assignment]
+    cbindings = None  # type: ignore[assignment]
+    Module = None  # type: ignore[assignment]
+    Model = None  # type: ignore[assignment]
+    _HAS_MBIENTLAB = False
+
+
+def _require_mbientlab() -> None:
+    """Raise a clear error if real-Mbient code is reached without the SDK."""
+    if not _HAS_MBIENTLAB:
+        raise RuntimeError(
+            "Mbient hardware code path invoked but the mbientlab SDK is not "
+            "installed. Install mbientlab to use real Mbient devices, or use "
+            "MockMbient via NB_MOCK_DEVICES=Mbient for hardware-less testing."
+        )
+
 
 from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.metadator import post_message, get_database_connection
@@ -207,14 +237,19 @@ class MetaWearWrapper(ABC):
     """
     A wrapper around a MetaWear object that provices an additional layer of abstraction.
     """
-    SUPPORTED_DEVICE_MODELS = [  # Should be the models with both accelerometer and gyroscope
-        Model.METAMOTION_S,
-        Model.METAMOTION_R,
-        Model.METAMOTION_RL,
-        Model.METAMOTION_C,
-        Model.METAWEAR_RG,
-        Model.METAWEAR_RPRO
-    ]
+
+    @classmethod
+    def supported_device_models(cls):
+        """Return the list of supported device-model constants (lazy: requires mbientlab)."""
+        _require_mbientlab()
+        return [
+            Model.METAMOTION_S,
+            Model.METAMOTION_R,
+            Model.METAMOTION_RL,
+            Model.METAMOTION_C,
+            Model.METAWEAR_RG,
+            Model.METAWEAR_RPRO,
+        ]
 
     @staticmethod
     def create_wrapper(device: MetaWear) -> 'MetaWearWrapper':
@@ -224,9 +259,10 @@ class MetaWearWrapper(ABC):
         :param device: The MetaWear object to wrap.
         :returns: An appropriate wrapper selected based on the board's configuration.
         """
+        _require_mbientlab()
         board = device.board
         model = libmetawear.mbl_mw_metawearboard_get_model(board)
-        if model not in MetaWearWrapper.SUPPORTED_DEVICE_MODELS:
+        if model not in MetaWearWrapper.supported_device_models():
             model_name = libmetawear.mbl_mw_metawearboard_get_model_name(board).decode()
             raise UnsupportedDevice(f'Unsupported Device Model: {model_name}')
 
@@ -509,8 +545,12 @@ class Mbient(Device):
         self.data_handlers: List['Mbient.DATA_HANDLER'] = []
         self._auto_reconnect_failures: int = 0
 
-        # Streaming-related variables
-        self.callback = cbindings.FnVoid_VoidP_DataP(self._callback)
+        # Streaming-related variables. The C-level callback binding is created
+        # lazily in setup() (where it's actually subscribed) so that
+        # constructing an Mbient instance does not require the mbientlab SDK
+        # to be installed — the mock subclass can call super().__init__
+        # without triggering the cbindings dereference.
+        self.callback = None
         self.n_samples_streamed = 0
 
         self.logger.debug(self.format_message(f'acc={self.accel_params}; gyro={self.gyro_params}'))
@@ -828,6 +868,7 @@ class Mbient(Device):
 
     def setup(self) -> None:
         """Configure the device (i.e., connection settings, sensor settings, data streaming callback)"""
+        _require_mbientlab()
         self.device_wrapper.setup_connection_settings(self.connection_params)
         sensor_signals = self.device_wrapper.setup_sensor_settings(self.accel_params, self.gyro_params)
 
@@ -835,6 +876,8 @@ class Mbient(Device):
         # (As opposed to an anonymous lambda or function-scoped variable.)
         # If not, then the program will silently fail when the callback gets triggered.
         # Speculation: Python can garbage collect variables that the C bindings expect to exist => memory access error.
+        if self.callback is None:
+            self.callback = cbindings.FnVoid_VoidP_DataP(self._callback)
         processor = MetaWearWrapper.create_data_fusion_processor(sensor_signals)
         if DISABLE_LSL:
             self.logger.warning('LSL Disabled!')

--- a/neurobooth_os/iout/mock/__init__.py
+++ b/neurobooth_os/iout/mock/__init__.py
@@ -1,0 +1,13 @@
+"""Hardware mocks for laptop/CI testing without real devices.
+
+Each mock module imports its corresponding real device module's top half
+(class definitions only — hardware imports are guarded in the real
+modules), subclasses the real ``Device``, and overrides hardware-touching
+hooks. The matching mock ``DeviceArgs`` subclass lives in
+``stim_param_reader.py`` and registers via
+:func:`neurobooth_os.iout.mock_substitution.register_mock` at import time.
+
+The package is intentionally separate from ``iout/mock_device.py``, which
+contains base-class testing scaffolding (``MockStreamDevice`` /
+``MockRecordingDevice``) for ``Device`` itself, not hardware mocks.
+"""

--- a/neurobooth_os/iout/mock/mock_eyetracker.py
+++ b/neurobooth_os/iout/mock/mock_eyetracker.py
@@ -1,0 +1,148 @@
+"""Synthetic EyeLink that emits LSL gaze samples without pylink.
+
+Overrides the four hardware hooks on :class:`EyeTracker`:
+
+- ``_resolve_monitor_size`` — returns canned 1920x1080 instead of
+  reading PsychoPy's monitor center, which may not be configured on
+  laptops/CI.
+- ``_connect_tracker`` — skips ``pylink.EyeLink`` and instead installs
+  a stub ``tk`` object so inherited code that touches ``self.tk`` (e.g.
+  ``close``) works.  Still posts ``DeviceInitialization``.
+- ``_begin_native_recording`` — no-op (no EDF, no ``startRecording``).
+- ``record`` — synthetic 13-column gaze samples at ``self.sample_rate``
+  Hz on a daemon thread.
+- ``_receive_data_file`` — writes a tiny stub ``.edf`` so file-cataloguing
+  downstream of ``stop()`` doesn't choke on a missing path.
+- ``calibrate`` — no-op (the real path uses ``EyeLinkCoreGraphicsPsychoPy``
+  which transitively imports pylink).
+
+The mock assumes a real ``psychopy.visual.Window`` for live laptop
+sessions, but tolerates a duck-typed window in unit tests because none
+of the overridden methods draw to it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, List, Optional, Tuple
+
+from pylsl import local_clock
+
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.eyelink_tracker import EyeTracker
+from neurobooth_os.iout.metadator import post_message
+from neurobooth_os.msg.messages import DeviceInitialization, Request
+
+
+# Minimal stub bytes for the mock EDF file. Real EDF is a binary EyeLink
+# format; downstream consumers (XDF split / log_sensor_file) only need
+# the file to exist at the expected path with non-zero length.
+_STUB_EDF_BYTES = b"MOCK_EDF_FILE_PLACEHOLDER\n"
+
+
+class _MockEyelinkHandle:
+    """Stub satisfying the ``self.tk`` attribute on inherited paths.
+
+    ``EyeTracker.close()`` calls ``self.tk.close()``; the mock has no
+    native handle, so a no-op is enough.
+    """
+
+    def close(self) -> None:
+        return None
+
+
+class MockEyeTracker(EyeTracker):
+    """Synthetic EyeLink tracker — no pylink, no EyeLink hardware."""
+
+    # Canned monitor size returned by ``_resolve_monitor_size``.  Kept on
+    # the class so tests can override it without touching method bodies.
+    MOCK_MONITOR_WIDTH = 1920
+    MOCK_MONITOR_HEIGHT = 1080
+
+    def _resolve_monitor_size(self) -> Tuple[int, int]:
+        return self.MOCK_MONITOR_WIDTH, self.MOCK_MONITOR_HEIGHT
+
+    def _connect_tracker(self) -> None:
+        # Skip pylink.EyeLink; install a stub handle so inherited
+        # ``close()`` works without an existence check.
+        self.tk = _MockEyelinkHandle()
+        body = DeviceInitialization(
+            stream_name=self.streamName,
+            outlet_id=self.outlet_id,
+            device_id=self.device_id,
+        )
+        msg = Request(source="EyeTracker", destination="CTR", body=body)
+        post_message(msg)
+        self.logger.info("MockEyeTracker: tracker connection skipped (no pylink)")
+
+    def _begin_native_recording(self) -> None:
+        # Real path opens an EDF file on the tracker and arms
+        # real-time mode; mock has none of that infrastructure.
+        self.logger.info("MockEyeTracker: native recording skipped")
+
+    def record(self) -> None:
+        """Emit synthetic 13-column gaze samples until ``self.recording`` clears.
+
+        Column layout matches the real ``record()`` method (see
+        ``EyeTracker.connect``):
+        R/L gaze (x,y,pupil), target (x,y,distance), resolution (x,y),
+        time_edf, time_local.
+        """
+        period = 1.0 / float(self.sample_rate)
+        # Constants for canned samples; the values aren't realistic but
+        # downstream code only needs the LSL stream shape and cadence.
+        gaze_x = float(self.MOCK_MONITOR_WIDTH) / 2.0
+        gaze_y = float(self.MOCK_MONITOR_HEIGHT) / 2.0
+        pupil = 1000.0
+
+        self.timestamps_et: List[float] = []
+        self.timestamps_local: List[float] = []
+        self.paused = False
+        self.logger.debug("MockEyeTracker: entering synthetic record loop")
+        try:
+            while self.recording:
+                if self.paused:
+                    time.sleep(period)
+                    continue
+                t_local = local_clock()
+                t_edf = t_local * 1000.0  # match real EyeLink ms timestamp
+                sample = [
+                    gaze_x, gaze_y, pupil,         # right eye
+                    gaze_x, gaze_y, pupil,         # left eye
+                    0.0, 0.0, 0.0,                 # target x, y, distance
+                    1.0, 1.0,                      # ppd x, y
+                    t_edf, t_local,
+                ]
+                self.outlet.push_sample(sample)
+                self.timestamps_et.append(t_edf)
+                self.timestamps_local.append(t_local)
+                time.sleep(period)
+        except Exception:
+            self.logger.exception("MockEyeTracker: synthetic record loop error")
+        finally:
+            self.logger.debug("MockEyeTracker: exiting synthetic record loop")
+
+    def _receive_data_file(self) -> None:
+        """Write a stub EDF at ``self.filename`` so file paths land on disk."""
+        try:
+            with open(self.filename, "wb") as fh:
+                fh.write(_STUB_EDF_BYTES)
+            self.logger.info(
+                f"MockEyeTracker: wrote stub EDF at {self.filename}")
+        except OSError as e:
+            # Best-effort; tests that care can supply a writable path.
+            self.logger.warning(
+                f"MockEyeTracker: could not write stub EDF at "
+                f"{self.filename}: {e}")
+
+    def calibrate(self) -> None:
+        # Real path uses EyeLinkCoreGraphicsPsychoPy which transitively
+        # imports pylink. Mock skips the entire pylink dance.
+        self.logger.info("MockEyeTracker: calibration skipped")
+        self.calibrated = True
+
+    def close(self) -> None:
+        # Inherited close handles tk.close() (our stub is a no-op) and
+        # state transitions; nothing extra needed.
+        super().close()

--- a/neurobooth_os/iout/mock/mock_iphone.py
+++ b/neurobooth_os/iout/mock/mock_iphone.py
@@ -1,0 +1,275 @@
+"""In-process mock of the iPhone device.
+
+``MockIPhone`` overrides :meth:`IPhone._handshake` to install a
+queue-backed in-process transport (:class:`_MockIPhoneTransport`)
+instead of opening a real ``USBMux`` socket.  The state-machine
+bookkeeping in ``_send_packet`` / ``_get_packet`` /
+``_process_received_message`` runs unchanged; the transport simulates
+the iOS app by consuming outgoing packets and queueing the appropriate
+responses.
+
+When the controller sends ``@START``, the transport spawns a daemon
+thread that emits ``@INPROGRESSTIMESTAMP`` messages at the configured
+FPS until ``@STOP`` is sent.  ``frame_preview()`` returns canned bytes
+without touching the camera.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import struct
+import threading
+import time
+from typing import List, Optional
+
+from neurobooth_os.iout.iphone import (
+    CONFIG,
+    IPhone,
+    IPhoneListeningThread,
+    IPhonePanic,
+    MessageTag,
+)
+
+
+# Placeholder bytes returned by ``frame_preview()``.  Not a valid PNG —
+# the iPhone code just hands the bytes back to the caller, so opaque
+# bytes are sufficient for the lifecycle.  Tests assert non-emptiness.
+_CANNED_PREVIEW_BYTES = b"MOCK_IPHONE_FRAME_PREVIEW_PLACEHOLDER"
+
+
+class _MockIPhoneTransport:
+    """Socket-like in-process transport that simulates iPhone app responses.
+
+    Implements the subset of :class:`socket.socket` used by ``IPhone``:
+    ``send`` / ``recv`` / ``settimeout`` / ``close``.
+
+    Each outgoing packet is parsed; the message type drives a small
+    table of canned responses that get queued for the listener thread to
+    pick up.  A separate daemon thread injects
+    ``@INPROGRESSTIMESTAMP`` messages between ``@STARTTIMESTAMP`` and
+    ``@STOPTIMESTAMP`` to mirror the real recording-progress stream.
+    """
+
+    def __init__(self, fps: int = 30, logger: Optional[logging.Logger] = None) -> None:
+        self._inbound: List[bytes] = []
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._timeout: Optional[float] = None
+        self._closed = False
+        self._fps = max(int(fps), 1)
+        self._frame_counter = 0
+        self._stream_thread: Optional[threading.Thread] = None
+        self._stop_streaming = threading.Event()
+        self.logger = logger
+
+    # ------------------------------------------------------------------
+    # socket-like interface
+    # ------------------------------------------------------------------
+    def send(self, data: bytes) -> int:
+        if len(data) < 16:
+            return len(data)
+        _version, _type, tag, _payload_size = struct.unpack("!IIII", data[:16])
+        if tag == MessageTag.NORMAL_MESSAGE:
+            try:
+                msg = IPhone._json_unwrap(data[16:])
+                self._handle_outgoing(msg)
+            except Exception:
+                if self.logger is not None:
+                    self.logger.exception(
+                        "MockIPhoneTransport: failed to parse outgoing packet")
+        return len(data)
+
+    def recv(self, n: int) -> bytes:
+        with self._cond:
+            deadline = (
+                time.monotonic() + self._timeout
+                if self._timeout is not None
+                else None
+            )
+            while True:
+                if self._inbound:
+                    head = self._inbound[0]
+                    if len(head) >= n:
+                        chunk = head[:n]
+                        if len(head) == n:
+                            self._inbound.pop(0)
+                        else:
+                            self._inbound[0] = head[n:]
+                        return chunk
+                    # Defensive: real packets are injected whole, so
+                    # this branch should not fire via the IPhone path.
+                    self._inbound.pop(0)
+                    return head
+                if self._closed:
+                    return b""
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise socket.timeout("recv timeout")
+                    self._cond.wait(remaining)
+                else:
+                    self._cond.wait()
+
+    def settimeout(self, t: Optional[float]) -> None:
+        self._timeout = t
+
+    def close(self) -> None:
+        self._stop_streaming.set()
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+        if self._stream_thread is not None and self._stream_thread.is_alive():
+            self._stream_thread.join(timeout=1.0)
+        self._stream_thread = None
+
+    # ------------------------------------------------------------------
+    # phone-side simulator
+    # ------------------------------------------------------------------
+    def _handle_outgoing(self, msg: dict) -> None:
+        msg_type = msg.get("MessageType", "")
+        if msg_type == "@STANDBY":
+            self._inject_message("@READY")
+        elif msg_type == "@START":
+            # @STARTTIMESTAMP first, then begin the synthetic stream.
+            # Order matters: IPhone's state machine requires @STARTTIMESTAMP
+            # to land before any @INPROGRESSTIMESTAMP.
+            self._inject_message(
+                "@STARTTIMESTAMP", timestamp=self._frame_timestamp())
+            self._begin_streaming()
+        elif msg_type == "@STOP":
+            self._end_streaming()
+            self._inject_message(
+                "@STOPTIMESTAMP", timestamp=self._frame_timestamp())
+        elif msg_type == "@PREVIEW":
+            self._inject_preview()
+        elif msg_type == "@DUMPALL":
+            # No files on the mock; drive the empty-list / error path.
+            self._inject_message("@ERROR", message="No files on mock device")
+        # @DUMP / @DUMPSUCCESS / @DISCONNECT — no responses required.
+
+    def _inject_message(
+        self,
+        msg_type: str,
+        timestamp: str = "",
+        message: str = "",
+    ) -> None:
+        msg = {
+            "MessageType": msg_type,
+            "SessionID": "",
+            "TimeStamp": timestamp,
+            "Message": message,
+        }
+        payload = ("####" + json.dumps(msg)).encode("utf-8")
+        header = struct.pack(
+            "!IIII", IPhone.VERSION, IPhone.TYPE_MESSAGE, 0, len(payload))
+        with self._cond:
+            self._inbound.append(header + payload)
+            self._cond.notify_all()
+
+    def _inject_preview(self) -> None:
+        png = _CANNED_PREVIEW_BYTES
+        header = struct.pack(
+            "!IIII",
+            IPhone.VERSION,
+            IPhone.TYPE_MESSAGE,
+            int(MessageTag.FRAME_PREVIEW),
+            len(png),
+        )
+        with self._cond:
+            self._inbound.append(header + png)
+            self._cond.notify_all()
+
+    def _begin_streaming(self) -> None:
+        self._stop_streaming.clear()
+        self._stream_thread = threading.Thread(
+            target=self._stream_loop,
+            name="MockIPhone-stream",
+            daemon=True,
+        )
+        self._stream_thread.start()
+
+    def _end_streaming(self) -> None:
+        self._stop_streaming.set()
+        if self._stream_thread is not None:
+            self._stream_thread.join(timeout=1.0)
+            self._stream_thread = None
+
+    def _stream_loop(self) -> None:
+        period = 1.0 / float(self._fps)
+        while not self._stop_streaming.is_set():
+            self._frame_counter += 1
+            self._inject_message(
+                "@INPROGRESSTIMESTAMP",
+                timestamp=self._frame_timestamp(),
+            )
+            self._stop_streaming.wait(period)
+
+    def _frame_timestamp(self) -> str:
+        # IPhone._lsl_push_sample uses ``eval`` to parse this back into a
+        # dict, so it must be a valid Python literal repr.
+        return repr({
+            "FrameNumber": self._frame_counter,
+            "Timestamp": time.time(),
+        })
+
+
+class MockIPhone(IPhone):
+    """Mock iPhone that runs the full state machine without a real device."""
+
+    def _handshake(self, config: CONFIG) -> bool:
+        if self._state != "#DISCONNECTED":
+            self.logger.error(
+                f"iPhone [state={self._state}]: "
+                "Mock handshake invoked in inappropriate state.")
+            return False
+        try:
+            fps = int(config.get("FPS", 30))
+        except (TypeError, ValueError):
+            fps = 30
+
+        self.transport = _MockIPhoneTransport(fps=fps, logger=self.logger)
+        try:
+            self._update_state("@HANDSHAKE")
+        except IPhonePanic as e:
+            self.panic(e)
+            return False
+
+        self._listen_thread = IPhoneListeningThread(self)
+        self._listen_thread.start()
+        self.connected = True
+
+        msg_camera_config = {"Message": json.dumps(config)}
+        try:
+            self._send_and_wait_for_response(
+                "@STANDBY",
+                msg_contents=msg_camera_config,
+                wait_on=list(self.STATE_TRANSITIONS["#STANDBY"].keys()),
+            )
+            return True
+        except IPhonePanic as e:
+            self.panic(e)
+            return False
+
+    def disconnect(self, join_listener: bool = True) -> bool:
+        """Skip the 4-second handshake-cooldown the real iPhone needs."""
+        if self._state == "#DISCONNECTED":
+            self.logger.debug("MockIPhone: already disconnected")
+            return False
+        self.logger.debug(
+            f"MockIPhone [state={self._state}]: Disconnecting")
+        self._update_state("@DISCONNECT")
+        self._listen_thread.stop()
+        self.transport.close()
+        if join_listener:
+            self._listen_thread.join(timeout=2)
+            # Don't raise on a stuck listener — the mock's transport.close()
+            # is reliable enough that this should never happen, and a
+            # late teardown shouldn't fail tests.
+            if self._listen_thread.is_alive():
+                self.logger.warning(
+                    "MockIPhone: listener thread did not exit cleanly")
+        self.connected = False
+        self.streaming = False
+        return True

--- a/neurobooth_os/iout/mock/mock_mbient.py
+++ b/neurobooth_os/iout/mock/mock_mbient.py
@@ -1,0 +1,197 @@
+"""Synthetic Mbient that emits LSL samples without real hardware.
+
+Overrides the two hardware hooks on :class:`Mbient`
+(``_acquire_hardware`` and ``_attach_data_source``) plus the lifecycle
+methods that touch the native MetaWear/warble libraries
+(``start`` / ``stop`` / ``disconnect`` / ``close`` / ``reset`` /
+``attempt_reconnect`` / ``on_task_reconnect`` / ``reset_and_reconnect``).
+
+Synthetic samples are produced by a daemon thread that calls every
+registered data handler at the higher of the configured ``acc_hz`` /
+``gyro_hz`` rates.  The values are constants (1g down, zero rotation);
+downstream code only needs the LSL samples to flow at the right
+shape and rate, not to look like real motion.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, List, Optional
+
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mbient import BatteryState, Mbient
+
+
+class _MockSample:
+    """Minimal stand-in for the mbientlab acc/gyro vector.
+
+    Only ``.x`` / ``.y`` / ``.z`` are accessed by ``Mbient._lsl_data_handler``,
+    so that's all we need.
+    """
+
+    __slots__ = ("x", "y", "z")
+
+    def __init__(self, x: float, y: float, z: float) -> None:
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class _MockMetaWearWrapper:
+    """Stub satisfying the ``device_wrapper`` calls inherited from ``Mbient``.
+
+    Inherited code paths in ``Mbient.start`` / ``stop`` / ``disconnect``
+    / ``log_battery_info`` reach into ``device_wrapper``; without this
+    stub they would raise ``AttributeError`` on the mock.  Every method
+    is a no-op; ``is_connected`` reflects the most recent ``disconnect``
+    call so tests that inspect it see the expected transition.
+    """
+
+    def __init__(self, dev_name: str) -> None:
+        self.dev_name = dev_name
+        self.model_name = "MockMetaMotion"
+        self.is_connected = True
+        self.on_disconnect = lambda status: None
+
+    def setup_connection_settings(self, *_args, **_kwargs) -> None:
+        return None
+
+    def setup_sensor_settings(self, *_args, **_kwargs) -> None:
+        # Real return is a SensorSignals tuple consumed by the fuser; the
+        # mock skips that path in ``_attach_data_source`` so None is fine.
+        return None
+
+    def enable_inertial_sampling(self) -> None:
+        return None
+
+    def disable_inertial_sampling(self) -> None:
+        return None
+
+    def start_inertial_sampling(self) -> None:
+        return None
+
+    def stop_inertial_sampling(self) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        self.is_connected = False
+        self.on_disconnect(0)
+
+    def reset_device(self) -> None:
+        return None
+
+    def get_battery_state(self) -> BatteryState:
+        return BatteryState(voltage=4000.0, charge=100.0)
+
+
+class MockMbient(Mbient):
+    """Mock Mbient that emits synthetic LSL samples on a daemon thread."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._mock_thread: Optional[threading.Thread] = None
+        self._mock_stop_event = threading.Event()
+
+    def _acquire_hardware(self) -> None:
+        # Skip BLE scan / connect / reset.  Install a stub wrapper so the
+        # inherited start/stop/disconnect paths have something to call.
+        self.device_wrapper = _MockMetaWearWrapper(self.dev_name)
+        self.logger.info(self.format_message(
+            "MockMbient: skipped BLE acquire (no hardware)"))
+
+    def _attach_data_source(self) -> None:
+        # Match the real path's effect on ``data_handlers`` so LSL is
+        # called first, but skip the fuser/cbindings entirely.
+        from neurobooth_os.iout.mbient import DISABLE_LSL  # noqa: WPS433
+        if DISABLE_LSL:
+            self.logger.warning("LSL Disabled!")
+        else:
+            self.data_handlers = [self._lsl_data_handler, *self.data_handlers]
+        self.logger.info(self.format_message(
+            "MockMbient: synthetic data source attached"))
+
+    def start(self, filename: Optional[str] = None, buzz: bool = False) -> List[str]:
+        """Begin emitting synthetic samples on a background thread."""
+        self.streaming = True
+        self.state = DeviceState.STARTED
+        self._mock_stop_event.clear()
+        # Use the higher of the two rates: the real fuser emits one sample
+        # per matched (acc, gyro) pair which arrive at the higher rate.
+        rate_hz = max(self.acc_hz, self.gyro_hz)
+        self._mock_thread = threading.Thread(
+            target=self._synthetic_loop,
+            args=(rate_hz,),
+            daemon=True,
+            name=f"MockMbient-{self.dev_name}",
+        )
+        self._mock_thread.start()
+        return []
+
+    def stop(self) -> None:
+        """Halt the synthetic-sample thread."""
+        self._mock_stop_event.set()
+        if self._mock_thread is not None:
+            self._mock_thread.join(timeout=1.0)
+            self._mock_thread = None
+        self.streaming = False
+        self.state = DeviceState.STOPPED
+
+    def disconnect(self) -> None:
+        if self.device_wrapper is not None:
+            self.device_wrapper.disconnect()
+        self.state = DeviceState.DISCONNECTED
+
+    def close(self) -> None:
+        if self.streaming:
+            self.stop()
+        self.subscribed_signals.clear()
+        self.state = DeviceState.STOPPED
+        self.disconnect()
+
+    def reset(self, timeout_sec: float = 10) -> None:
+        # Real reset waits on a native disconnect callback; the mock
+        # bypasses both the reset and the wait.
+        return None
+
+    def attempt_reconnect(
+        self,
+        status: Optional[int] = None,
+        notify: bool = True,
+        n_attempts: int = 3,
+    ) -> None:
+        # No native BLE link to recover; surface a benign log so tests
+        # can assert the path was exercised without sending the
+        # MbientDisconnected message that real disconnect would.
+        self.logger.info(self.format_message(
+            "MockMbient: attempt_reconnect (no-op)"))
+
+    def on_task_reconnect(self) -> None:
+        # Bypass ``Mbient.task_start_reconnect``, which performs a BLE
+        # scan and gates retries on real hardware availability.
+        return None
+
+    def reset_and_reconnect(self, timeout_sec: float = 10) -> bool:
+        # Operator action; nothing to reset, always succeed.
+        self.logger.info(self.format_message(
+            "MockMbient: reset_and_reconnect (no-op)"))
+        return True
+
+    def _synthetic_loop(self, rate_hz: int) -> None:
+        """Emit acc+gyro samples until ``_mock_stop_event`` is set."""
+        period = 1.0 / float(rate_hz)
+        # Constant values: 1g down at rest, zero rotation.  Downstream
+        # consumers only need the LSL stream shape and cadence, not
+        # realistic motion.
+        acc = _MockSample(0.0, 0.0, 1.0)
+        gyro = _MockSample(0.0, 0.0, 0.0)
+        while not self._mock_stop_event.is_set():
+            self.n_samples_streamed += 1
+            epoch_ms = time.time() * 1000.0
+            for handler in list(self.data_handlers):
+                try:
+                    handler(epoch_ms, acc, gyro)
+                except Exception:  # pragma: no cover — defensive
+                    self.logger.exception(self.format_message(
+                        "MockMbient: data handler raised"))
+            self._mock_stop_event.wait(period)

--- a/neurobooth_os/iout/mock_substitution.py
+++ b/neurobooth_os/iout/mock_substitution.py
@@ -1,0 +1,129 @@
+"""Mock-device substitution registry and resolution helpers.
+
+Mocks register themselves at import time via :func:`register_mock`, mapping a
+real ``DeviceArgs`` subclass to a mock counterpart. ``DeviceManager`` consults
+:func:`active_mock_targets` and :func:`apply_mock_substitution` during
+``create_streams`` to swap real device args for mock ones before
+``device_class()`` resolution runs.
+
+The active set comes from two sources, in priority order:
+
+1. ``NB_MOCK_DEVICES`` environment variable — comma-separated device-class
+   names (``Mbient,IPhone,EyeTracker``) or the special value ``all``.
+2. ``NeuroboothConfig.mock_devices`` field — same shape, persisted in
+   ``neurobooth_os_config.yaml``.
+
+The env var wins when both are set so a developer can always force-disable
+or force-enable mocks for a single run without editing config files.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Set, Type, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from neurobooth_os.iout.stim_param_reader import DeviceArgs
+
+
+# real DeviceArgs subclass -> mock DeviceArgs subclass
+MOCK_REGISTRY: Dict[Type["DeviceArgs"], Type["DeviceArgs"]] = {}
+
+# Sentinel that means "every registered mock target is active".
+_ALL = "all"
+
+ENV_VAR = "NB_MOCK_DEVICES"
+
+
+def register_mock(real_cls: Type["DeviceArgs"],
+                  mock_cls: Type["DeviceArgs"]) -> None:
+    """Register a mock DeviceArgs subclass as a substitute for a real one.
+
+    Called at module-import time from each mock module. ``mock_cls`` must
+    be a subclass of ``real_cls`` so all of ``real_cls``'s field validation
+    still applies; this is enforced at registration time.
+    """
+    if not issubclass(mock_cls, real_cls):
+        raise TypeError(
+            f"{mock_cls.__name__} must be a subclass of {real_cls.__name__} "
+            "to register as its mock"
+        )
+    MOCK_REGISTRY[real_cls] = mock_cls
+
+
+def _parse_target_list(raw: Optional[str]) -> Set[str]:
+    """Parse ``"Mbient,IPhone"`` or ``"all"`` into a normalised set."""
+    if not raw:
+        return set()
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def active_mock_targets() -> Set[str]:
+    """Return the set of mock-target names active for this run.
+
+    Sources, in priority order: ``NB_MOCK_DEVICES`` env var, then
+    ``NeuroboothConfig.mock_devices``. The result contains *device-class
+    names* (e.g. ``"Mbient"``, ``"IPhone"``, ``"EyeTracker"``) — not
+    device IDs — and may contain the literal ``"all"`` sentinel.
+
+    Returns an empty set when neither source is set or the config has not
+    been loaded.
+    """
+    env_raw = os.environ.get(ENV_VAR)
+    if env_raw is not None:
+        return _parse_target_list(env_raw)
+
+    # Fallback to the config field. Config may not be loaded yet (e.g. unit
+    # tests that import this module before calling load_config); treat that
+    # as "no config-driven targets".
+    try:
+        from neurobooth_os import config as cfg
+        targets = getattr(cfg.neurobooth_config, "mock_devices", None)
+    except Exception:
+        return set()
+    if not targets:
+        return set()
+    return {t.strip() for t in targets if t and t.strip()}
+
+
+def _is_target_active(real_cls: Type["DeviceArgs"], active: Set[str]) -> bool:
+    """Whether the mock for ``real_cls`` should be substituted in this run."""
+    if not active:
+        return False
+    if _ALL in active:
+        return True
+    # Match against the resolved Device class name. We use the Device class
+    # (not the DeviceArgs class name) so a user writes
+    # NB_MOCK_DEVICES=Mbient rather than NB_MOCK_DEVICES=MbientDeviceArgs.
+    try:
+        device_cls_name = real_cls.device_class().__name__
+    except (NotImplementedError, ImportError, Exception):
+        return False
+    return device_cls_name in active
+
+
+def apply_mock_substitution(device_args: "DeviceArgs",
+                            active: Optional[Set[str]] = None) -> "DeviceArgs":
+    """Return a mock-substituted ``DeviceArgs`` instance, or the original.
+
+    Field values from ``device_args`` are preserved on the substituted
+    instance via Pydantic ``model_construct`` — no re-validation runs, so
+    fields like ``ENV_devices`` that the original loader populated stay
+    intact.
+    """
+    if active is None:
+        active = active_mock_targets()
+    if not active:
+        return device_args
+
+    real_cls = type(device_args)
+    if real_cls not in MOCK_REGISTRY:
+        return device_args
+    if not _is_target_active(real_cls, active):
+        return device_args
+
+    mock_cls = MOCK_REGISTRY[real_cls]
+    # Reuse the validated field values from the real instance. model_construct
+    # skips re-validation, which is what we want — the YAML already validated
+    # them once.
+    return mock_cls.model_construct(**device_args.model_dump())

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -264,6 +264,21 @@ class IPhoneDeviceArgs(DeviceArgs):
         return IPhone
 
 
+class MockIPhoneDeviceArgs(IPhoneDeviceArgs):
+    """DeviceArgs for :class:`MockIPhone` — same fields, different device class.
+
+    Selected at runtime by the substitution registry when ``IPhone`` is in
+    ``NB_MOCK_DEVICES``; instances are built via Pydantic ``model_construct``,
+    so this subclass exists primarily to point ``device_class()`` at the
+    mock implementation.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_iphone import MockIPhone
+        return MockIPhone
+
+
 class FlirDeviceArgs(DeviceArgs):
     """
     FLIR device arguments
@@ -712,3 +727,4 @@ class RawTaskParams(EnvArgs):
 from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
 
 register_mock(MbientDeviceArgs, MockMbientDeviceArgs)
+register_mock(IPhoneDeviceArgs, MockIPhoneDeviceArgs)

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -230,6 +230,21 @@ class EyelinkDeviceArgs(DeviceArgs):
         return EyeTracker
 
 
+class MockEyelinkDeviceArgs(EyelinkDeviceArgs):
+    """DeviceArgs for :class:`MockEyeTracker` — same fields, different device class.
+
+    Selected at runtime by the substitution registry when ``EyeTracker``
+    is in ``NB_MOCK_DEVICES``; instances are built via Pydantic
+    ``model_construct``, so this subclass exists primarily to point
+    ``device_class()`` at the mock implementation.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_eyetracker import MockEyeTracker
+        return MockEyeTracker
+
+
 class IPhoneDeviceArgs(DeviceArgs):
     """
     IPhone device arguments
@@ -728,3 +743,4 @@ from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
 
 register_mock(MbientDeviceArgs, MockMbientDeviceArgs)
 register_mock(IPhoneDeviceArgs, MockIPhoneDeviceArgs)
+register_mock(EyelinkDeviceArgs, MockEyelinkDeviceArgs)

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -423,6 +423,21 @@ class MbientDeviceArgs(DeviceArgs):
         return Mbient
 
 
+class MockMbientDeviceArgs(MbientDeviceArgs):
+    """DeviceArgs for :class:`MockMbient` — same fields, different device class.
+
+    Selected at runtime by the substitution registry when ``Mbient`` is in
+    ``NB_MOCK_DEVICES``; instances are built via Pydantic ``model_construct``,
+    so this subclass exists primarily to point ``device_class()`` at the
+    mock implementation.
+    """
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_mbient import MockMbient
+        return MockMbient
+
+
 class MouseDeviceArgs(DeviceArgs):
     """DeviceArgs for the Mouse device.
 
@@ -684,3 +699,16 @@ class RawTaskParams(EnvArgs):
     instruction_id: Optional[str] = None
     device_id_array: List[str]
     arg_parser: str
+
+
+# ---------------------------------------------------------------------------
+# Mock-device registrations
+#
+# Done here (not in each mock module) so the registry is populated as soon as
+# this module is imported — which happens unconditionally during config load.
+# Without this, mocks would only register on demand and the first
+# ``apply_mock_substitution`` call would silently miss them.
+# ---------------------------------------------------------------------------
+from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
+
+register_mock(MbientDeviceArgs, MockMbientDeviceArgs)

--- a/tests/pytest/test_mock_eyetracker.py
+++ b/tests/pytest/test_mock_eyetracker.py
@@ -1,0 +1,181 @@
+"""Lifecycle tests for the synthetic EyeLink mock.
+
+These tests exercise ``MockEyeTracker`` end-to-end without ``pylink``
+installed and without a configured PsychoPy monitor center.  Coverage:
+
+- ``__init__`` -> ``connect`` lands the device in ``DeviceState.CONNECTED``
+  using canned monitor dimensions.
+- ``start`` -> recording -> ``stop`` cycles through state transitions
+  and writes a stub ``.edf`` file at the requested path.
+- The synthetic record loop pushes 13-column samples at the configured
+  sample rate.
+- ``calibrate`` is a no-op (does not touch ``EyeLinkCoreGraphicsPsychoPy``
+  or ``pylink``).
+- The substitution registry is populated by importing
+  ``stim_param_reader``.
+"""
+
+import os
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from neurobooth_os.iout import eyelink_tracker as eyelink_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock import mock_eyetracker as mock_eyetracker_mod
+from neurobooth_os.iout.mock.mock_eyetracker import (
+    _STUB_EDF_BYTES,
+    MockEyeTracker,
+)
+from neurobooth_os.iout.stim_param_reader import (
+    EyelinkDeviceArgs,
+    EyelinkSensorArgs,
+    MockEyelinkDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 500
+RECORDING_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockEyelinkDeviceArgs:
+    sensor = EyelinkSensorArgs.model_construct(
+        sensor_id="eyelink_sens_1",
+        sample_rate=SAMPLE_RATE_HZ,
+        calibration_type="HV5",
+        msec_delay=10,
+        calibration_area_proportion=(0.85, 0.85),
+        validation_area_proportion=(0.85, 0.85),
+    )
+    return MockEyelinkDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="EyeLink_dev_1",
+        sensor_ids=["eyelink_sens_1"],
+        sensor_array=[sensor],
+        ip="100.1.1.1",
+        arg_parser="iout.stim_param_reader.py::MockEyelinkDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockEyelinkDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture
+def mock_window():
+    """A duck-typed window. The mock never draws to it, so MagicMock works."""
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _silence_messaging(monkeypatch):
+    """Replace ``post_message`` in both modules so tests don't hit the DB.
+
+    ``EyeTracker`` imports ``post_message`` into ``eyelink_tracker``'s
+    namespace, and ``MockEyeTracker._connect_tracker`` imports it into
+    ``mock_eyetracker``'s namespace.  Both bindings need patching.
+    """
+    monkeypatch.setattr(eyelink_mod, "post_message", lambda msg: None)
+    monkeypatch.setattr(mock_eyetracker_mod, "post_message", lambda msg: None)
+
+
+class TestMockEyeTrackerLifecycle:
+
+    def test_connect_lands_in_connected(self, mock_args, mock_window):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        try:
+            assert device.state == DeviceState.CONNECTED
+            assert device.tk is not None
+            assert device.monitor_width == 1920
+            assert device.monitor_height == 1080
+            assert device.outlet is not None
+        finally:
+            device.close()
+
+    def test_start_stop_writes_stub_edf(self, mock_args, mock_window, tmp_path):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        edf_path = str(tmp_path / "task_a_eyelink.edf")
+        try:
+            files = device.start(edf_path)
+            assert files == ["task_a_eyelink.edf"]
+            assert device.streaming is True
+            assert device.recording is True
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            assert device.state == DeviceState.STOPPED
+            assert device.streaming is False
+            assert device.recording is False
+            assert os.path.exists(edf_path)
+            with open(edf_path, "rb") as f:
+                assert f.read() == _STUB_EDF_BYTES
+        finally:
+            device.close()
+
+    def test_close_after_recording(self, mock_args, mock_window, tmp_path):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        edf_path = str(tmp_path / "close_test.edf")
+        device.start(edf_path)
+        device.close()
+        assert device.state == DeviceState.DISCONNECTED
+
+
+class TestMockEyeTrackerLSLFlow:
+
+    def test_synthetic_samples_flow(self, mock_args, mock_window, tmp_path):
+        """Verify the synthetic record thread captures timestamps at the
+        configured rate.  Asserting on absolute count is brittle on
+        Windows scheduling; require a generous lower bound instead.
+        """
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        edf_path = str(tmp_path / "lsl_test.edf")
+        try:
+            device.start(edf_path)
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+        finally:
+            device.close()
+        assert device.timestamps_et, "Expected synthetic timestamps"
+        assert len(device.timestamps_local) == len(device.timestamps_et)
+        # 500 Hz over 300 ms is ~150 samples; the mock's ``time.sleep``
+        # cadence is OS-bound on Windows, so >= 5 is the loose floor.
+        assert len(device.timestamps_et) >= 5, (
+            f"Expected at least 5 synthetic samples; got "
+            f"{len(device.timestamps_et)}"
+        )
+
+    def test_calibrate_is_no_op(self, mock_args, mock_window):
+        device = MockEyeTracker(device_args=mock_args, win=mock_window)
+        try:
+            # The real ``calibrate`` reaches into pylink via
+            # EyeLinkCoreGraphicsPsychoPy. The mock should not.
+            device.calibrate()
+            assert device.calibrated is True
+        finally:
+            device.close()
+
+
+class TestMockEyeTrackerRegistration:
+
+    def test_mock_eyetracker_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(EyelinkDeviceArgs) is MockEyelinkDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockEyelinkDeviceArgs.device_class() is MockEyeTracker
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = EyelinkDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="EyeLink_dev_1",
+            sensor_ids=["eyelink_sens_1"],
+            ip="100.1.1.1",
+            sensor_array=[],
+            arg_parser="iout.stim_param_reader.py::EyelinkDeviceArgs()",
+        )
+        result = apply_mock_substitution(real, active={"EyeTracker"})
+        assert isinstance(result, MockEyelinkDeviceArgs)
+        assert result.device_id == "EyeLink_dev_1"
+        assert result.ip == "100.1.1.1"

--- a/tests/pytest/test_mock_iphone.py
+++ b/tests/pytest/test_mock_iphone.py
@@ -1,0 +1,202 @@
+"""Lifecycle tests for the synthetic iPhone mock.
+
+These tests exercise ``MockIPhone`` end-to-end without any USB / socket
+infrastructure or running iOS app.  Coverage:
+
+- Handshake takes the device from ``#DISCONNECTED`` to ``#READY`` via the
+  in-process transport (no ``USBMux``, no real socket).
+- ``start`` -> recording -> ``stop`` -> ``ensure_stopped`` cycles through
+  the state machine end-to-end.
+- LSL ``_lsl_push_sample`` sees ``@STARTTIMESTAMP``, several
+  ``@INPROGRESSTIMESTAMP``, then ``@STOPTIMESTAMP``.
+- ``frame_preview()`` returns the canned bytes the mock transport
+  injects.
+- The substitution registry is populated by importing
+  ``stim_param_reader``.
+"""
+
+import time
+
+import pytest
+
+from neurobooth_os.iout import iphone as iphone_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_iphone import (
+    _CANNED_PREVIEW_BYTES,
+    MockIPhone,
+)
+from neurobooth_os.iout.stim_param_reader import (
+    IPhoneDeviceArgs,
+    IPhoneSensorArgs,
+    MockIPhoneDeviceArgs,
+)
+
+
+SAMPLE_FPS = 30
+RECORDING_WINDOW_SEC = 0.5
+
+
+def _build_mock_args() -> MockIPhoneDeviceArgs:
+    """Construct a ``MockIPhoneDeviceArgs`` with the minimum fields ``IPhone`` reads."""
+    sensor = IPhoneSensorArgs.model_construct(
+        sensor_id="iphone_sens_1",
+        sample_rate=SAMPLE_FPS,
+        notifyonframe=1,
+        videoquality="high",
+        usecamerafacing="back",
+        brightness=50,
+        lenspos=0.5,
+    )
+    return MockIPhoneDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="IPhone_dev_1",
+        sensor_ids=["iphone_sens_1"],
+        sensor_array=[sensor],
+        arg_parser="iout.stim_param_reader.py::MockIPhoneDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockIPhoneDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _disable_lsl_and_messaging(monkeypatch):
+    """Skip LSL outlet creation and silence ``post_message`` so tests don't need
+    a real LSL or database backend.  ``IPhone`` uses ``DISABLE_LSL`` to
+    bypass ``_create_outlet`` (which posts ``DeviceInitialization``) and to
+    short-circuit ``_lsl_push_sample``; ``post_message`` is also reached
+    via ``send_status_msg`` and ``panic``.
+    """
+    monkeypatch.setattr(iphone_mod, "DISABLE_LSL", True)
+    monkeypatch.setattr(iphone_mod, "post_message", lambda msg: None)
+
+
+class TestMockIPhoneLifecycle:
+
+    def test_handshake_lands_in_ready(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        try:
+            assert device.connect() is True
+            assert device.connected is True
+            assert device.state == DeviceState.CONNECTED
+            assert device._state == "#READY"
+        finally:
+            device.close()
+
+    def test_start_stop_cycle(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        try:
+            assert device.connect() is True
+            files = device.start("/tmp/task_obs_1")
+            # IPhone.start strips the directory and appends "_IPhone".
+            assert files == ["task_obs_1_IPhone.mov", "task_obs_1_IPhone.json"]
+            assert device.streaming is True
+            assert device._state == "#RECORDING"
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+            assert device._state == "#READY"
+            assert device.streaming is False
+        finally:
+            device.close()
+
+    def test_close_drives_state_to_disconnected(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        device.connect()
+        device.close()
+        assert device.state == DeviceState.DISCONNECTED
+        assert device._state == "#DISCONNECTED"
+        assert device.connected is False
+        assert device.streaming is False
+
+    def test_close_after_recording_stops_stream_thread(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        device.connect()
+        device.start("/tmp/task_a")
+        # Verify the transport's synthetic-stream thread is running.
+        assert device.transport._stream_thread is not None
+        assert device.transport._stream_thread.is_alive()
+        device.close()
+        # close() drains the thread via transport.close().
+        assert (
+            device.transport._stream_thread is None
+            or not device.transport._stream_thread.is_alive()
+        )
+
+
+class TestMockIPhoneLSLFlow:
+
+    def test_lsl_push_sample_sees_full_recording_sequence(
+        self, mock_args, monkeypatch
+    ):
+        """During a recording the mock should drive @STARTTIMESTAMP,
+        a stream of @INPROGRESSTIMESTAMP at the configured FPS, and
+        @STOPTIMESTAMP — in that order — through ``_lsl_push_sample``.
+        """
+        device = MockIPhone(device_args=mock_args)
+        captured_types = []
+
+        def recorder(message):
+            mt = message.get("MessageType", "")
+            if mt in ("@STARTTIMESTAMP", "@INPROGRESSTIMESTAMP", "@STOPTIMESTAMP"):
+                captured_types.append(mt)
+
+        monkeypatch.setattr(device, "_lsl_push_sample", recorder)
+
+        try:
+            device.connect()
+            device.start("/tmp/task_a")
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+        finally:
+            device.close()
+
+        assert captured_types, "Expected at least one timestamp sample"
+        assert captured_types[0] == "@STARTTIMESTAMP"
+        # @STOPTIMESTAMP is the last frame-related message; trailing
+        # @INPROGRESSTIMESTAMP from the streaming thread shouldn't sneak
+        # in after stop() because the transport's _end_streaming joins
+        # the stream thread before queueing @STOPTIMESTAMP.
+        assert "@STOPTIMESTAMP" in captured_types
+        in_progress = sum(1 for t in captured_types if t == "@INPROGRESSTIMESTAMP")
+        # 30 FPS * 0.5s = ~15; allow generous slack for jitter.
+        assert in_progress >= 3, (
+            f"Expected several @INPROGRESSTIMESTAMP messages; got {in_progress}"
+        )
+
+    def test_frame_preview_returns_canned_bytes(self, mock_args):
+        device = MockIPhone(device_args=mock_args)
+        try:
+            device.connect()
+            preview = device.frame_preview()
+            assert preview == _CANNED_PREVIEW_BYTES
+            assert len(preview) > 0
+        finally:
+            device.close()
+
+
+class TestMockIPhoneRegistration:
+    """Verify the substitution registry is wired up for IPhone."""
+
+    def test_mock_iphone_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(IPhoneDeviceArgs) is MockIPhoneDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockIPhoneDeviceArgs.device_class() is MockIPhone
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = IPhoneDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="IPhone_dev_1",
+            sensor_ids=["iphone_sens_1"],
+            sensor_array=[],
+            arg_parser="iout.stim_param_reader.py::IPhoneDeviceArgs()",
+        )
+        result = apply_mock_substitution(real, active={"IPhone"})
+        assert isinstance(result, MockIPhoneDeviceArgs)
+        assert result.device_id == "IPhone_dev_1"

--- a/tests/pytest/test_mock_mbient.py
+++ b/tests/pytest/test_mock_mbient.py
@@ -1,0 +1,222 @@
+"""Lifecycle tests for the synthetic Mbient mock.
+
+These tests exercise ``MockMbient`` end-to-end without a real BLE device or
+the mbientlab SDK installed.  They cover:
+
+- ``bring_up`` -> ``start`` -> ``stop`` -> ``close`` round-trip with
+  synthetic samples flowing.
+- ``attempt_reconnect`` / ``on_task_reconnect`` / ``on_session_reset`` are
+  no-ops on the mock and don't post the ``MbientDisconnected`` warning
+  the real path emits.
+- The substitution registry is populated by importing
+  ``stim_param_reader``.
+"""
+
+import time
+
+import pytest
+
+from neurobooth_os.iout import mbient as mbient_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_mbient import MockMbient
+from neurobooth_os.iout.stim_param_reader import (
+    MbientDeviceArgs,
+    MbientSensorArgs,
+    MockMbientDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 100
+SAMPLE_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockMbientDeviceArgs:
+    """Construct a ``MockMbientDeviceArgs`` with the minimum fields ``Mbient.__init__`` reads."""
+    acc_sensor = MbientSensorArgs.model_construct(
+        sensor_id="acc1",
+        sample_rate=SAMPLE_RATE_HZ,
+        data_range=8,
+    )
+    gyro_sensor = MbientSensorArgs.model_construct(
+        sensor_id="gyro1",
+        sample_rate=SAMPLE_RATE_HZ,
+        data_range=2000,
+    )
+    return MockMbientDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="Mbient_TestDevice_1",
+        sensor_ids=["acc1", "gyro1"],
+        sensor_array=[acc_sensor, gyro_sensor],
+        mac="AA:BB:CC:DD:EE:FF",
+        device_name="TestDevice",
+        arg_parser="iout.stim_param_reader.py::MockMbientDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockMbientDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _disable_lsl_and_messaging(monkeypatch):
+    """Skip LSL outlet creation and silence ``post_message`` so tests don't need
+    a real network/database. ``mbient.DISABLE_LSL`` gates outlet creation in
+    ``connect()`` and the ``_lsl_data_handler`` injection in
+    ``_attach_data_source``; ``post_message`` is reached via ``send_status_msg``
+    in ``setup()`` regardless of that flag.
+    """
+    monkeypatch.setattr(mbient_mod, "DISABLE_LSL", True)
+    monkeypatch.setattr(mbient_mod, "post_message", lambda msg: None)
+
+
+@pytest.fixture
+def captured_messages(monkeypatch):
+    """Replace ``mbient.post_message`` with a recorder so tests can assert on
+    what messages a code path emits.  Overrides the autouse fixture's
+    silencer for the test that uses it.
+    """
+    posted = []
+    monkeypatch.setattr(mbient_mod, "post_message", lambda msg: posted.append(msg))
+    return posted
+
+
+class TestMockMbientLifecycle:
+    """Bring up, run, and tear down a mock Mbient end-to-end."""
+
+    def test_bring_up_returns_self(self, mock_args):
+        device = MockMbient(mock_args)
+        try:
+            assert device.bring_up({}) is device
+            assert device.streaming is True
+            assert device.state == DeviceState.STARTED
+        finally:
+            device.close()
+
+    def test_synthetic_samples_flow_at_configured_rate(self, mock_args):
+        device = MockMbient(mock_args)
+        captured = []
+        device.register_data_handler(
+            lambda epoch, acc, gyro: captured.append((epoch, acc.x, gyro.x))
+        )
+        try:
+            device.bring_up({})
+            time.sleep(SAMPLE_WINDOW_SEC)
+            device.stop()
+        finally:
+            device.close()
+
+        # At 100 Hz over 300 ms we expect ~30 samples; allow generous slack
+        # for Windows scheduling jitter and CI variance.
+        assert len(captured) >= 5, (
+            f"Expected at least 5 synthetic samples; got {len(captured)}"
+        )
+        # n_samples_streamed is incremented inside the synthetic loop and
+        # should match (or exceed by 1 if a sample landed between the
+        # final handler-call and our assertion).
+        assert device.n_samples_streamed >= len(captured)
+
+    def test_close_without_start_does_not_raise(self, mock_args):
+        # If connect() succeeds but start() never runs (or
+        # bring_up() short-circuits), close() must still tear down cleanly.
+        device = MockMbient(mock_args)
+        device.connect()
+        device.close()
+        assert device.streaming is False
+        assert device._mock_thread is None
+
+    def test_close_after_start_joins_thread(self, mock_args):
+        device = MockMbient(mock_args)
+        device.bring_up({})
+        # Sanity-check the thread is actually running before we ask for stop.
+        assert device._mock_thread is not None
+        assert device._mock_thread.is_alive()
+        device.close()
+        assert device.streaming is False
+        assert device._mock_thread is None
+        assert device.state == DeviceState.DISCONNECTED
+
+    def test_stop_then_start_again(self, mock_args):
+        # Mocks should tolerate stop/start cycles within a session.
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            device.stop()
+            assert device.streaming is False
+            device.start()
+            assert device.streaming is True
+            assert device._mock_thread is not None
+            assert device._mock_thread.is_alive()
+        finally:
+            device.close()
+
+
+class TestMockMbientReconnectPaths:
+    """The mock should not pretend to disconnect/reconnect or notify operators."""
+
+    def test_attempt_reconnect_does_not_post_disconnect(
+        self, mock_args, captured_messages
+    ):
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            device.attempt_reconnect()  # default args mirror callback signature
+            assert device.streaming is True
+        finally:
+            device.close()
+        body_types = [
+            type(m.body).__name__ for m in captured_messages if hasattr(m, "body")
+        ]
+        assert "MbientDisconnected" not in body_types, (
+            f"MockMbient.attempt_reconnect must not post MbientDisconnected; "
+            f"got {body_types}"
+        )
+
+    def test_on_task_reconnect_is_no_op(self, mock_args, captured_messages):
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            device.on_task_reconnect()
+            assert device.streaming is True
+        finally:
+            device.close()
+
+    def test_on_session_reset_returns_true(self, mock_args):
+        device = MockMbient(mock_args)
+        try:
+            device.bring_up({})
+            assert device.on_session_reset() is True
+        finally:
+            device.close()
+
+
+class TestMockMbientRegistration:
+    """The substitution registry is populated as a side-effect of importing
+    ``stim_param_reader``; verify both the entry and the device-class hop.
+    """
+
+    def test_mock_mbient_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(MbientDeviceArgs) is MockMbientDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockMbientDeviceArgs.device_class() is MockMbient
+
+    def test_apply_substitution_swaps_class(self):
+        # Round-trip through apply_mock_substitution to confirm the registry
+        # entry resolves under the env-var-driven path that DeviceManager uses.
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = MbientDeviceArgs.model_construct(
+            ENV_devices={"Mbient_d_1": {"mac": "AA:BB"}},
+            device_id="Mbient_d_1",
+            sensor_ids=["acc1"],
+            mac="AA:BB",
+            device_name="d",
+            arg_parser="iout.stim_param_reader.py::MbientDeviceArgs()",
+            sensor_array=[],
+        )
+        result = apply_mock_substitution(real, active={"Mbient"})
+        assert isinstance(result, MockMbientDeviceArgs)
+        # Field values preserved (model_construct, not re-validation).
+        assert result.device_id == "Mbient_d_1"
+        assert result.mac == "AA:BB"

--- a/tests/pytest/test_mock_substitution.py
+++ b/tests/pytest/test_mock_substitution.py
@@ -1,0 +1,225 @@
+"""Tests for the mock-device substitution mechanism.
+
+Covers:
+- ``register_mock`` registry behaviour and the subclass-of guard.
+- ``active_mock_targets`` source priority (env var > config field).
+- ``apply_mock_substitution`` returns the original instance when no
+  substitution applies, and a mock instance when it does.
+- The lazy hardware imports in ``mbient.py`` and ``eyelink_tracker.py``
+  do not require the underlying SDKs to be installed at import time.
+"""
+
+import builtins
+import importlib
+import os
+import sys
+from typing import Type
+from unittest.mock import patch
+
+import pytest
+
+from neurobooth_os.iout import mock_substitution as ms
+from neurobooth_os.iout.stim_param_reader import DeviceArgs
+
+
+# ---------------------------------------------------------------------------
+# Test-only DeviceArgs subclasses (don't pollute the real registry).
+# ---------------------------------------------------------------------------
+
+class _RealForTest(DeviceArgs):
+    @classmethod
+    def device_class(cls):
+        # Returns a stand-in class whose __name__ controls active-target
+        # matching. Tests can monkeypatch this.
+        return _RealDeviceCls
+
+
+class _MockForTest(_RealForTest):
+    @classmethod
+    def device_class(cls):
+        return _MockDeviceCls
+
+
+class _RealDeviceCls:
+    pass
+
+
+class _MockDeviceCls:
+    pass
+
+
+def _make_real(env_devices=None) -> _RealForTest:
+    """Build a _RealForTest instance with the minimum fields populated."""
+    return _RealForTest(
+        ENV_devices=env_devices or {"d1": {}},
+        device_id="d1",
+        arg_parser="iout.stim_param_reader.py::_RealForTest()",
+        sensor_ids=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: keep the global registry clean between tests.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    saved = dict(ms.MOCK_REGISTRY)
+    ms.MOCK_REGISTRY.clear()
+    yield
+    ms.MOCK_REGISTRY.clear()
+    ms.MOCK_REGISTRY.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(ms.ENV_VAR, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Registry behaviour
+# ---------------------------------------------------------------------------
+
+class TestRegister:
+    def test_register_then_lookup(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        assert ms.MOCK_REGISTRY[_RealForTest] is _MockForTest
+
+    def test_subclass_guard_rejects_non_subclass(self):
+        class _Unrelated(DeviceArgs):
+            pass
+        with pytest.raises(TypeError, match="must be a subclass"):
+            ms.register_mock(_RealForTest, _Unrelated)
+
+
+# ---------------------------------------------------------------------------
+# active_mock_targets parsing + priority
+# ---------------------------------------------------------------------------
+
+class TestActiveMockTargets:
+    def test_unset_returns_empty(self):
+        assert ms.active_mock_targets() == set()
+
+    def test_env_var_single(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, "Mbient")
+        assert ms.active_mock_targets() == {"Mbient"}
+
+    def test_env_var_multi_with_whitespace(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, " Mbient , IPhone , EyeTracker ")
+        assert ms.active_mock_targets() == {"Mbient", "IPhone", "EyeTracker"}
+
+    def test_env_var_all_sentinel(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, "all")
+        assert ms.active_mock_targets() == {"all"}
+
+    def test_env_var_empty_string_is_empty(self, monkeypatch):
+        monkeypatch.setenv(ms.ENV_VAR, "")
+        # Empty string means "set but empty"; treat as no targets.
+        assert ms.active_mock_targets() == set()
+
+    def test_config_fallback_when_env_unset(self, monkeypatch):
+        from neurobooth_os import config as cfg
+        # Inject a fake neurobooth_config exposing mock_devices.
+        class _Stub:
+            mock_devices = ["IPhone"]
+        monkeypatch.setattr(cfg, "neurobooth_config", _Stub())
+        assert ms.active_mock_targets() == {"IPhone"}
+
+    def test_env_var_wins_over_config(self, monkeypatch):
+        from neurobooth_os import config as cfg
+        class _Stub:
+            mock_devices = ["IPhone"]
+        monkeypatch.setattr(cfg, "neurobooth_config", _Stub())
+        monkeypatch.setenv(ms.ENV_VAR, "Mbient")
+        assert ms.active_mock_targets() == {"Mbient"}
+
+    def test_unloaded_config_returns_empty(self, monkeypatch):
+        from neurobooth_os import config as cfg
+        # Simulate config not yet loaded — neurobooth_config is None.
+        monkeypatch.setattr(cfg, "neurobooth_config", None)
+        assert ms.active_mock_targets() == set()
+
+
+# ---------------------------------------------------------------------------
+# apply_mock_substitution
+# ---------------------------------------------------------------------------
+
+class TestApplySubstitution:
+    def test_no_active_returns_original(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active=set())
+        assert result is real
+
+    def test_unregistered_class_returns_original(self):
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active={"_RealDeviceCls"})
+        assert result is real
+
+    def test_registered_and_active_returns_mock(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active={"_RealDeviceCls"})
+        assert isinstance(result, _MockForTest)
+        # Field values preserved via model_construct.
+        assert result.device_id == "d1"
+
+    def test_all_sentinel_substitutes(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(real, active={"all"})
+        assert isinstance(result, _MockForTest)
+
+    def test_active_set_for_other_class_skips_substitution(self):
+        ms.register_mock(_RealForTest, _MockForTest)
+        real = _make_real()
+        result = ms.apply_mock_substitution(
+            real, active={"SomeOtherDeviceCls"})
+        assert result is real
+
+
+# ---------------------------------------------------------------------------
+# Hardware-less import smoke tests for the lazy imports added in Phase 0a.
+# ---------------------------------------------------------------------------
+
+def _import_module_without(*blocked: str) -> object:
+    """Re-import target modules with certain top-level imports blocked.
+
+    Returns the freshly-imported module(s).
+    """
+    blocked_set = set(blocked)
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        for b in blocked_set:
+            if name == b or name.startswith(b + "."):
+                raise ImportError(f"simulated absence of {name}")
+        return orig_import(name, *args, **kwargs)
+
+    builtins.__import__ = fake_import
+    try:
+        for k in list(sys.modules):
+            if k in blocked_set or k.startswith(tuple(b + "." for b in blocked_set)):
+                del sys.modules[k]
+        # Drop the cached module so it re-imports under the patched __import__.
+        for cached in list(sys.modules):
+            if "iout.mbient" in cached or "iout.eyelink_tracker" in cached:
+                del sys.modules[cached]
+        import neurobooth_os.iout.mbient as mbient_mod
+        import neurobooth_os.iout.eyelink_tracker as eyelink_mod
+        return mbient_mod, eyelink_mod
+    finally:
+        builtins.__import__ = orig_import
+
+
+class TestLazyHardwareImports:
+    def test_mbient_imports_without_mbientlab(self):
+        mbient_mod, _ = _import_module_without("mbientlab")
+        assert mbient_mod._HAS_MBIENTLAB is False
+        # The Mbient class must be defined (so MockMbient can subclass it).
+        assert mbient_mod.Mbient is not None
+
+    def test_eyelink_imports_without_pylink(self):
+        _, eyelink_mod = _import_module_without("pylink")
+        assert eyelink_mod._HAS_PYLINK is False
+        assert eyelink_mod.EyeTracker is not None


### PR DESCRIPTION
## Summary

Umbrella PR for the mock-device work delivered in five stacked PRs (#732 / #733 / #734 / #735 / #736) plus the operator-facing testing reference. Closes #727 / #728 / #729 / #730 / #731.

Adds a substitution mechanism that swaps a real `DeviceArgs` class for a mock counterpart at `device_class()` resolution time, with three mocks shipped:

- **`MockMbient`** — synthetic acc+gyro samples on a daemon thread, no BLE.
- **`MockIPhone`** — in-process queue runs the iOS-app state machine, no USBMux/socket.
- **`MockEyeTracker`** — synthetic 13-column gaze samples, no pylink.

Activated via `NB_MOCK_DEVICES` env var (wins) or the new `mock_devices` field on `NeuroboothConfig`. Targets are device-class names (`Mbient`, `IPhone`, `EyeTracker`) or the `all` sentinel.

## Production-impact summary

**Zero behaviour change when no mocks are configured** (env var unset and `mock_devices` empty/null). The substitution loop in `lsl_streamer.py` and the GUI banner are both gated by an empty-targets check.

Real production code does change for actual hardware — small refactors that should be reviewed:

- `mbient.py` — `connect()` / `setup()` extracted into `_acquire_hardware()` / `_attach_data_source()` hooks. `self.callback` now lazy-created in `_attach_data_source` instead of `__init__`. `MetaWearWrapper.SUPPORTED_DEVICE_MODELS` → `supported_device_models()` classmethod. `mbientlab` import wrapped in try/except.
- `eyelink_tracker.py` — extracted `_resolve_monitor_size`, `_begin_native_recording`, `_receive_data_file` hooks. `pylink` import wrapped in try/except. `EyeLinkCoreGraphicsPsychoPy` import deferred from module-load to first `calibrate()` call.
- `iphone.py` — `self.sock` renamed to `self.transport` (still socket-shaped on the real path). **Removed** dead `_mock_handshake` and the unused `mock=` parameter on `__init__` / `prepare`.

## Out of scope

- Camera modules (`camera_intel`, `flir_cam`, `webcam`) and `microphone` still have eager SDK imports and no mocks. A laptop env that assigns those devices won't run end-to-end against `NB_MOCK_DEVICES=all` until they get the same lazy-import + mock pattern. See `docs/testing_with_mocks.md` for the documented workarounds.
- A companion configs-repo PR ([neurobooth/configs#106](https://github.com/neurobooth/configs/pull/106), already merged) drops the dangling `Mock_IPhone_dev_1` reference from the laptop env config.

## Test plan

- [x] `python -m pytest tests/pytest/ neurobooth_os/iout/tests/` → 140 passed (95 prior + 17 substitution + 11 Mbient + 9 IPhone + 8 EyeTracker)
- [x] Verified `mbient.py` and `eyelink_tracker.py` import cleanly with their hardware SDKs simulated absent
- [ ] Smoke test on the laptop env with `NB_MOCK_DEVICES=Mbient,IPhone,EyeTracker` — manual

## Docs

- `docs/arch/adding_a_device.md` — new "Running with mocks" architectural subsection
- `docs/testing_with_mocks.md` — operator-facing quick reference (activation, what each mock produces, multi-instance behaviour, what's not mocked, common pitfalls, where the YAML field goes)