### PR TITLE
Force OS-level focus to Subject ID input at GUI startup

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -298,6 +298,30 @@ def _start_activation_listener(window,
     return thread
 
 
+def _focus_subject_id_on_startup(window, logger: Optional[logging.Logger] = None) -> None:
+    """Reliably land keyboard focus on the Subject ID input at GUI start.
+
+    PySimpleGUI's ``focus=True`` on the Input element sets Tk-level focus
+    when the window first renders, but Windows does not auto-foreground a
+    process's new window when the launching process (CMD / .bat / shortcut)
+    holds the foreground — typing then goes to whatever was foreground
+    rather than into the input. Mirror the foreground-grab pattern from
+    ``_raise_self_window``: briefly set topmost, force focus on the Tk
+    root (so the OS treats the window as foreground), then set Tk focus
+    on the input element.
+    """
+    try:
+        window.TKroot.deiconify()
+        window.TKroot.lift()
+        window.TKroot.attributes('-topmost', True)
+        window.TKroot.after(500, lambda: window.TKroot.attributes('-topmost', False))
+        window.TKroot.focus_force()
+        window['subject_id'].set_focus()
+    except Exception as e:
+        if logger:
+            logger.info("Focus on startup failed: %s", e)
+
+
 def _raise_self_window(window, logger: Optional[logging.Logger] = None) -> None:
     """From GUI-A: raise this process's own main window.
 
@@ -692,6 +716,7 @@ def gui(logger):
         plttr = stream_plotter()
         log_sess = LogSession(application_version=state.release_version, config_version=state.config_version)
         event, values = window.read(0.1)
+        _focus_subject_id_on_startup(window, logger)
         while True:
             event, values = window.read(0.5)
             ############################################################


### PR DESCRIPTION
## Summary
Fixes a regression observed on staging running v0.90.0: the Subject ID input was supposed to receive keyboard focus on GUI startup (PR [#739](https://github.com/neurobooth/neurobooth-os/pull/739)), but operators still had to click the field before typing.

**Root cause.** PySimpleGUI's ``focus=True`` on the Input element calls Tk's ``focus_set()`` on the widget when the window first renders. That sets *Tk-level* focus inside the app but does **not** grab *OS-level* foreground on Windows: when the GUI launches from a CMD / .bat / shortcut that holds the foreground, the new window opens not-foregrounded and keystrokes go to whatever was foreground rather than into the input. The PR likely tested green for the original developer because they launched from an IDE that yields foreground politely; production launchers don't.

**Fix.** Add ``_focus_subject_id_on_startup`` in ``gui.py`` that mirrors the foreground-grab pattern from the existing ``_raise_self_window`` helper: briefly set the Tk root ``-topmost``, force focus on the root (so Windows treats the window as foreground), then set Tk focus on the ``subject_id`` input. 500ms topmost dwell — long enough for Windows to register the foreground change, short enough to avoid a noticeable visual flash on initial launch. Helper failures are logged but never raised.

Called once from ``gui()`` right after the first ``window.read(0.1)`` realize. The original ``focus=True`` in ``layouts.py:45`` is left in place as belt-and-suspenders for platforms where it works natively.

## Test plan
- [x] ``pytest tests/pytest`` — 141 passed (including ``test_gui_single_instance.py`` which exercises the adjacent activation-event mechanism).
- [ ] Deploy to staging; launch the GUI from the production launcher (.bat / desktop shortcut, not from an IDE) and confirm typing lands in the Subject ID field with no click required.
- [ ] On staging, confirm the brief topmost flash isn't disruptive on the operator's monitor.