### PR TITLE
Replace WMIC shell-out with Get-CimInstance over DCOM

### DIFF
--- a/docs/single_machine_testing.md
+++ b/docs/single_machine_testing.md
@@ -7,7 +7,7 @@ Note: You must be running Windows 10 or greater to run Neurobooth on your machin
 ## Configuration
 The main config file is `neurobooth_os_config.yaml`, located in the folder named by the `NB_CONFIG` environment variable. The format is the normalized machines + services layout: a top-level `machines:` dict keyed by machine name, plus `acquisition` / `presentation` / `control` sections that reference machines by name. See [system_configuration.md](arch/system_configuration.md) for the authoritative schema.
 
-For single-machine testing, define one machine in `machines:` with `user` set to `""`, and have all three service sections reference that machine by its dict key. An empty `user` triggers a local-execution shortcut in `netcomm/client.py:_run_cmd` so SCHTASKS, WMIC, and tasklist run on this machine without remote credentials — no Windows password is required, and `machines.<name>.password` should be omitted entirely.
+For single-machine testing, define one machine in `machines:` with `user` set to `""`, and have all three service sections reference that machine by its dict key. An empty `user` triggers a local-execution shortcut in `netcomm/client.py` so SCHTASKS, Get-CimInstance, and tasklist run on this machine without remote credentials — no Windows password is required, and `machines.<name>.password` should be omitted entirely.
 
 Minimal example (`neurobooth_os_config.yaml`):
 
@@ -76,9 +76,9 @@ If you're running the database on the same machine as the neurobooth code, set `
 For more information on configuration settings, see [system_configuration.md](arch/system_configuration.md).
 
 ## Servers
-ACQ and STM servers are started by the GUI through Windows `SCHTASKS`. On first launch, the GUI registers a scheduled task that runs the appropriate batch file (`server_acq.bat` or `server_stm.bat`) and then triggers it; on subsequent launches the existing task is reused. `WMIC` and `tasklist` are used alongside SCHTASKS to inventory and clean up Python processes between runs. You can view and troubleshoot the tasks in the Windows Task Scheduler.
+ACQ and STM servers are started by the GUI through Windows `SCHTASKS`. On first launch, the GUI registers a scheduled task that runs the appropriate batch file (`server_acq.bat` or `server_stm.bat`) and then triggers it; on subsequent launches the existing task is reused. PowerShell `Get-CimInstance` (over a DCOM `CimSession`) and `tasklist` are used alongside SCHTASKS to inventory and clean up Python processes between runs. You can view and troubleshoot the tasks in the Windows Task Scheduler.
 
-For single-machine testing, you do **not** need to enable remote WMI or configure a domain user — when `machines.<name>.user` is empty, `netcomm/client.py:_run_cmd` skips the remote `/S /U /P` arguments and runs SCHTASKS / WMIC / tasklist locally on the calling machine. The [WMI instructions](enable_WMI_instuctions.txt) are only relevant for multi-machine production deployments where CTR launches ACQ and STM on separate hosts.
+For single-machine testing, you do **not** need to enable remote WMI or configure a domain user — when `machines.<name>.user` is empty, `netcomm/client.py` skips the remote credentials and runs SCHTASKS / Get-CimInstance / tasklist locally on the calling machine. The [WMI instructions](enable_WMI_instuctions.txt) are only relevant for multi-machine production deployments where CTR launches ACQ and STM on separate hosts.
 
 Please Note: When the tasks are first added to the scheduler, they are created with a number of default settings, one of which causes the task to not run if the machine is not running on AC power. You should probably change that if you plan to work on a laptop and may run on battery.
 

--- a/neurobooth_os/netcomm/client.py
+++ b/neurobooth_os/netcomm/client.py
@@ -4,6 +4,8 @@ import re
 import os
 import subprocess
 import ast
+import csv
+import io
 import tempfile
 import xml.sax.saxutils as _saxutils
 from typing import List, Optional, Tuple
@@ -15,24 +17,17 @@ import neurobooth_os.config as cfg
 # attached by make_db_logger (log_manager.py). A privately-named logger
 # (e.g. logging.getLogger(__name__)) has no handlers attached and no
 # propagation path to the "app" logger, so its messages are silently
-# dropped — that's why SCHTASKS / WMIC failures used to vanish.
+# dropped — that's why SCHTASKS / Get-CimInstance failures used to vanish.
 logger = logging.getLogger("app")
 
 
 def _run_cmd(cmd_list: list, server_name: str = None, user: str = None, password: str = None) -> str:
     full_cmd = list(cmd_list)
     # Single-machine testing: an empty user means "run on this machine" — skip
-    # /S /U /P so tasklist/SCHTASKS/WMIC execute locally. See
+    # /S /U /P so tasklist/SCHTASKS execute locally. See
     # docs/single_machine_testing.md.
     if server_name and user:
-        executable = full_cmd[0].upper()
-        if executable == "WMIC":
-            # WMIC uses /NODE:, /USER:, /PASSWORD: instead of /S, /U, /P
-            full_cmd = full_cmd[:1] + [
-                f"/NODE:{server_name}", f"/USER:{user}", f"/PASSWORD:{password}"
-            ] + full_cmd[1:]
-        else:
-            full_cmd = full_cmd[:1] + ["/S", server_name, "/U", user, "/P", password] + full_cmd[1:]
+        full_cmd = full_cmd[:1] + ["/S", server_name, "/U", user, "/P", password] + full_cmd[1:]
 
     try:
         logger.debug(f"Running command: {' '.join(cmd_list)} (on {server_name or 'localhost'})")
@@ -83,6 +78,29 @@ def get_python_pids(server_name: str = None, user: str = None, password: str = N
     return pyth_pids
 
 
+_PS_REMOTE_GET_PYTHON_PROCESSES = r"""
+$ErrorActionPreference = 'Stop'
+$securepw = ConvertTo-SecureString $env:NB_REMOTE_PASSWORD -AsPlainText -Force
+$cred = New-Object System.Management.Automation.PSCredential($env:NB_REMOTE_USER, $securepw)
+$opt = New-CimSessionOption -Protocol Dcom
+$sess = New-CimSession -ComputerName $env:NB_REMOTE_HOST -Credential $cred -SessionOption $opt
+try {
+    Get-CimInstance -CimSession $sess -ClassName Win32_Process -Filter "Name='python.exe'" |
+        Select-Object ProcessId, CommandLine |
+        ConvertTo-Csv -NoTypeInformation
+} finally {
+    Remove-CimSession $sess
+}
+"""
+
+_PS_LOCAL_GET_PYTHON_PROCESSES = r"""
+$ErrorActionPreference = 'Stop'
+Get-CimInstance -ClassName Win32_Process -Filter "Name='python.exe'" |
+    Select-Object ProcessId, CommandLine |
+    ConvertTo-Csv -NoTypeInformation
+"""
+
+
 def get_all_python_processes_with_cmd(server_name: str = None, user: str = None, password: str = None) -> list:
     """Gets a list of Python process IDs and their command lines from the local or remote computer.
 
@@ -100,25 +118,63 @@ def get_all_python_processes_with_cmd(server_name: str = None, user: str = None,
     list
         List of dictionaries, each with 'pid' and 'commandline' for Python processes.
     """
-    cmd_args = ["WMIC", "process", "where", "name='python.exe'", "get", "ProcessId,CommandLine", "/FORMAT:CSV"]
+    # Remote calls use a DCOM CimSession to match the wire protocol WMIC used,
+    # so the existing inter-machine WMI/firewall/registry runbook in
+    # docs/enable_WMI_instuctions.txt remains the source of truth. WSMan/WinRM
+    # is deliberately not used (different security model — see #760).
+    #
+    # Credentials are passed via env vars so the password never appears in the
+    # process command line (strictly more secure than the previous WMIC call,
+    # which exposed it via /PASSWORD:).
+    if server_name and user:
+        ps_command = _PS_REMOTE_GET_PYTHON_PROCESSES
+        ps_env = {
+            **os.environ,
+            "NB_REMOTE_HOST": server_name,
+            "NB_REMOTE_USER": user,
+            "NB_REMOTE_PASSWORD": password or "",
+        }
+    else:
+        # Single-machine testing: empty user → run locally.
+        # See docs/single_machine_testing.md.
+        ps_command = _PS_LOCAL_GET_PYTHON_PROCESSES
+        ps_env = None
+
+    cmd = ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", ps_command]
     try:
-        output_wmic = _run_cmd(cmd_args, server_name, user, password)
-    except Exception:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=30, env=ps_env
+        )
+        output = result.stdout
+    except subprocess.CalledProcessError as e:
+        logger.error(
+            f"Get-CimInstance failed (on {server_name or 'localhost'}): "
+            f"stdout: {e.stdout}, stderr: {e.stderr}"
+        )
+        return []
+    except subprocess.TimeoutExpired as e:
+        logger.error(
+            f"Get-CimInstance timed out (on {server_name or 'localhost'}): "
+            f"stdout: {e.stdout}, stderr: {e.stderr}"
+        )
+        return []
+    except OSError as e:
+        logger.error(f"Failed to launch powershell.exe: {e}")
         return []
 
+    # ConvertTo-Csv -NoTypeInformation emits one header row followed by one
+    # row per object: "ProcessId","CommandLine". csv.reader handles quoted
+    # fields and embedded commas correctly (which the previous naive
+    # str.split(',') did not).
     processes = []
-    # Skip the first line (header) and the last empty line
-    lines = output_wmic.strip().split("\n")
-    if len(lines) > 1:
-        for line in lines[1:]:  # Skip header
-            parts = line.split(',')
-            if len(parts) >= 2:
-                try:
-                    pid = parts[0].strip()
-                    cmd_line = parts[1].strip()
-                    processes.append({"pid": pid, "commandline": cmd_line})
-                except ValueError:
-                    logger.warning(f"Could not parse WMIC output line: {line}")
+    rows = list(csv.reader(io.StringIO(output)))
+    if len(rows) <= 1:
+        return processes
+    for row in rows[1:]:
+        if len(row) >= 2:
+            processes.append({"pid": row[0].strip(), "commandline": row[1].strip()})
+        else:
+            logger.warning(f"Could not parse Get-CimInstance output row: {row}")
     return processes
 
 


### PR DESCRIPTION
## Summary

- Replaces the `WMIC process where name='python.exe' get ProcessId,CommandLine /FORMAT:CSV` shell-out in `neurobooth_os/netcomm/client.py` with PowerShell `Get-CimInstance Win32_Process` bound to an explicit DCOM `CimSession`. WMIC is deprecated by Microsoft and is no longer installed by default on Windows 11; this swap unblocks Win11 without changing the wire protocol or requiring any change to the existing WMI / firewall / registry runbook in `docs/enable_WMI_instuctions.txt`.
- Passes credentials via env vars instead of command-line arguments, so the password no longer appears in the `powershell.exe` process command line (the previous WMIC call exposed it via `/PASSWORD:`).
- Drops the now-unused WMIC branch in `_run_cmd`. SCHTASKS, `tasklist`, and `taskkill` paths are untouched — all three still ship on Win11 by default.
- Updates `docs/single_machine_testing.md` to mention Get-CimInstance instead of WMIC.

## Latent bugs fixed in passing

The rewrite naturally corrects two bugs in the WMIC parser that surfaced once I reasoned through the new pipeline:

1. **Column-mapping bug.** WMIC remote `/FORMAT:CSV` output is `Node,CommandLine,ProcessId` (alphabetical by column name when invoked with `/NODE:`). The old parser at `client.py:117` read `parts[0]` as `pid`, so `kill_remote_pid([proc['pid']], node_name)` at `client.py:250` has been calling `taskkill /PID <hostname> /F` for the entire history of this code — silently failing every time the orphan-process kill at `start_server` triggered. `Get-CimInstance | Select-Object ProcessId, CommandLine` emits columns in the requested order; the new parser maps them correctly. The bug was invisible on single-machine testing because local WMIC output omits the `Node` column.
2. **`str.split(',')` on CSV.** The old parser broke on cmdlines containing commas. Switched to stdlib `csv.reader`, which handles quoted fields correctly.

## Why DCOM and not WSMan/WinRM

Per #760: deliberately preserving the DCOM transport (via `New-CimSessionOption -Protocol Dcom`) keeps every existing ACL / firewall rule / registry tweak in `docs/enable_WMI_instuctions.txt` load-bearing. WSMan would change the security model and is its own follow-up if ever pursued.

## Test plan

- [x] `uv run ruff check neurobooth_os/netcomm/client.py` — clean.
- [x] Local smoke test: `get_all_python_processes_with_cmd(None, None, None)` returns `[{'pid': '<numeric>', 'commandline': '...'}]` for live `python.exe` processes.
- [x] Empty-user smoke test: `get_all_python_processes_with_cmd('', '', '')` exercises the single-machine path and returns the same shape.
- [ ] Operator validation on a Win10 booth: from CTR, call `get_all_python_processes_with_cmd("STM", "STM", pwd)` and confirm a non-empty result against a peer.
- [ ] Operator end-to-end: full booth session via the GUI; watch `app` logger for any new netcomm WARN/ERROR rows.
- [ ] Deferred to #769 (Win11 pilot): re-run on the Win11 booth and confirm the code path works without WMIC FoD installed.

Refs #760, #759.
