### PR TITLE
Auto-focus the Subject ID input on GUI startup

### DIFF
--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -42,6 +42,7 @@ def _init_layout(conn, exclusion=None):
                 size=(44, 1),
                 background_color="white",
                 text_color="black",
+                focus=True,
             ),
         ],
         [_space()],


### PR DESCRIPTION
## Summary

The Subject ID input on the initial layout previously required an explicit click before typing. PySimpleGUI's `Input` element accepts `focus=True` to claim initial keyboard focus when the window opens, so operators can start typing the subject ID immediately without reaching for the mouse.

## Change

```diff
 sg.Input(
     key="subject_id",
     size=(44, 1),
     background_color="white",
     text_color="black",
+    focus=True,
 ),
```

The change is localized to `_init_layout` in `layouts.py`; subsequent layouts (after a subject is selected) are unaffected.

## Test plan

- [ ] Open the GUI; confirm the Subject ID field has the cursor before any click.
- [ ] Type a subject ID immediately after the window appears; confirm characters land in the field.
- [ ] Tab key moves focus to the next element (Find subject button) as before.