### PR TITLE
Route netcomm.client logging through the app logger

### DIFF
--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -11,13 +11,12 @@ from typing import List, Optional, Tuple
 import neurobooth_os.config as cfg
 
 
-def setup_log(name):
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    return logger
-
-
-logger = setup_log(__name__)
+# Route through the "app" logger so messages reach the PostgreSQLHandler
+# attached by make_db_logger (log_manager.py). A privately-named logger
+# (e.g. logging.getLogger(__name__)) has no handlers attached and no
+# propagation path to the "app" logger, so its messages are silently
+# dropped — that's why SCHTASKS / WMIC failures used to vanish.
+logger = logging.getLogger("app")
 
 
 def _run_cmd(cmd_list: list, server_name: str = None, user: str = None, password: str = None) -> str:


### PR DESCRIPTION
## Summary

`neurobooth_os/netcomm/client.py` created its own private logger via `logging.getLogger(__name__)` with no handlers attached. The `PostgreSQLHandler` set up by `make_db_logger` is attached to a separate logger named `\"app\"` — and Python's logging hierarchy only propagates up the dotted name space, so `neurobooth_os.netcomm.client` messages can't reach `app`. Result: every `logger.error` / `logger.warning` / `logger.debug` call in `_run_cmd`, `start_server`, `kill_remote_pid`, etc. has been silently dropped.

This is what made the recent SCHTASKS `/Create /XML` failures on Wang invisible. `_run_cmd` carefully captures `e.stdout` and `e.stderr` on `CalledProcessError`, calls `logger.error(...)` with both, and re-raises — but the only thing that actually surfaces is the Python traceback, which omits subprocess output by design (`CalledProcessError.__repr__` shows the command and exit code only).

## Fix

Switch `netcomm/client.py` to use `logging.getLogger(\"app\")` directly. The `setup_log` helper was only used internally and is removed.

## Test plan

- [x] Import check: `python -c \"from neurobooth_os.netcomm import client; print(client.logger.name)\"` prints `app`
- [x] No other module imported `setup_log` (`grep -r setup_log` shows the helper was local to this file)
- [ ] Verify on Wang: re-run a deploy that fails in `start_servers`, confirm SCHTASKS stdout/stderr now appears in `log_application`

## Side note (out of scope for this PR)

The same private-logger pattern likely exists in other modules. Worth a sweep to find any `logging.getLogger(__name__)` that should be using the `app` logger to land in the DB. Filing follow-up if confirmed.