### PR TITLE
Bound DSC._wait_release with a timeout to prevent task wedge

### DIFF
--- a/neurobooth_os/tasks/DSC.py
+++ b/neurobooth_os/tasks/DSC.py
@@ -195,12 +195,37 @@ class DSC(Task_Eyetracker):
         #     )
         self.io.quit()
 
-    def _wait_release(self, keys=None):
-        while True:
+    def _wait_release(self, keys=None, timeout_s: float = 2.0):
+        """Wait for a key-release event, with a bounded fallback.
+
+        PsychoPy's keyboard backend occasionally drops the release event for
+        a key whose press was registered (observed under heavy camera /
+        LSL load). Without a timeout, ``_wait_release`` hangs the task
+        thread forever and the task runs past its ``tot_time`` budget —
+        the busy-cursor symptom seen in long DSC_obs sessions on the
+        staging machine.
+
+        :param keys: keys to wait for; passed through to ``getReleases``.
+        :param timeout_s: maximum wall-clock seconds to wait before
+            giving up and returning an empty list. Two seconds is well
+            above any realistic finger-up latency but short enough that
+            a missed release doesn't blow the trial budget.
+        :returns: the list returned by ``getReleases`` once non-empty,
+            or ``[]`` if ``timeout_s`` elapses first.
+        """
+        deadline = core.CountdownTimer(timeout_s)
+        while deadline.getTime() > 0:
             rels = self.keyboard.getReleases(keys=keys)
             if len(rels):
                 return rels
             utils.countdown(0.001)
+        # Timed out — log so the dropped-release pattern is visible in
+        # session logs without manual instrumentation.
+        print(
+            f"DSC: _wait_release timed out after {timeout_s:g}s "
+            f"(keys={keys}); proceeding with empty release set"
+        )
+        return []
 
     def _my_textbox2(self, text, pos=(0, 0)):
         tbx = TextBox2(


### PR DESCRIPTION
## Summary

`DSC._wait_release` was an unbounded `while True` polling `self.keyboard.getReleases`. Under heavy camera / LSL streaming load (multiple Intel + FLIR cameras + Mbients + iPhone + EyeLink), PsychoPy's keyboard backend occasionally drops the release event for a key whose press was registered. Without a timeout, the task's main thread hangs in the inner polling loop — preventing both the trial's `count_down` and the test's outer `tot_time` budget from being re-checked, since both are evaluated only on the next iteration of the trial loop.

Symptom: PsychoPy window unresponsive (Windows busy-cursor), task runs past its scheduled duration, only un-sticks when something external breaks the wedge.

Observed live in a staging session on 2026-04-27 — DSC_obs ran well past `tot_time`, only ended when the operator pressed Terminate Servers, which closed LabRecorder and incidentally let the dropped release land.

## Change

```python
-def _wait_release(self, keys=None):
-    while True:
+def _wait_release(self, keys=None, timeout_s: float = 2.0):
+    """Wait for a key-release event, with a bounded fallback. ..."""
+    deadline = core.CountdownTimer(timeout_s)
+    while deadline.getTime() > 0:
         rels = self.keyboard.getReleases(keys=keys)
         if len(rels):
             return rels
         utils.countdown(0.001)
+    print(f"DSC: _wait_release timed out after {timeout_s:g}s ...")
+    return []
```

`timeout_s=2.0` is well above any plausible finger-up latency, short enough that a dropped release doesn't blow the trial budget. The single call site at `DSC._execute_frame:405` assigns the return value but never reads it, so returning `[]` on timeout is a transparent no-op for trial logic.

The print on timeout makes the dropped-release pattern visible in session logs without manual instrumentation — useful for confirming whether this fires often enough on staging to warrant a deeper fix in PsychoPy's keyboard handling.

## Test plan

- [ ] Re-run a DSC_obs session under the same camera load that produced the wedge; confirm task ends within its scheduled duration regardless of whether the keyboard backend drops a release.
- [ ] If the print fires, that's a real signal that PsychoPy is dropping events and the underlying issue is worth investigating separately (LSL contention, pyglet event-queue overflow, etc.).