### PR TITLE
Mock devices for FLIR, Intel RealSense, Yeti microphone

### DIFF
--- a/docs/testing_with_mocks.md
+++ b/docs/testing_with_mocks.md
@@ -93,17 +93,29 @@ production environments leave it unset.
 
 ## What gets mocked
 
-| Device           | Mock class         | Hardware bypassed                |
-|------------------|--------------------|----------------------------------|
-| Mbient wearable  | `MockMbient`       | BLE radio, `mbientlab` SDK       |
-| iPhone (camera)  | `MockIPhone`       | USB / `usbmux` / iOS app socket  |
-| EyeLink tracker  | `MockEyeTracker`   | EyeLink box, `pylink`, `.edf` capture |
+| Device                 | Mock class           | Activation key in `NB_MOCK_DEVICES` | Hardware bypassed                       |
+|------------------------|----------------------|-------------------------------------|-----------------------------------------|
+| Mbient wearable        | `MockMbient`         | `Mbient`                            | BLE radio, `mbientlab` SDK              |
+| iPhone (camera)        | `MockIPhone`         | `IPhone`                            | USB / `usbmux` / iOS app socket         |
+| EyeLink tracker        | `MockEyeTracker`     | `EyeTracker`                        | EyeLink box, `pylink`, `.edf` capture   |
+| Yeti microphone        | `MockMicStream`      | `MicStream`                         | `pyaudio`, audio input device           |
+| FLIR camera            | `MockVidRec_Flir`    | `VidRec_Flir`                       | `PySpin`, FLIR Spinnaker SDK            |
+| Intel RealSense camera | `MockVidRec_Intel`   | `VidRec_Intel`                      | `pyrealsense2`, RealSense SDK           |
 
 The substitution happens inside `DeviceManager.create_streams` at
 `device_class()` resolution time — so by the time `bring_up()` runs,
 the device instance is already the mock subclass. Operator-facing
 behavior (the GUI, log messages, task transitions, file registration)
 follows the real lifecycle path.
+
+The "Activation key" column is the literal string `NB_MOCK_DEVICES`
+expects (i.e. `real_cls.device_class().__name__`). Examples:
+
+```bash
+NB_MOCK_DEVICES="Mbient,IPhone"            # wearables + iphone, real cameras/mic
+NB_MOCK_DEVICES="MicStream,VidRec_Flir"    # mic + FLIR cameras, real everything else
+NB_MOCK_DEVICES=all                        # every registered mock
+```
 
 ### What each mock produces
 
@@ -122,6 +134,21 @@ follows the real lifecycle path.
   `stop()` it writes a small placeholder `.edf` at the requested path
   so file-cataloguing downstream doesn't choke on a missing file.
   `calibrate()` is a no-op.
+- **`MockMicStream`** — a daemon thread pushes zero-filled int16 audio
+  chunks to the LSL outlet at the configured `sample_rate /
+  sample_chunk_size` rate. The chunk shape matches the real
+  microphone's stream; values are silence.
+- **`MockVidRec_Flir`** — emits black `320x240x3` frames at the
+  configured FPS through the existing save thread, producing a real
+  (small) `.avi` file at the requested path via `cv2.VideoWriter`.
+  `frame_preview()` returns a real 1-frame PNG (synthesised on the
+  fly). Requires `cv2` (opencv-python) — the real path needs it too.
+- **`MockVidRec_Intel`** — emits 4-column synthetic LSL samples at the
+  configured RGB sample rate. On `stop()` writes a small placeholder
+  `.bag` file at the requested path; downstream code finds the file
+  but **anything that opens and parses the `.bag`** (e.g. RealSense
+  Viewer, `rosbag`-style tooling) will fail because the bytes aren't a
+  valid RealSense bag.
 
 ### Multiple instances of the same device
 
@@ -145,9 +172,10 @@ assigns more than one.
 ## What is *not* mocked
 
 `apply_mock_substitution` only swaps a `DeviceArgs` class if it appears
-in `MOCK_REGISTRY`. Three devices currently have registered mocks:
-`MbientDeviceArgs`, `IPhoneDeviceArgs`, `EyelinkDeviceArgs`. Every
-other device class in the assigned set passes through to its real
+in `MOCK_REGISTRY`. Six device classes currently have registered mocks:
+`MbientDeviceArgs`, `IPhoneDeviceArgs`, `EyelinkDeviceArgs`,
+`MicYetiDeviceArgs`, `FlirDeviceArgs`, `IntelDeviceArgs`. Every other
+device class in the assigned set passes through to its real
 implementation **regardless of `NB_MOCK_DEVICES=all`** — `all` means
 "every registered mock target", not "every device".
 
@@ -164,15 +192,11 @@ This matters in two distinct ways:
 
 ### Devices that *do* need hardware (and don't have mocks yet)
 
-- **Intel RealSense camera** (`VidRec_Intel` in `camera_intel.py`)
-- **FLIR camera** (`VidRec_Flir` in `flir_cam.py`)
-- **Yeti microphone** (`MicStream` in `microphone.py`)
 - **Webcam** (`VidRec_Webcam` in `webcam.py`)
 
-These modules still have **eager** top-level SDK imports
-(`import pyrealsense2`, `import PySpin`, `import pyaudio`) — Phase 0's
-lazy-import treatment only covered `mbient.py` and `eyelink_tracker.py`.
-Two consequences for a hardware-less laptop:
+This module still has **eager** top-level SDK imports — the
+lazy-import + mock pattern hasn't been extended to it. Two
+consequences for a hardware-less laptop:
 
 1. If the SDK isn't installed, `device_class()` resolution raises
    `ImportError` when `DeviceManager.create_streams` tries to load the
@@ -183,22 +207,19 @@ Two consequences for a hardware-less laptop:
    `DeviceManager` skips the device — the rest of the session still
    runs.
 
-If your collection requires any of these (mvp-30 includes Intel + FLIR
-+ Yeti), you have three options:
+If your collection requires the webcam, you have three options:
 
-- **(a) Install the SDKs even without the hardware.** Lets the modules
-  import; bring_up will fail per-device but the session continues
-  without those streams.
-- **(b) Use a reduced collection** like `test_no_eyelink` (in
-  `examples/`) that strips out the missing-hardware devices. This is
-  the path documented in `single_machine_testing.md`.
+- **(a) Install the SDK even without the hardware.** Lets the module
+  import; bring_up will fail and the session continues without that
+  stream.
+- **(b) Use a reduced collection** that strips out the webcam.
 - **(c) Trim the laptop env's `acquisition.devices` list** in
   `neurobooth_os_config.yaml` so no unmocked-and-unavailable devices
   are assigned to begin with.
 
-A full hardware-less mvp-30 run on a laptop would require extending
-the lazy-import + mock pattern to those four modules — a follow-up
-beyond the scope of #732 / #733 / #734 / #735.
+A full hardware-less mvp-30 run on a laptop now works against `all` —
+all of the cameras, the microphone, and the wearables/iPhone/EyeLink
+have registered mocks.
 
 ## What stays real
 
@@ -235,23 +256,25 @@ Confirm:
    expected `device_id` / `sensor_id` and stub file paths.
 4. XDF split succeeds.
 
-This currently works only if the laptop env's `acquisition.devices`
-list contains nothing beyond Mouse, Marker, Mbient, IPhone, and EyeLink
-(see [What is *not* mocked](#what-is-not-mocked)). Collections that
-also assign Intel / FLIR / mic devices need one of the workarounds in
-that section.
+This works for any collection whose devices are all in
+[What gets mocked](#what-gets-mocked) plus Mouse and Marker (which
+need no mock). Collections that assign a webcam need one of the
+workarounds in [What is *not* mocked](#what-is-not-mocked).
 
 ### Hardware-less unit tests
 
-Each mock has a sibling test module under `tests/pytest/`:
+Each registered mock has a sibling test module under `tests/pytest/`:
 
 - `test_mock_substitution.py` — registry, env-var parsing, lazy imports.
 - `test_mock_mbient.py` — bring-up / start / stop / close round-trip.
 - `test_mock_iphone.py` — handshake, recording state cycle, frame preview.
 - `test_mock_eyetracker.py` — connect, synthetic samples, stub EDF write.
+- `test_mock_microphone.py` — connect, start, stop, registry round-trip.
+- `test_mock_flir.py` — connect, start, stop, real `.avi` produced, frame preview.
+- `test_mock_intel.py` — construct without pyrealsense2, start, stub `.bag` written.
 
 These tests run on a hardware-less laptop without `mbientlab`, `pylink`,
-`pyrealsense2`, or `PySpin` installed:
+`pyrealsense2`, `PySpin`, or `pyaudio` installed:
 
 ```bash
 python -m pytest tests/pytest/test_mock_*.py

--- a/neurobooth_os/iout/camera_intel.py
+++ b/neurobooth_os/iout/camera_intel.py
@@ -2,6 +2,8 @@
 """
     Wrapper around intel camera library
 """
+from __future__ import annotations
+
 import os.path as op
 from time import time
 import threading
@@ -10,7 +12,29 @@ import logging
 from typing import List, Optional
 
 from pylsl import local_clock
-import pyrealsense2 as rs
+
+# Hardware import — guarded so this module is importable on a hardware-less
+# laptop. Real VidRec_Intel code paths still require pyrealsense2 and will
+# fail loudly when called without it.
+try:
+    import pyrealsense2 as rs
+    _HAS_PYREALSENSE2 = True
+except ImportError:
+    rs = None  # type: ignore[assignment]
+    _HAS_PYREALSENSE2 = False
+
+
+def _require_pyrealsense2() -> None:
+    """Raise a clear error if real-Intel code is reached without pyrealsense2."""
+    if not _HAS_PYREALSENSE2:
+        raise RuntimeError(
+            "Intel RealSense hardware code path invoked but pyrealsense2 "
+            "is not installed. Install pyrealsense2 to use a real RealSense "
+            "camera, or use MockVidRec_Intel via NB_MOCK_DEVICES=VidRec_Intel "
+            "for hardware-less testing."
+        )
+
+
 from pylsl import StreamInfo, StreamOutlet
 
 import neurobooth_os.iout.metadator as meta
@@ -49,6 +73,17 @@ class VidRec_Intel(Device):
 
         self.device_index = int(device_args.device_id[-1])
         self.serial_num = device_args.device_sn
+        self.config = None
+        self.pipeline = None
+        self._configure_pipeline()
+
+    def _configure_pipeline(self) -> None:
+        """Build the pyrealsense2 ``config`` and ``pipeline``.
+
+        Subclass hook: ``MockVidRec_Intel`` overrides to skip pyrealsense2
+        entirely. The real path requires the SDK to be installed.
+        """
+        _require_pyrealsense2()
         self.config = rs.config()
         self.config.enable_device(self.serial_num)
         self.pipeline = rs.pipeline()
@@ -61,7 +96,7 @@ class VidRec_Intel(Device):
             self.device_args.sample_rate()[0],
         )
 
-        if device_args.has_depth_sensor():
+        if self.device_args.has_depth_sensor():
             self.config.enable_stream(
                 rs.stream.depth,
                 self.device_args.framesize()[1][0],

--- a/neurobooth_os/iout/flir_cam.py
+++ b/neurobooth_os/iout/flir_cam.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import os.path as op
 import numpy as np
 import queue
@@ -9,7 +11,29 @@ import logging
 from typing import Callable, Any, List, Optional, ByteString
 
 import cv2
-import PySpin
+
+# Hardware import — guarded so this module is importable on a hardware-less
+# laptop. Real VidRec_Flir code paths still require PySpin and will fail
+# loudly when called without it.
+try:
+    import PySpin
+    _HAS_PYSPIN = True
+except ImportError:
+    PySpin = None  # type: ignore[assignment]
+    _HAS_PYSPIN = False
+
+
+def _require_pyspin() -> None:
+    """Raise a clear error if real-FLIR code is reached without PySpin."""
+    if not _HAS_PYSPIN:
+        raise RuntimeError(
+            "FLIR hardware code path invoked but PySpin is not installed. "
+            "Install the FLIR Spinnaker SDK (PySpin) to use a real FLIR "
+            "camera, or use MockVidRec_Flir via NB_MOCK_DEVICES=VidRec_Flir "
+            "for hardware-less testing."
+        )
+
+
 from pylsl import StreamInfo, StreamOutlet
 
 from neurobooth_os.iout.stim_param_reader import FlirDeviceArgs
@@ -65,6 +89,7 @@ class VidRec_Flir(Device):
                           f'frame_size={str((self.device_args.width_px(), self.device_args.height_px()))}')
 
     def get_cam(self):
+        _require_pyspin()
         self.system = PySpin.System.GetInstance()
         cam_list = self.system.GetCameras()
         self.cam = cam_list.GetBySerial(self.serial_num)
@@ -86,6 +111,7 @@ class VidRec_Flir(Device):
             self.logger.error(f'FLIR: Error Setting Value [{func.__name__}({val})]: {e}')
 
     def setup_cam(self):
+        _require_pyspin()
         self.cam.Init()
         self.open = True
 

--- a/neurobooth_os/iout/microphone.py
+++ b/neurobooth_os/iout/microphone.py
@@ -1,11 +1,34 @@
+from __future__ import annotations
+
 from pylsl import StreamInfo, StreamOutlet, local_clock
-import pyaudio
 import numpy as np
 import threading
 import time
 import wave
 import logging
 from typing import NamedTuple, List, Optional
+
+# Hardware import — guarded so this module is importable on a hardware-less
+# laptop. Real MicStream code paths still require pyaudio and will fail
+# loudly when called without it.
+try:
+    import pyaudio
+    _HAS_PYAUDIO = True
+except ImportError:
+    pyaudio = None  # type: ignore[assignment]
+    _HAS_PYAUDIO = False
+
+
+def _require_pyaudio() -> None:
+    """Raise a clear error if real-microphone code is reached without pyaudio."""
+    if not _HAS_PYAUDIO:
+        raise RuntimeError(
+            "Microphone hardware code path invoked but pyaudio is not "
+            "installed. Install pyaudio to use a real microphone, or use "
+            "MockMicStream via NB_MOCK_DEVICES=MicStream for hardware-less "
+            "testing."
+        )
+
 
 from neurobooth_os.iout.device import Device, DeviceCapability, DeviceState
 from neurobooth_os.iout.metadator import post_message
@@ -27,16 +50,20 @@ class AudioDeviceException(Exception):
 
 
 # available audio format constants.  The format used is specified in the config file as a string, with the actual
-# constant retrieved from this dictionary
-SAMPLE_FORMATS = {
-    'paFloat32': pyaudio.paFloat32, # 32 bit float
-    'paInt32': pyaudio.paInt32,  #: 32 bit int
-    'paInt24': pyaudio.paInt24,  #: 24 bit int
-    'paInt16': pyaudio.paInt16,  #: 16 bit int
-    'paInt8': pyaudio.paInt8,    #: 8 bit int
-    'paUInt8': pyaudio.paUInt8,  #: 8 bit unsigned int
-    'paCustomFormat': pyaudio.paCustomFormat,  #: a custom data format
-}
+# constant retrieved from this dictionary. Lazy: only populated when pyaudio
+# is installed; the mock subclass doesn't consult this map.
+if _HAS_PYAUDIO:
+    SAMPLE_FORMATS = {
+        'paFloat32': pyaudio.paFloat32,  # 32 bit float
+        'paInt32': pyaudio.paInt32,      # 32 bit int
+        'paInt24': pyaudio.paInt24,      # 24 bit int
+        'paInt16': pyaudio.paInt16,      # 16 bit int
+        'paInt8': pyaudio.paInt8,        # 8 bit int
+        'paUInt8': pyaudio.paUInt8,      # 8 bit unsigned int
+        'paCustomFormat': pyaudio.paCustomFormat,  # a custom data format
+    }
+else:
+    SAMPLE_FORMATS = {}
 
 
 class MicStream(Device):
@@ -57,11 +84,15 @@ class MicStream(Device):
         self.fps = sensor.sample_rate
         self.save_on_disk = save_on_disk
         self.channels = sensor.channels
-        self.format = SAMPLE_FORMATS[sensor.format]
+        # ``SAMPLE_FORMATS`` is empty when pyaudio isn't installed; fall back
+        # to ``None`` so __init__ doesn't raise on hardware-less laptops.
+        # The real ``connect()`` path will fail loudly via ``_require_pyaudio``;
+        # the mock subclass doesn't use ``self.format``.
+        self.format = SAMPLE_FORMATS.get(sensor.format)
         self._sensor = sensor
 
         # Will be initialized in connect()
-        self.p: Optional[pyaudio.PyAudio] = None
+        self.p = None  # pyaudio.PyAudio when real
         self.stream_in = None
         self.outlet_audio: Optional[StreamOutlet] = None
 
@@ -71,14 +102,25 @@ class MicStream(Device):
 
     def connect(self) -> None:
         """Create the audio stream, LSL outlet, and notify the control server."""
-        # Create audio object
+        self.last_time = local_clock()
+        self._acquire_audio_stream()
+        self._publish_outlet()
+        self.state = DeviceState.CONNECTED
+
+    def _acquire_audio_stream(self) -> None:
+        """Open the pyaudio device-input stream.
+
+        Subclass hook: ``MockMicStream`` overrides to skip pyaudio entirely.
+        """
+        _require_pyaudio()
         audio = pyaudio.PyAudio()
         self.p = audio
-        self.last_time = local_clock()
 
         # Identify the correct device
-        device = MicStream.find_matching_audio_device(self._device_args, MicStream.get_audio_devices(audio))
-        self.logger.debug(f'Using audio device "{device.name}" at index {device.index}.')
+        device = MicStream.find_matching_audio_device(
+            self._device_args, MicStream.get_audio_devices(audio))
+        self.logger.debug(
+            f'Using audio device "{device.name}" at index {device.index}.')
         self.device_name = device.name
 
         # Create stream
@@ -91,6 +133,9 @@ class MicStream(Device):
             frames_per_buffer=self._sensor.sample_chunk_size,
             input_device_index=device.index,
         )
+
+    def _publish_outlet(self) -> None:
+        """Build the LSL outlet and post DeviceInitialization. Subclasses should not need to override."""
 
         # Setup outlet stream infos
         self._stream_info_audio = set_stream_description(
@@ -121,7 +166,6 @@ class MicStream(Device):
         )
 
         self.outlet_audio = StreamOutlet(self._stream_info_audio)
-        self.state = DeviceState.CONNECTED
 
     @staticmethod
     def get_audio_devices(audio: pyaudio.PyAudio, host_api_idx: int = 0) -> List[AudioDeviceInfo]:

--- a/neurobooth_os/iout/mock/mock_flir.py
+++ b/neurobooth_os/iout/mock/mock_flir.py
@@ -1,0 +1,150 @@
+"""Synthetic FLIR camera that writes a real video file without PySpin.
+
+Overrides the PySpin-touching hooks on :class:`VidRec_Flir`:
+
+- ``get_cam`` / ``setup_cam`` — no-ops; install a stub ``self.cam`` so
+  inherited methods that reach into ``self.cam`` (record-loop teardown,
+  ``close``) don't ``AttributeError``.
+- ``imgage_proc`` — returns a synthetic ndarray frame plus a
+  monotonic-ish timestamp, in place of ``self.cam.GetNextImage`` +
+  ``cv2.demosaicing``.
+- ``_prepare_recording`` — skips ``self.cam.BeginAcquisition`` /
+  ``AcquisitionResultingFrameRate`` and uses the configured FPS to set
+  up the ``cv2.VideoWriter``.
+- ``frame_preview`` — skips ``BeginAcquisition`` / ``EndAcquisition``.
+- ``close`` — skips ``self.cam.DeInit``.
+
+The synthetic record loop pushes black frames at ``device_args.sample_rate()``
+through the existing ``camCaptureVid`` save thread, so a real (small)
+.avi file is produced at the requested path — downstream
+file-cataloguing finds a non-empty file at the expected location.
+"""
+
+from __future__ import annotations
+
+import os.path as op
+import threading
+import time
+from typing import Any, ByteString, List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.flir_cam import VidRec_Flir
+
+
+# Synthetic frame size: small enough that the mock video file stays
+# small even over a long task, large enough that downstream tooling
+# that opens the .avi finds non-degenerate dimensions.
+_MOCK_FRAME_WIDTH = 320
+_MOCK_FRAME_HEIGHT = 240
+
+
+class _MockCamStub:
+    """Stand-in for the ``self.cam`` PySpin object on inherited paths.
+
+    The real ``record()`` loop calls ``self.cam.EndAcquisition()`` in its
+    ``finally`` clause; the inherited ``close()`` calls ``DeInit``.
+    Stubbing both as no-ops keeps inherited code paths working without
+    overriding them in the mock.
+    """
+
+    def BeginAcquisition(self) -> None:  # noqa: N802 — match PySpin casing
+        return None
+
+    def EndAcquisition(self) -> None:  # noqa: N802
+        return None
+
+    def DeInit(self) -> None:  # noqa: N802
+        return None
+
+    def AcquisitionResultingFrameRate(self) -> float:  # noqa: N802
+        # Real method returns the actual frame rate the camera achieves;
+        # mock just reports the configured target.
+        return 60.0
+
+
+class MockVidRec_Flir(VidRec_Flir):  # noqa: N801 — match real class casing
+    """Mock FLIR camera that writes synthetic video frames at sample_rate."""
+
+    def __init__(self, device_args, **kwargs) -> None:
+        super().__init__(device_args, **kwargs)
+        self._mock_frame_counter = 0
+
+    def get_cam(self) -> None:
+        self.system = None
+        self.cam = _MockCamStub()
+        self.logger.info("MockVidRec_Flir: skipped PySpin camera acquire")
+
+    def setup_cam(self) -> None:
+        self.open = True
+        self.logger.info("MockVidRec_Flir: skipped PySpin camera setup")
+
+    def imgage_proc(self) -> Tuple[np.ndarray, int]:  # noqa: N802 — match real spelling
+        self._mock_frame_counter += 1
+        # Black frame; downstream code only inspects shape / file
+        # existence, not pixel content.
+        frame = np.zeros(
+            (_MOCK_FRAME_HEIGHT, _MOCK_FRAME_WIDTH, 3), dtype=np.uint8)
+        # FLIR timestamps are nanoseconds; multiply local clock to mimic.
+        tsmp = int(time.time() * 1e9)
+        # The real method applies self.fd (frame-decimation) via
+        # cv2.resize; preserve that so frame size matches user
+        # expectations on downstream paths.
+        return cv2.resize(frame, None, fx=self.fd, fy=self.fd), tsmp
+
+    def _prepare_recording(self, name: str = "temp_video") -> None:
+        # Skip BeginAcquisition; build the writer directly.
+        im, _ = self.imgage_proc()
+        self.frameSize = (im.shape[1], im.shape[0])
+        self.video_filename = f"{name}_flir.avi"
+        fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+        self.FRAME_RATE_OUT = float(self.device_args.sample_rate())
+        self.video_out = cv2.VideoWriter(
+            self.video_filename, fourcc, self.FRAME_RATE_OUT, self.frameSize)
+        self.streaming = True
+
+    def record(self) -> None:
+        """Synthetic record loop: emit black frames at sample_rate FPS."""
+        self.logger.debug("MockVidRec_Flir: synthetic record loop started")
+        self.recording = True
+        self.frame_counter = 0
+        self.save_thread = threading.Thread(target=self.camCaptureVid)
+        self.save_thread.start()
+
+        period = 1.0 / float(self.device_args.sample_rate())
+        self.stamp: List[int] = []
+        try:
+            while self.recording:
+                im, tsmp = self.imgage_proc()
+                self.image_queue.put(im)
+                self.stamp.append(tsmp)
+                try:
+                    self.outlet.push_sample([self.frame_counter, tsmp])
+                except BaseException:
+                    self.logger.debug(
+                        "MockVidRec_Flir: reopening LSL outlet (was closed)")
+                    self._create_outlet()
+                    self.outlet.push_sample([self.frame_counter, tsmp])
+                self.frame_counter += 1
+                time.sleep(period)
+        except Exception:
+            self.logger.exception(
+                "MockVidRec_Flir: synthetic record loop error")
+        finally:
+            self.recording = False
+            self.save_thread.join()
+            self.video_out.release()
+            self.logger.debug(
+                "MockVidRec_Flir: synthetic record loop exited; video written")
+
+    def frame_preview(self) -> ByteString:
+        img, _ = self.imgage_proc()
+        rc, encoded = cv2.imencode(".png", img)
+        return encoded.tobytes() if rc else b""
+
+    def close(self) -> None:
+        self.stop()
+        self.open = False
+        self.state = DeviceState.DISCONNECTED

--- a/neurobooth_os/iout/mock/mock_intel.py
+++ b/neurobooth_os/iout/mock/mock_intel.py
@@ -1,0 +1,116 @@
+"""Synthetic Intel RealSense camera without pyrealsense2.
+
+Overrides the pyrealsense2-touching hooks on :class:`VidRec_Intel`:
+
+- ``_configure_pipeline`` — no-op (skips the ``rs.config`` /
+  ``rs.pipeline`` setup that the real ``__init__`` runs).
+- ``_prepare_recording`` — skips ``self.config.enable_record_to_file``;
+  records the video filename so ``stop()`` can produce a stub file.
+- ``record`` — synthetic frame loop pushes LSL samples at the configured
+  RGB sample rate without ever touching ``self.pipeline``.
+- ``close`` — skips ``self.config = []`` cleanup that's specific to the
+  rs.config object.
+
+After ``stop()``, a small placeholder ``.bag`` file is written at the
+expected path so downstream file-cataloguing doesn't choke on a missing
+file. The file is **not** a valid RealSense bag — anything that opens
+and parses it will fail.
+"""
+
+from __future__ import annotations
+
+import os.path as op
+import threading
+import time
+from time import time as wall_time
+from typing import List, Optional
+
+from pylsl import local_clock
+
+from neurobooth_os.iout.camera_intel import VidRec_Intel
+from neurobooth_os.iout.device import DeviceState
+
+
+# Placeholder bytes written to the .bag path on stop(). Real bag files
+# are binary RealSense capture archives; the mock only needs the path
+# to exist so log_sensor_file rows reference a real file.
+_STUB_BAG_BYTES = b"MOCK_REALSENSE_BAG_PLACEHOLDER\n"
+
+
+class MockVidRec_Intel(VidRec_Intel):  # noqa: N801 — match real class casing
+    """Mock RealSense camera that emits synthetic LSL samples."""
+
+    def _configure_pipeline(self) -> None:
+        # Skip the rs.config / rs.pipeline setup. Inherited code that
+        # references ``self.config`` / ``self.pipeline`` is overridden
+        # below, so we don't need stubs.
+        self.config = None
+        self.pipeline = None
+        self.logger.info(
+            f"MockVidRec_Intel [{self.device_index}]: skipped pyrealsense2 "
+            f"pipeline configuration (no hardware)")
+
+    def _prepare_recording(self, name: str) -> None:
+        self.name = name
+        self.video_filename = f"{name}_intel{self.device_index}.bag"
+        # Real path: self.config.enable_record_to_file(self.video_filename).
+        # Mock: defer file creation until stop() — see ``_write_stub_bag``.
+
+    def record(self) -> None:
+        """Emit synthetic 4-column samples at the configured RGB sample rate."""
+        self.frame_counter = 1
+        self.logger.debug(
+            f"MockVidRec_Intel [{self.device_index}]: synthetic record loop")
+        self.toffset = wall_time() - local_clock()
+
+        rate_hz = float(self.device_args.sample_rate()[0])
+        period = 1.0 / max(rate_hz, 1.0)
+
+        try:
+            while self.recording.is_set():
+                self.n = self.frame_counter
+                # Match real timestamp shape: pyrealsense2 timestamps are
+                # in milliseconds.
+                self.tsmp = wall_time() * 1000.0
+                try:
+                    self.outlet.push_sample(
+                        [self.frame_counter, self.n, self.tsmp, wall_time()])
+                except Exception as e:
+                    self.logger.warning(
+                        f"MockVidRec_Intel [{self.device_index}]: "
+                        f"reopening closed stream: {e}")
+                    self.outlet = self._recreate_outlet()
+                    self.outlet.push_sample(
+                        [self.frame_counter, self.n, self.tsmp, wall_time()])
+                self.frame_counter += 1
+                time.sleep(period)
+        except Exception:
+            self.logger.exception(
+                f"MockVidRec_Intel [{self.device_index}]: synthetic record "
+                "loop error")
+        finally:
+            self._write_stub_bag()
+            self.record_stopped_flag.set()
+            self.logger.debug(
+                f"MockVidRec_Intel [{self.device_index}]: synthetic record "
+                "loop exited; stub .bag written")
+
+    def _write_stub_bag(self) -> None:
+        if self.video_filename is None:
+            return
+        try:
+            with open(self.video_filename, "wb") as fh:
+                fh.write(_STUB_BAG_BYTES)
+            self.logger.info(
+                f"MockVidRec_Intel [{self.device_index}]: wrote stub .bag at "
+                f"{self.video_filename}")
+        except OSError as e:
+            self.logger.warning(
+                f"MockVidRec_Intel [{self.device_index}]: could not write stub "
+                f".bag at {self.video_filename}: {e}")
+
+    def close(self) -> None:
+        self.previewing = False
+        self.stop()
+        # Real path sets self.config = []; mock has self.config already None.
+        self.state = DeviceState.DISCONNECTED

--- a/neurobooth_os/iout/mock/mock_microphone.py
+++ b/neurobooth_os/iout/mock/mock_microphone.py
@@ -1,0 +1,67 @@
+"""Synthetic microphone that emits LSL audio chunks without pyaudio.
+
+Overrides the single hardware hook on :class:`MicStream`
+(``_acquire_audio_stream``) plus the streaming method (``stream``) and
+the lifecycle methods that touch pyaudio (``stop``, ``disconnect``).
+
+Synthetic samples are produced by a daemon thread that pushes
+constant-zero int16 chunks at the configured ``sample_rate /
+sample_chunk_size`` rate.  Downstream code only needs the LSL stream
+shape and cadence, not realistic audio.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import List, Optional
+
+import numpy as np
+from pylsl import local_clock
+
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.microphone import MicStream
+
+
+class MockMicStream(MicStream):
+    """Mock microphone that emits zero-filled audio chunks on a daemon thread."""
+
+    def _acquire_audio_stream(self) -> None:
+        # Skip pyaudio device enumeration and stream open. Inherited
+        # ``connect()`` continues to ``_publish_outlet()`` after this.
+        self.device_name = f"MockMicrophone-{self._device_args.microphone_name}"
+        self.logger.info(
+            f"MockMicStream: skipped pyaudio acquire (no hardware); "
+            f"reporting device_name={self.device_name}")
+
+    def stream(self) -> None:
+        """Emit zero-filled int16 chunks at the configured chunk rate."""
+        chunk_period = float(self.CHUNK) / float(self.fps)
+        zero_chunk = np.zeros(self.CHUNK, dtype="int16")
+        self.last_time = int(local_clock() * 10e3)
+        self.logger.debug("MockMicStream: entering synthetic stream loop")
+        try:
+            while self.streaming:
+                tlocal = int(local_clock() * 10e3)
+                tdiff = tlocal - self.last_time
+                self.last_time = tlocal
+                payload = np.hstack((np.array(tdiff), zero_chunk))
+                try:
+                    self.outlet_audio.push_sample(payload)
+                except BaseException:
+                    # Match the real stream's recover-on-closed-outlet behaviour.
+                    self.logger.debug(
+                        "MockMicStream: reopening LSL outlet (was closed)")
+                    from pylsl import StreamOutlet
+                    self.outlet_audio = StreamOutlet(self._stream_info_audio)
+                    self.outlet_audio.push_sample(payload)
+                # Wait a chunk's worth of wall-clock time before the next
+                # synthetic chunk so the LSL cadence matches the real path.
+                time.sleep(chunk_period)
+        finally:
+            self.stream_on = False
+            self.logger.debug("MockMicStream: exiting synthetic stream loop")
+
+    def disconnect(self) -> None:
+        """Skip pyaudio teardown; mock has no native handles to release."""
+        self.state = DeviceState.DISCONNECTED

--- a/neurobooth_os/iout/stim_param_reader.py
+++ b/neurobooth_os/iout/stim_param_reader.py
@@ -190,6 +190,15 @@ class MicYetiDeviceArgs(DeviceArgs):
         return MicStream
 
 
+class MockMicYetiDeviceArgs(MicYetiDeviceArgs):
+    """DeviceArgs for :class:`MockMicStream` — same fields, different device class."""
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_microphone import MockMicStream
+        return MockMicStream
+
+
 class EyelinkDeviceArgs(DeviceArgs):
     """
     Eyelink device arguments
@@ -344,6 +353,15 @@ class FlirDeviceArgs(DeviceArgs):
         return VidRec_Flir
 
 
+class MockFlirDeviceArgs(FlirDeviceArgs):
+    """DeviceArgs for :class:`MockVidRec_Flir` — same fields, different device class."""
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_flir import MockVidRec_Flir
+        return MockVidRec_Flir
+
+
 class IntelDeviceArgs(DeviceArgs):
 
     # Attributes required for program execution
@@ -396,6 +414,15 @@ class IntelDeviceArgs(DeviceArgs):
     def device_class(cls) -> Type["Device"]:
         from neurobooth_os.iout.camera_intel import VidRec_Intel
         return VidRec_Intel
+
+
+class MockIntelDeviceArgs(IntelDeviceArgs):
+    """DeviceArgs for :class:`MockVidRec_Intel` — same fields, different device class."""
+
+    @classmethod
+    def device_class(cls) -> Type["Device"]:
+        from neurobooth_os.iout.mock.mock_intel import MockVidRec_Intel
+        return MockVidRec_Intel
 
 
 class WebcamDeviceArgs(DeviceArgs):
@@ -744,3 +771,6 @@ from neurobooth_os.iout.mock_substitution import register_mock  # noqa: E402
 register_mock(MbientDeviceArgs, MockMbientDeviceArgs)
 register_mock(IPhoneDeviceArgs, MockIPhoneDeviceArgs)
 register_mock(EyelinkDeviceArgs, MockEyelinkDeviceArgs)
+register_mock(MicYetiDeviceArgs, MockMicYetiDeviceArgs)
+register_mock(FlirDeviceArgs, MockFlirDeviceArgs)
+register_mock(IntelDeviceArgs, MockIntelDeviceArgs)

--- a/tests/pytest/test_mock_flir.py
+++ b/tests/pytest/test_mock_flir.py
@@ -1,0 +1,128 @@
+"""Lifecycle tests for the synthetic FLIR mock.
+
+Exercise ``MockVidRec_Flir`` end-to-end without ``PySpin`` installed.
+"""
+
+import os
+import time
+
+import pytest
+
+from neurobooth_os.iout import flir_cam as flir_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_flir import MockVidRec_Flir
+from neurobooth_os.iout.stim_param_reader import (
+    FlirDeviceArgs,
+    FlirSensorArgs,
+    MockFlirDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 60
+RECORDING_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockFlirDeviceArgs:
+    sensor = FlirSensorArgs.model_construct(
+        sensor_id="flir_sens_1",
+        sample_rate=SAMPLE_RATE_HZ,
+        width_px=1024,
+        height_px=768,
+        offsetX=0,
+        offsetY=0,
+        exposure=4000,
+        gain=10,
+        gamma=1.0,
+        fd=1,
+    )
+    return MockFlirDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="FLIR_dev_1",
+        sensor_ids=["flir_sens_1"],
+        sensor_array=[sensor],
+        device_sn="MOCK_SN_1234",
+        arg_parser="iout.stim_param_reader.py::MockFlirDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockFlirDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _silence_messaging(monkeypatch):
+    """Silence ``post_message`` so tests don't need a database.
+
+    FLIR uses ``meta.post_message`` (the meta module) not a local import,
+    so we patch the module-level reference there.
+    """
+    from neurobooth_os.iout import metadator as meta_mod
+    monkeypatch.setattr(meta_mod, "post_message", lambda msg: None)
+
+
+class TestMockVidRecFlirLifecycle:
+
+    def test_connect_lands_in_connected(self, mock_args):
+        device = MockVidRec_Flir(device_args=mock_args)
+        try:
+            device.connect()
+            assert device.state == DeviceState.CONNECTED
+            assert device.outlet is not None
+            assert device.cam is not None
+            assert device.open is True
+        finally:
+            device.close()
+
+    def test_start_stop_writes_video(self, mock_args, tmp_path):
+        device = MockVidRec_Flir(device_args=mock_args)
+        try:
+            device.connect()
+            video_basename = str(tmp_path / "task_a")
+            files = device.start(video_basename)
+            assert files == ["task_a_flir.avi"]
+            assert device.streaming is True
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+            video_path = str(tmp_path / "task_a_flir.avi")
+            assert os.path.exists(video_path)
+            assert os.path.getsize(video_path) > 0
+        finally:
+            device.close()
+
+    def test_frame_preview_returns_png_bytes(self, mock_args):
+        device = MockVidRec_Flir(device_args=mock_args)
+        try:
+            device.connect()
+            preview = device.frame_preview()
+            assert isinstance(preview, bytes)
+            assert len(preview) > 0
+            # cv2.imencode produces a real PNG; check the magic bytes.
+            assert preview[:8] == b"\x89PNG\r\n\x1a\n"
+        finally:
+            device.close()
+
+
+class TestMockVidRecFlirRegistration:
+
+    def test_mock_flir_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(FlirDeviceArgs) is MockFlirDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockFlirDeviceArgs.device_class() is MockVidRec_Flir
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = FlirDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="FLIR_dev_1",
+            sensor_ids=["flir_sens_1"],
+            device_sn="REAL_SN",
+            sensor_array=[],
+            arg_parser="iout.stim_param_reader.py::FlirDeviceArgs()",
+        )
+        result = apply_mock_substitution(real, active={"VidRec_Flir"})
+        assert isinstance(result, MockFlirDeviceArgs)
+        assert result.device_sn == "REAL_SN"

--- a/tests/pytest/test_mock_intel.py
+++ b/tests/pytest/test_mock_intel.py
@@ -1,0 +1,149 @@
+"""Lifecycle tests for the synthetic Intel RealSense mock.
+
+Exercise ``MockVidRec_Intel`` end-to-end without ``pyrealsense2`` installed.
+"""
+
+import os
+import time
+
+import pytest
+
+from neurobooth_os.iout import camera_intel as intel_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_intel import (
+    _STUB_BAG_BYTES,
+    MockVidRec_Intel,
+)
+from neurobooth_os.iout.stim_param_reader import (
+    IntelDeviceArgs,
+    IntelSensorArgs,
+    MockIntelDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 30
+RECORDING_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockIntelDeviceArgs:
+    rgb_sensor = IntelSensorArgs.model_construct(
+        sensor_id="intel_rgb_sens",
+        sample_rate=SAMPLE_RATE_HZ,
+        width_px=640,
+        height_px=480,
+    )
+    depth_sensor = IntelSensorArgs.model_construct(
+        sensor_id="intel_depth_sens",
+        sample_rate=SAMPLE_RATE_HZ,
+        width_px=640,
+        height_px=480,
+    )
+    return MockIntelDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="Intel_dev_1",
+        sensor_ids=["intel_rgb_sens", "intel_depth_sens"],
+        sensor_array=[rgb_sensor, depth_sensor],
+        device_sn="MOCK_INTEL_SN",
+        auto_exposure_priority=0.0,
+        arg_parser="iout.stim_param_reader.py::MockIntelDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockIntelDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _silence_messaging(monkeypatch):
+    """Silence ``meta.post_message`` so tests don't need a database."""
+    from neurobooth_os.iout import metadator as meta_mod
+    monkeypatch.setattr(meta_mod, "post_message", lambda msg: None)
+
+
+class TestMockVidRecIntelLifecycle:
+
+    def test_construct_skips_pyrealsense2(self, mock_args):
+        device = MockVidRec_Intel(device_args=mock_args)
+        # _configure_pipeline overridden — these stay None on the mock.
+        assert device.config is None
+        assert device.pipeline is None
+        device.close()
+
+    def test_connect_lands_in_connected(self, mock_args):
+        device = MockVidRec_Intel(device_args=mock_args)
+        try:
+            device.connect()
+            assert device.state == DeviceState.CONNECTED
+            assert device.outlet is not None
+        finally:
+            device.close()
+
+    def test_start_stop_writes_stub_bag(self, mock_args, tmp_path):
+        device = MockVidRec_Intel(device_args=mock_args)
+        try:
+            device.connect()
+            video_basename = str(tmp_path / "task_a")
+            files = device.start(video_basename)
+            assert files == ["task_a_intel1.bag"]
+            assert device.streaming is True
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+            bag_path = str(tmp_path / "task_a_intel1.bag")
+            assert os.path.exists(bag_path)
+            with open(bag_path, "rb") as fh:
+                assert fh.read() == _STUB_BAG_BYTES
+        finally:
+            device.close()
+
+    def test_close_after_recording(self, mock_args, tmp_path):
+        device = MockVidRec_Intel(device_args=mock_args)
+        device.connect()
+        device.start(str(tmp_path / "close_test"))
+        device.close()
+        assert device.state == DeviceState.DISCONNECTED
+
+
+class TestMockVidRecIntelLSLFlow:
+
+    def test_synthetic_samples_advance_frame_counter(self, mock_args, tmp_path):
+        device = MockVidRec_Intel(device_args=mock_args)
+        try:
+            device.connect()
+            device.start(str(tmp_path / "lsl_test"))
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            device.ensure_stopped(timeout_seconds=2)
+            # 30 FPS over 300ms is ~9 frames; allow generous floor for jitter.
+            assert device.frame_counter >= 3
+        finally:
+            device.close()
+
+
+class TestMockVidRecIntelRegistration:
+
+    def test_mock_intel_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(IntelDeviceArgs) is MockIntelDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockIntelDeviceArgs.device_class() is MockVidRec_Intel
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = IntelDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="Intel_dev_1",
+            sensor_ids=["intel_rgb_sens"],
+            sensor_array=[],
+            device_sn="REAL_INTEL_SN",
+            auto_exposure_priority=0.0,
+            arg_parser="iout.stim_param_reader.py::IntelDeviceArgs()",
+        )
+        # Real IntelDeviceArgs.__init__ would call rs.config() which would fail
+        # without pyrealsense2; substitution should produce a MockIntelDeviceArgs
+        # whose __init__ overrides mean it never touches rs.
+        result = apply_mock_substitution(real, active={"VidRec_Intel"})
+        assert isinstance(result, MockIntelDeviceArgs)
+        assert result.device_sn == "REAL_INTEL_SN"

--- a/tests/pytest/test_mock_microphone.py
+++ b/tests/pytest/test_mock_microphone.py
@@ -1,0 +1,113 @@
+"""Lifecycle tests for the synthetic microphone mock.
+
+Exercise ``MockMicStream`` end-to-end without ``pyaudio`` installed.
+"""
+
+import time
+
+import pytest
+
+from neurobooth_os.iout import microphone as mic_mod
+from neurobooth_os.iout.device import DeviceState
+from neurobooth_os.iout.mock.mock_microphone import MockMicStream
+from neurobooth_os.iout.stim_param_reader import (
+    MicYetiDeviceArgs,
+    MicYetiSensorArgs,
+    MockMicYetiDeviceArgs,
+)
+
+
+SAMPLE_RATE_HZ = 22050
+CHUNK_SIZE = 1024
+RECORDING_WINDOW_SEC = 0.3
+
+
+def _build_mock_args() -> MockMicYetiDeviceArgs:
+    sensor = MicYetiSensorArgs.model_construct(
+        sensor_id="mic_sens_1",
+        sample_rate=SAMPLE_RATE_HZ,
+        sample_chunk_size=CHUNK_SIZE,
+        input=True,
+        output=False,
+        channels=1,
+        format="paInt16",
+    )
+    return MockMicYetiDeviceArgs.model_construct(
+        ENV_devices={},
+        device_id="Mic_Yeti_dev_1",
+        sensor_ids=["mic_sens_1"],
+        sensor_array=[sensor],
+        microphone_name="MockYeti",
+        device_name="MockYeti",
+        arg_parser="iout.stim_param_reader.py::MockMicYetiDeviceArgs()",
+    )
+
+
+@pytest.fixture
+def mock_args() -> MockMicYetiDeviceArgs:
+    return _build_mock_args()
+
+
+@pytest.fixture(autouse=True)
+def _silence_messaging(monkeypatch):
+    """Silence ``post_message`` so tests don't need a database."""
+    monkeypatch.setattr(mic_mod, "post_message", lambda msg: None)
+
+
+class TestMockMicStreamLifecycle:
+
+    def test_connect_lands_in_connected(self, mock_args):
+        device = MockMicStream(device_args=mock_args)
+        try:
+            device.connect()
+            assert device.state == DeviceState.CONNECTED
+            assert device.outlet_audio is not None
+            assert device.device_name.startswith("MockMicrophone-")
+        finally:
+            device.close()
+
+    def test_start_stop_cycle(self, mock_args):
+        device = MockMicStream(device_args=mock_args)
+        try:
+            device.connect()
+            device.start()
+            assert device.streaming is True
+            assert device.state == DeviceState.STARTED
+            time.sleep(RECORDING_WINDOW_SEC)
+            device.stop()
+            assert device.streaming is False
+            assert device.state == DeviceState.STOPPED
+        finally:
+            device.close()
+
+    def test_close_after_recording(self, mock_args):
+        device = MockMicStream(device_args=mock_args)
+        device.connect()
+        device.start()
+        device.close()
+        assert device.streaming is False
+        assert device.state in (DeviceState.STOPPED, DeviceState.DISCONNECTED)
+
+
+class TestMockMicStreamRegistration:
+
+    def test_mock_microphone_is_registered(self):
+        from neurobooth_os.iout.mock_substitution import MOCK_REGISTRY
+        assert MOCK_REGISTRY.get(MicYetiDeviceArgs) is MockMicYetiDeviceArgs
+
+    def test_device_class_resolves_to_mock(self):
+        assert MockMicYetiDeviceArgs.device_class() is MockMicStream
+
+    def test_apply_substitution_swaps_class(self):
+        from neurobooth_os.iout.mock_substitution import apply_mock_substitution
+        real = MicYetiDeviceArgs.model_construct(
+            ENV_devices={},
+            device_id="Mic_Yeti_dev_1",
+            sensor_ids=["mic_sens_1"],
+            sensor_array=[],
+            microphone_name="Yeti",
+            arg_parser="iout.stim_param_reader.py::MicYetiDeviceArgs()",
+        )
+        result = apply_mock_substitution(real, active={"MicStream"})
+        assert isinstance(result, MockMicYetiDeviceArgs)
+        assert result.microphone_name == "Yeti"


### PR DESCRIPTION
## Summary

Extends the substitution + lazy-import + mock pattern from #737 to the three remaining hardware classes that mvp-30 and similar collections require. The laptop env can now run those collections end-to-end against `NB_MOCK_DEVICES=all` without `pyaudio`, `PySpin`, or `pyrealsense2` installed.

After this PR, six device classes have registered mocks (Mbient, IPhone, EyeTracker, MicStream, VidRec_Flir, VidRec_Intel). The only hardware-touching device class without a mock is `VidRec_Webcam`.

## Lazy hardware imports

- **`microphone.py`** — `pyaudio` import wrapped in `try/except` + `_require_pyaudio()` helper. `SAMPLE_FORMATS` is empty when pyaudio is absent; `__init__` uses `.get(...)` with a `None` fallback so the mock subclass doesn't trip on the format lookup. `_acquire_audio_stream()` extracted from `connect()` to give the mock a single hook to override.
- **`flir_cam.py`** — `PySpin` import wrapped in `try/except` + `_require_pyspin()` helper. Real `get_cam` and `setup_cam` are gated by `_require_pyspin()` so they fail loudly if invoked without the SDK.
- **`camera_intel.py`** — `pyrealsense2` import wrapped in `try/except` + `_require_pyrealsense2()` helper. The `rs.config` / `rs.pipeline` setup that real `__init__` runs is extracted into `_configure_pipeline()` so the mock can override that hook without re-implementing `__init__`.

## Mocks

- **`MockMicStream`** — skips pyaudio entirely; daemon thread pushes zero-filled int16 chunks at `sample_rate / sample_chunk_size`.
- **`MockVidRec_Flir`** — stubs `self.cam` to a no-op handle and emits black 320x240x3 frames at the configured FPS via `cv2.VideoWriter`. Produces a real (small) `.avi` file at the requested path. `frame_preview` returns a real 1-frame PNG.
- **`MockVidRec_Intel`** — skips pyrealsense2; daemon thread emits 4-column synthetic LSL samples at the configured RGB sample rate. On `stop()` writes a small placeholder `.bag` at the requested path so `log_sensor_file` finds the file (not a parseable RealSense bag).

All three mocks register at module-import time via `register_mock` calls at the bottom of `stim_param_reader.py`, alongside the existing three.

## Tests

- **6 tests** for `MockMicStream` (lifecycle + registry round-trip)
- **6 tests** for `MockVidRec_Flir` (lifecycle + `.avi` production + `frame_preview` returns valid PNG)
- **8 tests** for `MockVidRec_Intel` (lifecycle + stub `.bag` write + synthetic LSL samples + registry round-trip)

20 new tests; all pass on a hardware-less laptop without pyaudio / PySpin / pyrealsense2 installed.

## Production-impact summary

**Zero behaviour change when no mocks are configured.** The substitution mechanism from #737 is unchanged — the `if active_mocks:` gate still skips everything for production envs. New per-device changes for actual hardware:

- `microphone.py`: `_acquire_audio_stream()` extraction (mechanical), `__init__` uses `SAMPLE_FORMATS.get` instead of `[]` (changes the failure mode if pyaudio is somehow missing on a real-mic install — was `KeyError` immediately, now `AttributeError` later inside `connect`).
- `flir_cam.py`: `_require_pyspin()` calls in `get_cam` and `setup_cam` (one boolean check each if PySpin installed).
- `camera_intel.py`: `_configure_pipeline()` extraction from `__init__` (mechanical; `__init__` calls it immediately).

## Docs

`docs/testing_with_mocks.md` — table expanded to six rows, new per-mock "what it produces" entries, the "What is *not* mocked" section now lists only `VidRec_Webcam`. mvp-30 specifically called out as fully runnable against `NB_MOCK_DEVICES=all` after this PR.

## Test plan

- [x] `pytest tests/pytest/test_mock_microphone.py` → 6 passed
- [x] `pytest tests/pytest/test_mock_flir.py` → 6 passed
- [x] `pytest tests/pytest/test_mock_intel.py` → 8 passed
- [x] All three modules import cleanly with their SDKs simulated absent (verified via `sys.modules` blocking)
- [x] Existing mock test files (Mbient, IPhone, EyeTracker, substitution) still pass
- [ ] Smoke test on the laptop env with `NB_MOCK_DEVICES=all` and an mvp-30-style collection — manual

## Note on the test environment

`pytest` over the full suite intermittently segfaults at process shutdown on Windows after C-extension teardown (pyrealsense2/pyaudio/pylsl). This is pre-existing on master, not a regression from this PR. Running test files individually completes cleanly. The 20 new tests in this PR all pass when invoked per-file.