### PR TITLE
Qualify SCHTASKS UserId with machine name

### DIFF
--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -123,7 +123,8 @@ def get_all_python_processes_with_cmd(server_name: str = None, user: str = None,
 
 
 def _build_task_xml(bat_path: str, acq_index: Optional[int],
-                    user: Optional[str] = None) -> str:
+                    user: Optional[str] = None,
+                    machine: Optional[str] = None) -> str:
     """Build a Task Scheduler XML for an event-triggered server task.
 
     SCHTASKS /Create has no CLI flag for the battery-condition setting, so a
@@ -137,8 +138,11 @@ def _build_task_xml(bat_path: str, acq_index: Optional[int],
     When ``user`` is provided, a <Principals> block is included so SCHTASKS
     /S /XML accepts the file: remote task creation requires an explicit
     UserId, and the /TR flow that this code replaced got it from /U
-    automatically. Local creation (no /S) auto-fills Principals from the
-    calling context, so we omit the block when ``user`` is empty/None.
+    automatically. The UserId is qualified as ``machine\\user`` (matching
+    how SCHTASKS /Query reports the existing task's Author) unless ``user``
+    already contains a backslash, in which case it's used as-is. Local
+    creation (no /S) auto-fills Principals from the calling context, so
+    we omit the block when ``user`` is empty/None.
     """
     command = _saxutils.escape(bat_path)
     args_block = ""
@@ -148,7 +152,14 @@ def _build_task_xml(bat_path: str, acq_index: Optional[int],
     principals_block = ""
     actions_open = "  <Actions>\n"
     if user:
-        user_escaped = _saxutils.escape(user)
+        # Qualify with the target machine name when not already domain-qualified.
+        # Bare "ACQ" is rejected by Task Scheduler XML validation as ambiguous;
+        # "ACQ\\ACQ" (which is what /Query shows for the existing task) is not.
+        if "\\" not in user and machine:
+            qualified_user = f"{machine}\\{user}"
+        else:
+            qualified_user = user
+        user_escaped = _saxutils.escape(qualified_user)
         principals_block = (
             '  <Principals>\n'
             '    <Principal id="Author">\n'
@@ -285,7 +296,7 @@ def start_server(node_name, acq_index=None, save_pid_txt=True):
     # default DisallowStartIfOnBatteries=true and would queue forever on a
     # laptop on battery. See _build_task_xml for the schema we apply.
     print(f"Creating Windows task: {task_name}")
-    xml_content = _build_task_xml(s.bat, acq_index, user=s.user)
+    xml_content = _build_task_xml(s.bat, acq_index, user=s.user, machine=s.name)
     fd, xml_path = tempfile.mkstemp(suffix='.xml')
     try:
         with os.fdopen(fd, 'wb') as f:


### PR DESCRIPTION
## Summary

Follow-up to #755. After adding the `<Principals>` block, SCHTASKS still rejected the XML on Wang's CTR -> ACQ deploy:

\`\`\`
ERROR: The parameter is incorrect.
(14,8):UserId:
\`\`\`

Plain user names aren't always resolvable from the side validating the XML. SCHTASKS \`/Query\` reports the existing Wang ACQ task's Author as \`ACQ\ACQ\` — the machine-qualified form. The prior \`/U\`-driven \`/TR\` path produced the same.

## Fix

\`_build_task_xml\` takes an optional \`machine\` parameter; when \`user\` is supplied without a backslash, the UserId is prefixed: \`{machine}\{user}\`. \`start_server\` passes \`s.name\`. Already-qualified usernames pass through unchanged. Local single-machine path is unaffected — the entire Principals block is still omitted when \`user\` is empty.

For Wang the rendered UserId becomes \`acq\ACQ\` (machine-name from the YAML config; Windows is case-insensitive on user/machine names so this matches the existing task's \`ACQ\ACQ\`).

## Test plan

- [x] Render with \`user='ACQ', machine='acq'\` → \`<UserId>acq\ACQ</UserId>\`
- [x] Render with \`user=None\` → no Principals block (single-machine path preserved)
- [ ] Deploy on Wang and confirm \`controller.start_servers()\` proceeds past SCHTASKS.