### PR TITLE
Add LSL-startup-timeout investigation scripts

### DIFF
--- a/extras/perf/_correlate_freezes.py
+++ b/extras/perf/_correlate_freezes.py
@@ -1,0 +1,106 @@
+"""Correlate CTR freezes with STM/ACQ system_resource gaps for the two
+sessions with LSL-startup timeouts on 2026-04-29 (3220 and 3223).
+
+If ACQ shows coincident gaps, that points at shared infrastructure
+rather than a CTR-isolated freeze.
+"""
+import pandas as pd
+from _db import get_conn
+
+DATE = "2026-04-29"
+SESSIONS = {
+    3220: "101031_2026-04-29",
+    3223: "101120_2026-04-29",
+}
+
+
+def main():
+    conn, tunnel = get_conn()
+    try:
+        # 1. Pull all LSL-startup wait events for the two affected sessions
+        # so we know the timeout timestamps precisely
+        all_lsl = []
+        for sid, sname in SESSIONS.items():
+            df = pd.read_sql_query("""
+                SELECT %s::int AS log_session_id, server_time, message
+                FROM log_application
+                WHERE session_id = %s
+                  AND message LIKE 'Waiting for LSL startup took:%%'
+                ORDER BY server_time
+            """, conn, params=(sid, sname))
+            df["sec"] = df["message"].str.extract(r"took: ([\d.]+)").astype(float)
+            all_lsl.append(df)
+        lsl = pd.concat(all_lsl, ignore_index=True)
+        timeouts = lsl[lsl["sec"] > 20].copy()
+        # The "took" line is logged AT the END of the wait. So the wait window is
+        # [server_time - sec, server_time].
+        timeouts["wait_start"] = timeouts["server_time"] - pd.to_timedelta(timeouts["sec"], unit="s")
+        timeouts["wait_end"]   = timeouts["server_time"]
+        print("=== LSL-startup timeouts (>20s) in 3220 & 3223 ===")
+        print(timeouts[["log_session_id", "wait_start", "wait_end", "sec"]].to_string(index=False))
+
+        # 2. For each machine, pull all log_system_resource samples on 2026-04-29
+        # within the relevant time range, compute gaps, and find anomalous ones
+        machines = ["CTR", "STM", "ACQ_0"]
+        gap_summary = {}
+        for m in machines:
+            df = pd.read_sql_query("""
+                SELECT created_at FROM log_system_resource
+                WHERE machine_name = %s AND created_at::date = %s::date
+                ORDER BY created_at
+            """, conn, params=(m, DATE))
+            if df.empty:
+                print(f"\n--- {m}: no samples on {DATE} ---")
+                continue
+            df["gap_s"] = df["created_at"].diff().dt.total_seconds()
+            gap_summary[m] = df
+            big = df[df["gap_s"] > 30]
+            print(f"\n--- {m}: {len(df)} samples on {DATE}, "
+                  f"first {df['created_at'].min()}, last {df['created_at'].max()}; "
+                  f"{len(big)} gap(s) > 30s ---")
+            with pd.option_context("display.max_colwidth", 50, "display.width", 200):
+                # Show gaps > 30s
+                if not big.empty:
+                    big_disp = big[["created_at", "gap_s"]].copy()
+                    big_disp["gap_min"] = (big_disp["gap_s"] / 60).round(1)
+                    big_disp["resumes_at"] = big_disp["created_at"]
+                    big_disp["went_silent_at"] = big_disp["created_at"] - pd.to_timedelta(big_disp["gap_s"], unit="s")
+                    print(big_disp[["went_silent_at", "resumes_at", "gap_s", "gap_min"]].to_string(index=False))
+
+        # 3. For each timeout, check whether each machine's logger had a coincident gap
+        print("\n\n=== Per-timeout cross-machine check ===")
+        rows = []
+        for _, r in timeouts.iterrows():
+            row = {"session": int(r["log_session_id"]),
+                   "wait_start": r["wait_start"], "wait_end": r["wait_end"],
+                   "lsl_sec": round(r["sec"], 2)}
+            for m, df in gap_summary.items():
+                # Did this machine have any sample within the wait window?
+                in_window = df[(df["created_at"] >= r["wait_start"])
+                               & (df["created_at"] <= r["wait_end"])]
+                row[f"{m}_samples_in_window"] = len(in_window)
+                # If no samples, what's the gap covering this window?
+                if in_window.empty:
+                    last_before = df[df["created_at"] < r["wait_start"]]
+                    next_after  = df[df["created_at"] > r["wait_end"]]
+                    if not last_before.empty and not next_after.empty:
+                        cover = (next_after["created_at"].iloc[0]
+                                 - last_before["created_at"].iloc[-1]).total_seconds()
+                        row[f"{m}_covering_gap_s"] = round(cover, 1)
+                    else:
+                        row[f"{m}_covering_gap_s"] = None
+                else:
+                    row[f"{m}_covering_gap_s"] = None
+            rows.append(row)
+        out = pd.DataFrame(rows)
+        with pd.option_context("display.max_colwidth", 50, "display.width", 240,
+                               "display.max_rows", 50):
+            print(out.to_string(index=False))
+    finally:
+        conn.close()
+        if tunnel is not None:
+            tunnel.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/perf/_ctr_during_lsl_timeout.py
+++ b/extras/perf/_ctr_during_lsl_timeout.py
@@ -1,0 +1,113 @@
+"""During each LSL-startup-timeout window in session 3223, what was CTR doing?
+
+Look for any CTR-side trace that landed during the 31.6s windows:
+- log_application rows with server_type='control' (or whatever CTR uses)
+- log_system_resource samples (CTR has its own SystemResourceLogger thread,
+  per gui.py:706, writing every 10s — gaps would indicate process-level
+  freeze beyond just the main thread)
+"""
+import pandas as pd
+from _db import get_conn
+
+SESSION_NAME = "101120_2026-04-29"  # session 3223
+
+# The 5 timeout windows (each ~31.6s long, starting from when STM's
+# _wait_for_lsl_recording_to_start began polling).
+# Use server_time of the "Waiting for LSL startup took: 31.62" log entry as
+# the END of the window, then 31.6s before for the start.
+TIMEOUTS_END = [
+    "2026-04-29 19:56:44.713206",
+    "2026-04-29 20:01:06.415293",
+    "2026-04-29 20:02:41.507213",
+    "2026-04-29 20:03:22.463487",
+    "2026-04-29 20:04:05.777592",
+]
+
+
+def main():
+    conn, tunnel = get_conn()
+    try:
+        # 0. Confirm CTR writes to log_system_resource at all + show overall sample
+        # cadence for the session window
+        ranges = pd.read_sql_query("""
+            SELECT machine_name, COUNT(*) AS n,
+                   MIN(created_at) AS first, MAX(created_at) AS last
+            FROM log_system_resource
+            WHERE created_at BETWEEN '2026-04-29 19:25' AND '2026-04-29 20:35'
+            GROUP BY machine_name ORDER BY machine_name
+        """, conn)
+        print("=== log_system_resource activity 19:25 - 20:35 UTC ===")
+        print(ranges.to_string(index=False))
+
+        # 1. What server_types appear in log_application for this session?
+        q1 = """
+        SELECT server_type, server_id, COUNT(*) AS n,
+               MIN(server_time) AS first_seen, MAX(server_time) AS last_seen
+        FROM log_application
+        WHERE session_id = %s
+        GROUP BY server_type, server_id
+        ORDER BY server_type, server_id
+        """
+        print("=== server_type / server_id breakdown for session 3223 ===")
+        print(pd.read_sql_query(q1, conn, params=(SESSION_NAME,)).to_string(index=False))
+
+        # 2. log_system_resource: schema and any CTR rows for the day
+        cols = pd.read_sql_query("""
+            SELECT column_name FROM information_schema.columns
+            WHERE table_name = 'log_system_resource' ORDER BY ordinal_position""", conn)
+        print(f"\n=== log_system_resource columns ===")
+        print(", ".join(cols["column_name"].tolist()))
+
+        # 3. Per-window: any log_application or log_system_resource rows
+        # that landed *during* each timeout window
+        for end_ts in TIMEOUTS_END:
+            end_t = pd.Timestamp(end_ts, tz="UTC")
+            start_t = end_t - pd.Timedelta(seconds=31.6)
+            print(f"\n\n--- window {start_t} -> {end_t} ---")
+
+            # log_application — anything from any source during the window
+            la = pd.read_sql_query("""
+                SELECT server_time, server_type, server_id, log_level, function, message
+                FROM log_application
+                WHERE server_time BETWEEN %s AND %s
+                  AND session_id = %s
+                ORDER BY server_time
+            """, conn, params=(start_t, end_t, SESSION_NAME))
+            la = la[~la["message"].str.contains("MESSAGE RECEIVED", na=False)]
+            la["message"] = la["message"].str[:120]
+            print(f"  log_application rows during window: {len(la)}")
+            n_ctr = (la["server_type"] == "control").sum() if "control" in la["server_type"].unique() else 0
+            n_stm = (la["server_type"] == "presentation").sum()
+            n_acq = (la["server_type"] == "acquisition").sum()
+            print(f"    by server_type: control={n_ctr}  presentation={n_stm}  acquisition={n_acq}")
+            # If there are any CTR rows during the window, that's evidence of life
+            ctr_rows = la[la["server_type"] == "control"]
+            if not ctr_rows.empty:
+                print(f"  CTR rows during window:")
+                with pd.option_context("display.max_colwidth", 130, "display.width", 240):
+                    print(ctr_rows.to_string(index=False))
+
+            # log_system_resource — does CTR have a sample during the window?
+            try:
+                lsr = pd.read_sql_query("""
+                    SELECT * FROM log_system_resource
+                    WHERE created_at BETWEEN %s AND %s
+                      AND machine_name = 'CTR'
+                    ORDER BY created_at
+                """, conn, params=(start_t, end_t))
+                print(f"  log_system_resource rows for CTR during window: {len(lsr)}")
+                if not lsr.empty:
+                    keep = [c for c in ["created_at", "machine_name", "cpu_usage",
+                                         "ram_used", "ram_total"]
+                            if c in lsr.columns]
+                    print(lsr[keep].to_string(index=False))
+            except Exception as e:
+                print(f"  log_system_resource query failed: {e}")
+    finally:
+        conn.close()
+        if tunnel is not None:
+            tunnel.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/perf/_investigate_3223_lsl.py
+++ b/extras/perf/_investigate_3223_lsl.py
@@ -1,0 +1,62 @@
+"""Investigate the 31.6s LSL-startup pattern in session 3223."""
+import pandas as pd
+from _db import get_conn
+
+SESSION_NAME = "101120_2026-04-29"  # 3223 = subject 101120
+
+def main():
+    conn, tunnel = get_conn()
+    try:
+        # 1. Confirm session_id
+        sn_q = "SELECT log_session_id, subject_id, date::text AS date FROM log_session WHERE log_session_id = 3223"
+        print(pd.read_sql_query(sn_q, conn).to_string(index=False))
+
+        # 2. All Waiting-for-LSL-startup lines for this session, in order
+        q1 = """
+        SELECT server_time, message
+        FROM log_application
+        WHERE session_id = %s
+          AND message LIKE 'Waiting for LSL startup took:%%'
+        ORDER BY server_time
+        """
+        df = pd.read_sql_query(q1, conn, params=(SESSION_NAME,))
+        df["sec"] = df["message"].str.extract(r"took: ([\d.]+)").astype(float)
+        print(f"\n=== {len(df)} LSL-startup waits in session 3223 ===")
+        print(f"Distribution of seconds:")
+        print(df["sec"].describe().round(2).to_string())
+        print("\nAll values:")
+        print(df.to_string(index=False))
+
+        # 3. Did the timeout warning fire? Check for 'LsLRecording not received' AND
+        # other CTR-related issues during the session
+        q2 = """
+        SELECT server_time, server_type, log_level, function, message
+        FROM log_application
+        WHERE session_id = %s
+          AND (message ILIKE '%%LsLRecording%%not received%%'
+            OR message ILIKE '%%lsl%%'
+            OR (log_level IN ('WARNING','ERROR','CRITICAL') AND server_type = 'presentation'))
+        ORDER BY server_time
+        """
+        df2 = pd.read_sql_query(q2, conn, params=(SESSION_NAME,))
+        df2["message"] = df2["message"].str[:140]
+        print(f"\n=== LSL-related + warning lines for session 3223 ({len(df2)}) ===")
+        with pd.option_context("display.max_colwidth", 150, "display.width", 240,
+                               "display.max_rows", 200):
+            print(df2.to_string(index=False))
+
+        # 4. Compare against another session that day to see if it's session-specific
+        for sid in ["101031_2026-04-29", "101119_2026-04-29",
+                    "100975_2026-04-29", "101123_2026-04-29"]:  # 3220, 3221, 3222, 3224
+            d = pd.read_sql_query(q1, conn, params=(sid,))
+            d["sec"] = d["message"].str.extract(r"took: ([\d.]+)").astype(float)
+            print(f"\n--- {sid}: n={len(d)}, median={d['sec'].median():.2f}, "
+                  f"max={d['sec'].max():.2f}, n_over_20s={int((d['sec']>20).sum())}")
+    finally:
+        conn.close()
+        if tunnel is not None:
+            tunnel.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/perf/_investigate_top3_outliers.py
+++ b/extras/perf/_investigate_top3_outliers.py
@@ -1,0 +1,76 @@
+"""Find the 3 longest transitions in this week's CSV and pull the
+log_application window around each to look for attributable causes.
+"""
+import pandas as pd
+from _db import get_conn
+
+CSV = "intertask_from_applog.csv"
+TOP_N = 3
+WINDOW_BEFORE = 30  # seconds before the transition started
+WINDOW_AFTER  = 5   # seconds after end
+
+
+def main():
+    df = pd.read_csv(CSV)
+    df["from_finished_at"] = pd.to_datetime(df["from_finished_at"])
+    df["to_started_at"]    = pd.to_datetime(df["to_started_at"])
+    df["transition_at"]    = pd.to_datetime(df["transition_at"])
+
+    top = df.nlargest(TOP_N, "transition_sec")[
+        ["log_session_id", "from_task", "to_task", "transition_sec",
+         "from_finished_at", "to_started_at", "transition_at",
+         "stm_stop_acq_sec", "stm_wait_acq_sec", "stm_idle_sec",
+         "acq0_stop_sec", "acq0_start_sec", "acq1_stop_sec", "acq1_start_sec"]
+    ].reset_index(drop=True)
+
+    print("=== Top 3 longest transitions ===")
+    with pd.option_context("display.max_colwidth", 30, "display.width", 220):
+        print(top.to_string(index=False))
+
+    conn, tunnel = get_conn()
+    try:
+        for i, r in top.iterrows():
+            print(f"\n\n========= #{i+1}: session {int(r['log_session_id'])} "
+                  f"{r['from_task']} -> {r['to_task']}: {r['transition_sec']:.1f}s =========")
+            print(f"  STM phases — stop_acq={r['stm_stop_acq_sec']}  "
+                  f"wait_acq={r['stm_wait_acq_sec']}  idle={r['stm_idle_sec']}")
+            print(f"  ACQ_0 — stop={r['acq0_stop_sec']}  start={r['acq0_start_sec']}")
+            print(f"  ACQ_1 — stop={r['acq1_stop_sec']}  start={r['acq1_start_sec']}")
+            print(f"  Window: {r['from_finished_at']} -> {r['to_started_at']} -> {r['transition_at']}")
+
+            win_start = r["from_finished_at"] - pd.Timedelta(seconds=WINDOW_BEFORE)
+            win_end   = r["transition_at"]    + pd.Timedelta(seconds=WINDOW_AFTER)
+
+            q = """
+            SELECT server_time, server_type, server_id, log_level, device, function, message
+            FROM log_application
+            WHERE server_time BETWEEN %s AND %s
+            ORDER BY server_time
+            """
+            la = pd.read_sql_query(q, conn, params=(win_start, win_end))
+            # Drop noisiest debug lines that would bury the signal
+            la = la[~la["message"].str.contains("MESSAGE RECEIVED", na=False)]
+            # Surface anomalies: warnings/errors, retries, resets, long waits
+            anom = la[
+                (la["log_level"].isin(["WARNING", "ERROR", "CRITICAL"]))
+                | la["message"].str.contains(
+                    "retry|reset|reconnect|disconn|timeout|abort|fail|exception|"
+                    "wait.*took|stop.*took|start.*took|skip|drop|stale",
+                    case=False, na=False, regex=True
+                )
+            ].copy()
+            anom["message"] = anom["message"].str[:160]
+
+            print(f"\n  Anomalies + phase-time lines in window ({len(anom)} of {len(la)}):")
+            with pd.option_context("display.max_colwidth", 170, "display.width", 280,
+                                   "display.max_rows", 200):
+                print(anom[["server_time", "server_type", "server_id", "log_level",
+                            "device", "function", "message"]].to_string(index=False))
+    finally:
+        conn.close()
+        if tunnel is not None:
+            tunnel.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the four `extras/perf/` investigation scripts that were used while looking into #753 (intermittent 30s LSL-startup timeouts in sessions 3220 / 3223 on 2026-04-29). All four were already on disk, just not under version control. Mirrors the existing leading-underscore convention in `extras/perf/` for internal/diagnostic scripts.

| Script | Reusability |
|---|---|
| `_correlate_freezes.py` | Generalizable. Correlates CTR freezes with STM/ACQ `log_system_resource` gaps; hardcoded session IDs swap easily when the issue recurs. Source of the "consecutive `log_system_resource` gaps >30s on `machine_name='CTR'` signal a process- or machine-level freeze" finding. |
| `_investigate_top3_outliers.py` | Generic. Reads whatever CSV is at `intertask_from_applog.csv` (regenerated via the tracked `_intertask_from_applog.py`) and pulls the `log_application` window around the top-N longest transitions. |
| `_investigate_3223_lsl.py` | Session-3223 specific. Hardcoded session id; committed for historical-record / methodology recovery if #753 recurs. |
| `_ctr_during_lsl_timeout.py` | Session-3223 specific. Hardcoded the five exact timeout timestamps; same rationale as above. |

## Test plan

- [x] All four files compile (no syntax errors).
- [ ] When #753 recurs, swap the session IDs in `_correlate_freezes.py` and re-run; methodology should hold.

Refs #753.
