### PR TITLE
Mock fidelity: labeled previews and calibration animation

### DIFF
--- a/neurobooth_os/iout/mock/mock_eyetracker.py
+++ b/neurobooth_os/iout/mock/mock_eyetracker.py
@@ -13,12 +13,14 @@ Overrides the four hardware hooks on :class:`EyeTracker`:
   Hz on a daemon thread.
 - ``_receive_data_file`` — writes a tiny stub ``.edf`` so file-cataloguing
   downstream of ``stop()`` doesn't choke on a missing path.
-- ``calibrate`` — no-op (the real path uses ``EyeLinkCoreGraphicsPsychoPy``
-  which transitively imports pylink).
+- ``calibrate`` — animates a 9-point fixation pattern (mock target dots)
+  in place of the real ``EyeLinkCoreGraphicsPsychoPy`` flow, which
+  transitively imports pylink. ESC skips the remainder.
 
 The mock assumes a real ``psychopy.visual.Window`` for live laptop
-sessions, but tolerates a duck-typed window in unit tests because none
-of the overridden methods draw to it.
+sessions, but tolerates a duck-typed window in unit tests: ``calibrate``
+gates its drawing on ``isinstance(self.win, visual.Window)`` so a
+``MagicMock`` window falls straight through to the lifecycle bookkeeping.
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ import threading
 import time
 from typing import Any, List, Optional, Tuple
 
+from psychopy import core, event, visual
 from pylsl import local_clock
 
 from neurobooth_os.iout.device import DeviceState
@@ -39,6 +42,18 @@ from neurobooth_os.msg.messages import DeviceInitialization, Request
 # format; downstream consumers (XDF split / log_sensor_file) only need
 # the file to exist at the expected path with non-zero length.
 _STUB_EDF_BYTES = b"MOCK_EDF_FILE_PLACEHOLDER\n"
+
+
+# Standard 9-point fixation pattern for the mock calibration animation,
+# expressed as fractions of the half-window in each axis (range -1..1).
+# Center first, then a ring of eight edge/corner points.
+_FIXATION_POINTS: Tuple[Tuple[float, float], ...] = (
+    (0.0, 0.0),
+    (-0.8, 0.8), (0.0, 0.8), (0.8, 0.8),
+    (-0.8, 0.0), (0.8, 0.0),
+    (-0.8, -0.8), (0.0, -0.8), (0.8, -0.8),
+)
+_POINT_DURATION_SEC = 0.4
 
 
 class _MockEyelinkHandle:
@@ -188,10 +203,55 @@ class MockEyeTracker(EyeTracker):
                 f"{self.filename}: {e}")
 
     def calibrate(self) -> None:
-        # Real path uses EyeLinkCoreGraphicsPsychoPy which transitively
-        # imports pylink. Mock skips the entire pylink dance.
-        self.logger.info("MockEyeTracker: calibration skipped")
+        """Animate a 9-point fixation pattern in place of real calibration.
+
+        The real path uses ``EyeLinkCoreGraphicsPsychoPy`` which transitively
+        imports ``pylink``; this mock walks a circle target through the
+        standard nine fixation positions so the GUI flow looks the same
+        end-to-end. ESC ends the animation early — the task still continues
+        because ``calibrated`` is set unconditionally, mirroring the real
+        flow where ESC inside ``doTrackerSetup`` returns control to the
+        calibration task.
+        """
+        self.logger.info("MockEyeTracker: running mock calibration")
+        try:
+            if isinstance(self.win, visual.Window):
+                self._draw_mock_calibration()
+        except Exception:
+            self.logger.exception(
+                "MockEyeTracker: mock calibration animation failed")
         self.calibrated = True
+
+    def _draw_mock_calibration(self) -> None:
+        win_w, win_h = self.win.size
+        header = visual.TextStim(
+            self.win,
+            text="MOCK calibration (no eye tracker)\nPress ESC to skip",
+            color="white",
+            units="pix",
+            pos=(0, win_h * 0.4),
+            height=24,
+        )
+        target = visual.Circle(
+            self.win,
+            radius=20,
+            fillColor="white",
+            lineColor="white",
+            units="pix",
+        )
+        event.clearEvents()
+        for fx, fy in _FIXATION_POINTS:
+            target.pos = (fx * win_w / 2.0, fy * win_h / 2.0)
+            target.draw()
+            header.draw()
+            self.win.flip()
+            deadline = core.getTime() + _POINT_DURATION_SEC
+            while core.getTime() < deadline:
+                if event.getKeys(keyList=["escape"]):
+                    self.win.flip()
+                    return
+                core.wait(0.01)
+        self.win.flip()
 
     def close(self) -> None:
         # Inherited close handles tk.close() (our stub is a no-op) and

--- a/neurobooth_os/iout/mock/mock_flir.py
+++ b/neurobooth_os/iout/mock/mock_flir.py
@@ -140,7 +140,21 @@ class MockVidRec_Flir(VidRec_Flir):  # noqa: N801 — match real class casing
                 "MockVidRec_Flir: synthetic record loop exited; video written")
 
     def frame_preview(self) -> ByteString:
-        img, _ = self.imgage_proc()
+        # Draw on a fresh full-size frame so the label is legible
+        # regardless of frame-decimation settings, and so recorded video
+        # frames stay untouched.
+        img = np.full(
+            (_MOCK_FRAME_HEIGHT, _MOCK_FRAME_WIDTH, 3), 40, dtype=np.uint8)
+        cv2.putText(
+            img,
+            "MOCK FLIR",
+            (40, 130),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1.0,
+            (255, 255, 255),
+            2,
+            cv2.LINE_AA,
+        )
         rc, encoded = cv2.imencode(".png", img)
         return encoded.tobytes() if rc else b""
 

--- a/neurobooth_os/iout/mock/mock_iphone.py
+++ b/neurobooth_os/iout/mock/mock_iphone.py
@@ -10,8 +10,8 @@ responses.
 
 When the controller sends ``@START``, the transport spawns a daemon
 thread that emits ``@INPROGRESSTIMESTAMP`` messages at the configured
-FPS until ``@STOP`` is sent.  ``frame_preview()`` returns canned bytes
-without touching the camera.
+FPS until ``@STOP`` is sent.  ``frame_preview()`` returns a canned
+labeled PNG without touching the camera.
 """
 
 from __future__ import annotations
@@ -24,6 +24,9 @@ import threading
 import time
 from typing import List, Optional
 
+import cv2
+import numpy as np
+
 from neurobooth_os.iout.iphone import (
     CONFIG,
     IPhone,
@@ -33,10 +36,35 @@ from neurobooth_os.iout.iphone import (
 )
 
 
-# Placeholder bytes returned by ``frame_preview()``.  Not a valid PNG —
-# the iPhone code just hands the bytes back to the caller, so opaque
-# bytes are sufficient for the lifecycle.  Tests assert non-emptiness.
-_CANNED_PREVIEW_BYTES = b"MOCK_IPHONE_FRAME_PREVIEW_PLACEHOLDER"
+_PREVIEW_WIDTH = 320
+_PREVIEW_HEIGHT = 240
+
+
+def _build_canned_preview_bytes() -> bytes:
+    """Build a labeled PNG used as the canned ``@PREVIEW`` response.
+
+    Returns a real PNG so the GUI's ``len(image) < 100`` short-circuit
+    in ``handle_frame_preview_reply`` doesn't fire — the operator sees
+    a clearly-labeled placeholder rather than ``ERROR: Unable to
+    preview (None)``.
+    """
+    img = np.full(
+        (_PREVIEW_HEIGHT, _PREVIEW_WIDTH, 3), 40, dtype=np.uint8)
+    cv2.putText(
+        img,
+        "MOCK iPhone",
+        (40, 130),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        1.0,
+        (255, 255, 255),
+        2,
+        cv2.LINE_AA,
+    )
+    rc, encoded = cv2.imencode(".png", img)
+    return encoded.tobytes() if rc else b""
+
+
+_CANNED_PREVIEW_BYTES = _build_canned_preview_bytes()
 
 
 class _MockIPhoneTransport:

--- a/tests/pytest/test_mock_iphone.py
+++ b/tests/pytest/test_mock_iphone.py
@@ -9,8 +9,8 @@ infrastructure or running iOS app.  Coverage:
   the state machine end-to-end.
 - LSL ``_lsl_push_sample`` sees ``@STARTTIMESTAMP``, several
   ``@INPROGRESSTIMESTAMP``, then ``@STOPTIMESTAMP``.
-- ``frame_preview()`` returns the canned bytes the mock transport
-  injects.
+- ``frame_preview()`` returns a real PNG (the canned labeled image
+  the mock transport injects).
 - The substitution registry is populated by importing
   ``stim_param_reader``.
 """
@@ -21,10 +21,7 @@ import pytest
 
 from neurobooth_os.iout import iphone as iphone_mod
 from neurobooth_os.iout.device import DeviceState
-from neurobooth_os.iout.mock.mock_iphone import (
-    _CANNED_PREVIEW_BYTES,
-    MockIPhone,
-)
+from neurobooth_os.iout.mock.mock_iphone import MockIPhone
 from neurobooth_os.iout.stim_param_reader import (
     IPhoneDeviceArgs,
     IPhoneSensorArgs,
@@ -167,13 +164,15 @@ class TestMockIPhoneLSLFlow:
             f"Expected several @INPROGRESSTIMESTAMP messages; got {in_progress}"
         )
 
-    def test_frame_preview_returns_canned_bytes(self, mock_args):
+    def test_frame_preview_returns_png_bytes(self, mock_args):
         device = MockIPhone(device_args=mock_args)
         try:
             device.connect()
             preview = device.frame_preview()
-            assert preview == _CANNED_PREVIEW_BYTES
+            assert isinstance(preview, bytes)
             assert len(preview) > 0
+            # cv2.imencode produces a real PNG; check the magic bytes.
+            assert preview[:8] == b"\x89PNG\r\n\x1a\n"
         finally:
             device.close()
 


### PR DESCRIPTION
## Summary
Two GUI-visible gaps in the mock device path that made operator testing confusing.

**Mock iPhone/FLIR frame previews now return labeled PNGs.**
- Mock iPhone returned 37 bytes of opaque placeholder, which tripped the GUI's `len(image) < 100` short-circuit in `handle_frame_preview_reply` and surfaced as `ERROR: Unable to preview (None)` on every preview request. It now returns a real 320x240 PNG labeled `MOCK iPhone`.
- Mock FLIR already returned a valid PNG, but a pure-black frame is hard to distinguish from a broken camera. It now returns a labeled `MOCK FLIR` PNG. Recorded video frames are untouched.
- `test_mock_iphone.py` now asserts PNG magic + non-empty (mirroring the existing `test_mock_flir.py` pattern) instead of exact-bytes equality against the old placeholder.

**Mock eye-tracker calibration now shows a stimulus.**
- `MockEyeTracker.calibrate()` was a no-op because the real path uses `EyeLinkCoreGraphicsPsychoPy` which transitively imports `pylink`. Operators saw instructions, then the Continue/Repeat slide, with nothing in between.
- The mock now walks a circle target through the standard 9 fixation positions (~3.6s total) with a `MOCK calibration` header so the GUI flow matches the real task end-to-end.
- ESC skips the remainder; `calibrated` is set unconditionally so the task continues normally — mirroring the real flow where ESC inside `doTrackerSetup` returns control to the calibration task.
- Drawing is gated on `isinstance(self.win, visual.Window)` so existing test fixtures (`MagicMock` window) fall through unchanged.

## Test plan
- [x] `pytest tests/pytest/test_mock_iphone.py tests/pytest/test_mock_flir.py tests/pytest/test_mock_eyetracker.py` — 25 passed
- [ ] Run a session against the mock iPhone in the GUI and confirm the preview pane renders the labeled image instead of `ERROR: Unable to preview (None)`
- [ ] Run a session against the mock FLIR in the GUI and confirm the preview pane shows the `MOCK FLIR` label
- [ ] Run the Calibration task with the mock eye tracker and confirm the 9-point pattern displays between the instructions and the Continue/Repeat slide
- [ ] Press ESC during the mock calibration animation and confirm the task advances to Continue/Repeat without hanging