### PR TITLE
Log per-video-play timing data to diagnose A/V sync drift

### DIFF
--- a/neurobooth_os/tasks/utils.py
+++ b/neurobooth_os/tasks/utils.py
@@ -5,6 +5,8 @@ Utilities for executing tasks
 
 from __future__ import absolute_import, division
 
+import csv
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from psychopy import core, event, monitors, sound
@@ -18,6 +20,7 @@ from pylsl import local_clock
 from psychopy import visual
 
 from neurobooth_os.iout.stim_param_reader import get_cfg_path
+from neurobooth_os.log_manager import _get_log_dir
 
 text_continue = 'Please press:\n\t"Continue" to advance'
 text_practice_screen = "Please practice the task \n\tPress any button when done"
@@ -259,17 +262,145 @@ def get_keys(keyList=()):
         delay(0.005)
 
 
+# Timing instrumentation for play_video. Used to diagnose A/V sync drift —
+# compare ``play_to_first_flip_ms`` (audio-vs-first-frame offset) and the
+# flip-interval distribution against a known-good machine. One CSV row per
+# video play is appended to ``neurobooth_video_timing.csv`` in the same
+# log directory as ``neurobooth_crash.log`` (resolved via _get_log_dir).
+_TIMING_LOG_FILENAME = "neurobooth_video_timing.csv"
+_TIMING_LOG_FIELDS = (
+    "timestamp_iso",
+    "video_path",
+    "video_fps",
+    "video_duration_s",
+    "wall_duration_s",
+    "play_to_first_flip_ms",
+    "flip_count",
+    "expected_frames",
+    "flip_interval_mean_ms",
+    "flip_interval_p50_ms",
+    "flip_interval_p99_ms",
+    "flip_interval_max_ms",
+    "exited_via",
+)
+
+
+def _video_timing_log_path() -> Optional[str]:
+    """Return the timing CSV path under the configured log dir, or None on failure."""
+    try:
+        log_dir = _get_log_dir()
+        os.makedirs(log_dir, exist_ok=True)
+    except Exception:
+        return None
+    return op.join(log_dir, _TIMING_LOG_FILENAME)
+
+
+def _percentile(sorted_values: List[float], p: float) -> float:
+    """Linear-rank percentile from a pre-sorted list."""
+    n = len(sorted_values)
+    if not n:
+        return 0.0
+    idx = max(0, min(int(p * (n - 1)), n - 1))
+    return sorted_values[idx]
+
+
+def _log_video_timing(
+    log_path: str,
+    mov: visual.MovieStim3,
+    play_call_clock: float,
+    first_flip_clock: float,
+    last_flip_clock: float,
+    flip_intervals_ms: List[float],
+    exited_via: str,
+) -> None:
+    """Append one summary row to the video timing CSV. Never raises."""
+    try:
+        video_fps = (
+            getattr(mov, "_videoFPS", None)
+            or getattr(mov, "videoFPS", None)
+            or getattr(mov, "fps", None)
+        )
+        video_duration = (
+            getattr(mov, "duration", None)
+            or getattr(mov, "_duration", None)
+        )
+        video_path = getattr(mov, "filename", "") or ""
+
+        wall_duration_s = last_flip_clock - first_flip_clock
+        play_to_first_flip_ms = (first_flip_clock - play_call_clock) * 1000.0
+
+        n = len(flip_intervals_ms)
+        if n:
+            intervals_sorted = sorted(flip_intervals_ms)
+            mean_ms = sum(flip_intervals_ms) / n
+            max_ms = intervals_sorted[-1]
+            p50_ms = _percentile(intervals_sorted, 0.50)
+            p99_ms = _percentile(intervals_sorted, 0.99)
+        else:
+            mean_ms = max_ms = p50_ms = p99_ms = 0.0
+
+        expected_frames = (
+            video_duration * video_fps
+            if video_duration and video_fps
+            else None
+        )
+
+        row = {
+            "timestamp_iso": datetime.now(timezone.utc).isoformat(),
+            "video_path": op.basename(video_path),
+            "video_fps": f"{video_fps:.3f}" if video_fps else "",
+            "video_duration_s": (
+                f"{video_duration:.3f}" if video_duration else ""
+            ),
+            "wall_duration_s": f"{wall_duration_s:.3f}",
+            "play_to_first_flip_ms": f"{play_to_first_flip_ms:.2f}",
+            "flip_count": n + 1,
+            "expected_frames": (
+                f"{expected_frames:.1f}" if expected_frames else ""
+            ),
+            "flip_interval_mean_ms": f"{mean_ms:.3f}",
+            "flip_interval_p50_ms": f"{p50_ms:.3f}",
+            "flip_interval_p99_ms": f"{p99_ms:.3f}",
+            "flip_interval_max_ms": f"{max_ms:.3f}",
+            "exited_via": exited_via,
+        }
+
+        write_header = not op.exists(log_path)
+        with open(log_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=_TIMING_LOG_FIELDS)
+            if write_header:
+                writer.writeheader()
+            writer.writerow(row)
+    except Exception:
+        # Instrumentation must never crash the task.
+        pass
+
+
 def play_video(win, mov, wait_time=1, stop=True, keyList=None):
+    first_flip_clock = last_flip_clock = 0.0
+    flip_intervals_ms: List[float] = []
+    prev_flip_clock: Optional[float] = None
+    exited_via = "finished"
+
     clock = core.Clock()
     if mov.status == visual.FINISHED:
         win.flip()
         mov.seek(0)
 
+    play_call_clock = local_clock()
     mov.play()
     while mov.status != visual.FINISHED:
         mov.draw()
         win.flip()
+        now = local_clock()
+        if prev_flip_clock is None:
+            first_flip_clock = now
+        else:
+            flip_intervals_ms.append((now - prev_flip_clock) * 1000.0)
+        prev_flip_clock = now
+        last_flip_clock = now
         if clock.getTime() >= wait_time and event.getKeys(keyList=keyList):
+            exited_via = "keypress"
             if stop:
                 mov.stop()
                 mov.seek(0)
@@ -277,3 +408,15 @@ def play_video(win, mov, wait_time=1, stop=True, keyList=None):
                 mov.pause()
                 mov.seek(0)
             break
+
+    log_path = _video_timing_log_path()
+    if log_path is not None and prev_flip_clock is not None:
+        _log_video_timing(
+            log_path=log_path,
+            mov=mov,
+            play_call_clock=play_call_clock,
+            first_flip_clock=first_flip_clock,
+            last_flip_clock=last_flip_clock,
+            flip_intervals_ms=flip_intervals_ms,
+            exited_via=exited_via,
+        )


### PR DESCRIPTION
## Summary
Adds always-on timing instrumentation to ``play_video`` (``tasks/utils.py``) to diagnose audio/video sync drift. One CSV row per video play is appended to ``neurobooth_video_timing.csv`` in the configured log directory (same resolution chain as ``neurobooth_crash.log``: ``current_server().local_log_dir`` from ``neurobooth_os_config.yaml`` → ``NB_INSTALL`` → ``~``).

Each row captures:
- ``play_to_first_flip_ms`` — audio-vs-first-frame offset proxy.
- ``flip_count`` vs. ``expected_frames`` (FPS × duration) — drift indicator.
- Flip-interval distribution (mean / p50 / p99 / max in ms) — vsync health and frame-drop rate.
- ``wall_duration_s`` vs. ``video_duration_s`` — early-truncation detector (the symptom that surfaced the 1.5s deficit on a 60Hz laptop while a 240Hz booth was clean).

## Why land it
- Already produced actionable data on a real laptop run: pinned the desync to a fixed ~1.5s tail truncation per video (audio EOS firing early), independent of clip length, with a healthy 60Hz display loop.
- Per-flip overhead is one ``local_clock()`` call + one float subtract — negligible.
- Logger failures are caught and swallowed; instrumentation cannot crash a task.
- Next time an operator reports a timing complaint, the CSV already exists from prior runs.

## Test plan
- [x] Ran a partial laptop session; CSV written to ``$NB_INSTALL/neurobooth_video_timing.csv`` (14 rows, all well-formed).
- [x] ``pytest tests/pytest`` — 134 passed (no regression).
- [ ] Run a partial booth session and confirm the CSV lands at the configured ``local_log_dir`` next to ``neurobooth_crash.log``.