### PR TITLE
Drop stale __version__ from __init__.py; setup.py reads current_config.py

### DIFF
--- a/docs/release process.md
+++ b/docs/release process.md
@@ -7,14 +7,9 @@ The goals for this process are:
 3. To make it easier to determine what code modifications are in each environment, and whether issues identified in one environment are likely to affect another. 
 
 This process uses GitHub's release support. In this model, a release is a bundle of code with a name and a git tag. By convention, the release name and tag are the same.
-The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. In code, the name is stored in a `__version__` attribute in a way that is consistent with Python package naming standards. 
-Specifically, the `__init__.py` module in the neurobooth-os folder holds the attribute.  
+The release name also appears in the deployed code so anyone looking at the environment can tell what version is deployed. In source, `neurobooth_os/current_config.py` holds the version inside a `version = ...` assignment. The file is marked as a generated file; the deployment scripts (`configs/checkout_and_deploy.bat` / `configs/version.bat`) overwrite the assignment with the real release tag at deploy time. A plain master checkout reads the sentinel `'NO VERSION SET'`.
 
-Keeping the version name in the code in sync with the release is a key part of the process:
-- When release 0.0.4 is in development, `__version__ = "v0.0.4"`
-- When the release has been created, `__version__` is incremented: `__version__ = "0.0.5"`. 
-
-(At some point this version name shuffling can be automated.)
+Because deploy stamps the version in, **the source value is never edited by hand**. There is no pre-release version-bump commit and no post-release increment — release numbering is driven entirely by git tags + GitHub releases.
 
 Release numbering should generally follow [Semantic Versioning guidelines](https://semver.org/). Until/unless we plan to publish a release to a public index server, development release names can be used. A development release name consists of the normal three-part numbering system with ".devN" appended. 
 
@@ -24,12 +19,10 @@ The process:
 
 Development is performed on feature branches as usual. When complete, feature branches are merged into master. Frequent merges of small branches simplifies coordination between developers and makes it easier to review code. The rest of the process is as follows:
 
-1. Make sure that the committed `__version__` in neurobooth_os matches the planned release name.
-4. Create a candidate release in GitHub, ensuring that it is marked as "pre-release". This tags the code in the release to the current state in the git history.
-5. Increment the version in `__init__.py`, and commit the changes so developers can begin working on the next version.
-6. Deploy the candidate release into staging and complete testing 
-6. Publish the release in GitHub 
-7. Deploy the published release into production environment(s). 
+1. Create a candidate release in GitHub against master HEAD, ensuring that it is marked as "pre-release". This tags the code in the release to the current state in the git history. Do **not** edit `current_config.py` first — deploy will stamp it.
+2. Deploy the candidate release into staging and complete testing.
+3. Publish the release in GitHub (remove the "pre-release" flag).
+4. Deploy the published release into production environment(s). 
  
 Checking out and deploying releases: 
 

--- a/neurobooth_os/__init__.py
+++ b/neurobooth_os/__init__.py
@@ -1,3 +1,1 @@
 """Neurobooth OS"""
-
-__version__ = "0.0.54.0"

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,13 @@ URL = ''
 LICENSE = 'BSD (3-clause)'
 DOWNLOAD_URL = 'https://github.com/neurobooth/neurobooth-os'
 
-# get the version
+# Get the version from neurobooth_os/current_config.py — that's the file
+# the deploy step (configs/version.bat) overwrites with the real release
+# tag. A plain source checkout reads the sentinel "NO VERSION SET".
 version = None
-with open(os.path.join('neurobooth_os', '__init__.py'), 'r') as fid:
+with open(os.path.join('neurobooth_os', 'current_config.py'), 'r') as fid:
     for line in (line.strip() for line in fid):
-        if line.startswith('__version__'):
+        if line.startswith('version'):
             version = line.split('=')[1].strip().strip('\'').strip('"')
             break
 if version is None:


### PR DESCRIPTION
## Summary

`neurobooth_os/__init__.py` carried `__version__ = "0.0.54.0"` — a leftover from the old release process where the version was meant to be bumped in source for each release. The actual deploy workflow has long since moved to `neurobooth_os/current_config.py`, which holds `version = 'NO VERSION SET'` as a sentinel that `configs/checkout_and_deploy.bat` overwrites at deploy time. The `__init__.py` value was 35 releases out of date and pointed nobody at the real source of truth.

## Changes

- **`neurobooth_os/__init__.py`** — drop the `__version__` line. The module still has its docstring; nothing else lived there.
- **`setup.py`** — text-scan reads `version` from `current_config.py` instead of `__version__` from `__init__.py`. Plain source checkout installs as version `"NO VERSION SET"`; a deployed copy installs as the real release tag — same as before, just sourced from the file the deploy step actually edits.
- **`docs/release process.md`** — rewrite to match the deploy-stamp workflow. Drop the "1. Make sure committed `__version__` matches the planned release name" and "5. Increment the version in `__init__.py`, and commit" steps, since `current_config.py` is generated at deploy time and never edited in source.

## Verification

- `import neurobooth_os` still succeeds (module is just a docstring now).
- The new `setup.py` text scan returns `"NO VERSION SET"` on master.
- No callers of `neurobooth_os.__version__` exist outside of `setup.py`'s text scan (verified by grep).

## Test plan

- [ ] `pip install -e .` from a fresh checkout — confirm install completes; the package shows version "NO VERSION SET" via `pip show neurobooth-os`.
- [ ] Run the deploy step on staging and confirm `current_config.py` is overwritten with the real release tag, and `pip show neurobooth-os` reflects that version.