### PR TITLE
Guard pylink import in tasks/task_eyetracker.py

### DIFF
--- a/neurobooth_os/tasks/task_eyetracker.py
+++ b/neurobooth_os/tasks/task_eyetracker.py
@@ -1,14 +1,35 @@
 from __future__ import division, absolute_import
 
 import os
+from enum import Enum
 from typing import Union
 
-import pylink
 from psychopy import visual
-from enum import Enum
 
 from neurobooth_os.tasks import Task
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix
+
+# Hardware import — guarded so this module is importable on a hardware-less
+# machine (mock-device testing per docs/single_machine_testing.md). Real
+# EyeLink code paths still require pylink and will fail loudly when called
+# without it. Mirrors the pattern in iout/eyelink_tracker.py.
+try:
+    import pylink
+    _HAS_PYLINK = True
+except ImportError:
+    pylink = None  # type: ignore[assignment]
+    _HAS_PYLINK = False
+
+
+def _require_pylink() -> None:
+    """Raise a clear error if real-EyeLink code is reached without pylink."""
+    if not _HAS_PYLINK:
+        raise RuntimeError(
+            "EyeLink hardware code path invoked but pylink is not installed. "
+            "Install the EyeLink SDK (uv sync --extra eyelink) to use a real "
+            "EyeLink, or use MockEyeTracker via NB_MOCK_DEVICES=EyeTracker "
+            "for hardware-less testing."
+        )
 
 
 class EyelinkColor(Enum):
@@ -193,7 +214,7 @@ class Eyelink_HostPC(Task_Eyetracker):
     def _render_image(self, path_to_image: Union[str, os.PathLike],
                      crop_x: int, crop_y: int, crop_width: int, crop_height: int,
                      host_x: int, host_y: int,
-                     drawing_options: any = pylink.BX_MAXCONTRAST) -> None:
+                     drawing_options: any = None) -> None:
         """
            Employs the imageBackdrop method of eyetracker to display an image on
            HostPC screen. Documentation available as comments in (and code adapted
@@ -213,7 +234,12 @@ class Eyelink_HostPC(Task_Eyetracker):
                                           the image
            :param host_x/host_y: x,y position in pixels on the HostPC screen where
                                  the image needs to be rendered
-           :param drawing_options: drawing options from SR Research's pylink package
+           :param drawing_options: drawing options from SR Research's pylink
+                                   package. ``None`` (the default) is
+                                   resolved to ``pylink.BX_MAXCONTRAST`` at
+                                   call time, which keeps this module
+                                   importable on hardware-less dev machines
+                                   that have no pylink installed.
 
            Example usage:
            If you want to render a 1920 by 1080 image on a 1920x1080 screen,
@@ -241,6 +267,9 @@ class Eyelink_HostPC(Task_Eyetracker):
         self.clear_screen()
 
         if self.eye_tracker is not None:
+            if drawing_options is None:
+                _require_pylink()
+                drawing_options = pylink.BX_MAXCONTRAST
             self.eye_tracker.tk.imageBackdrop(path_to_image,
                                            crop_x, crop_y, crop_width, crop_height,
                                            host_x, host_y,


### PR DESCRIPTION
## Summary

- `neurobooth_os/tasks/task_eyetracker.py:6` had an unguarded `import pylink`. Because `tasks/__init__.py:4` re-exports `Task_Eyetracker`, this broke the entire `neurobooth_os.tasks` import chain on any machine without the EyeLink SDK installed.
- Concretely: STM crashed at module-level imports (before `main()` ran), so `enable_crash_handler` never wrote a banner, the fallback logger never fired, and `server_stm.bat` does not redirect stdout/stderr — the operator saw a window flash and disappear with no diagnostic anywhere.
- Mock-based hardware-less testing (`NB_MOCK_DEVICES=EyeTracker`, the `test_no_eyelink` task collection per `docs/single_machine_testing.md:98-99`) was effectively broken by this. The breakage post-dates the hardware-mock work; the unguarded import was likely introduced or reintroduced during the recent uv migration (#758).

## Fix

Mirrors the pattern already in `neurobooth_os/iout/eyelink_tracker.py:11-26`:

```python
try:
    import pylink
    _HAS_PYLINK = True
except ImportError:
    pylink = None
    _HAS_PYLINK = False

def _require_pylink() -> None:
    if not _HAS_PYLINK:
        raise RuntimeError(...)
```

Also fixes a second pylink leak into module-load time: `_render_image` had `drawing_options: any = pylink.BX_MAXCONTRAST`, which is evaluated at class-definition time. Switched the default to `None` and resolve to `pylink.BX_MAXCONTRAST` at call time, inside the existing `if self.eye_tracker is not None:` guard so mock runs (eye_tracker is None) never reach the pylink lookup.

## Test plan

- [x] `uv run ruff check neurobooth_os/tasks/task_eyetracker.py` — clean.
- [x] `python -c "import neurobooth_os.server_stm"` succeeds on a machine without pylink installed.
- [x] `_HAS_PYLINK == False` and `pylink is None` when the SDK is absent.
- [x] `_require_pylink()` raises `RuntimeError` with a clear message pointing operators at `uv sync --extra eyelink` or `NB_MOCK_DEVICES=EyeTracker`.
- [ ] Operator: with `pylink` installed (`uv sync --extra eyelink`), real-EyeLink session should behave identically to pre-commit (the `_HAS_PYLINK == True` path is a strict no-op vs. the prior code).

## Diagnostic-gap follow-up (separate, not in this PR)

This bug was hard to find because three diagnostic paths failed in series:

1. `enable_crash_handler` is called at `server_stm.py:45`, *after* `config.load_config_by_service_name`, contradicting its own docstring ("This should be called as early as possible — before config loading"). A module-level crash never gets a banner.
2. `make_fallback_logger` only fires from `main()`'s `except Exception`. Module-level crashes happen before `main()` is entered.
3. `server_stm.bat` / `server_acq.bat` / `server_ctr.bat` do not redirect stdout or stderr; the launching cmd window closes when python dies.

Worth a separate small PR to (a) move `enable_crash_handler` above config-load in each server's `main`, and (b) redirect server `.bat` output to a per-launch log. Filing as its own issue rather than expanding this PR's scope.
