### PR TITLE
Guard pylink import in saccade_task.py and pursuit_task.py

### DIFF
--- a/neurobooth_os/tasks/saccade/saccade_task.py
+++ b/neurobooth_os/tasks/saccade/saccade_task.py
@@ -1,8 +1,30 @@
 # -*- coding: utf-8 -*-
-import pylink
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix
 from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC
 import numpy as np
+
+# Hardware import — guarded so this module is importable on a hardware-less
+# machine. ACQ pulls task constructors via meta.build_tasks_for_collection's
+# dynamic import (metadator.py:727) and would otherwise fail on a booth
+# without the EyeLink SDK installed even though ACQ never executes the task.
+# Mirrors the pattern in tasks/task_eyetracker.py and iout/eyelink_tracker.py.
+try:
+    import pylink
+    _HAS_PYLINK = True
+except ImportError:
+    pylink = None  # type: ignore[assignment]
+    _HAS_PYLINK = False
+
+
+def _require_pylink() -> None:
+    """Raise a clear error if real-EyeLink code is reached without pylink."""
+    if not _HAS_PYLINK:
+        raise RuntimeError(
+            "EyeLink hardware code path invoked but pylink is not installed. "
+            "Install the EyeLink SDK (uv sync --extra eyelink) to use a real "
+            "EyeLink, or use MockEyeTracker via NB_MOCK_DEVICES=EyeTracker "
+            "for hardware-less testing."
+        )
 
 
 class Saccade(Eyelink_HostPC):
@@ -107,7 +129,9 @@ class Saccade(Eyelink_HostPC):
         # Send trial variables to record in the EDF data file
         self.sendMessage(f"!V TRIAL_VAR amp_x {amp_x:.2f}")
         self.sendMessage(f"!V TRIAL_VAR amp_y {amp_y:.2f}")
-        pylink.pumpDelay(1)  # give the tracker a break
+        if self.eye_tracker is not None:
+            _require_pylink()
+            pylink.pumpDelay(1)  # give the tracker a break
         self.sendMessage(f"!V TRIAL_VAR ntrials {self.ntrials:.2f}")
 
         # Send a 'TRIAL_RESULT' message to mark the end of the trial

--- a/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
+++ b/neurobooth_os/tasks/smooth_pursuit/pursuit_task.py
@@ -2,9 +2,32 @@
 import numpy as np
 from math import sin, pi
 from psychopy import core
-import pylink
+
 from neurobooth_os.tasks.smooth_pursuit.utils import deg2pix, peak_vel2freq, deg2rad
 from neurobooth_os.tasks.task_eyetracker import Eyelink_HostPC
+
+# Hardware import — guarded so this module is importable on a hardware-less
+# machine. ACQ pulls task constructors via meta.build_tasks_for_collection's
+# dynamic import (metadator.py:727) and would otherwise fail on a booth
+# without the EyeLink SDK installed even though ACQ never executes the task.
+# Mirrors the pattern in tasks/task_eyetracker.py and iout/eyelink_tracker.py.
+try:
+    import pylink
+    _HAS_PYLINK = True
+except ImportError:
+    pylink = None  # type: ignore[assignment]
+    _HAS_PYLINK = False
+
+
+def _require_pylink() -> None:
+    """Raise a clear error if real-EyeLink code is reached without pylink."""
+    if not _HAS_PYLINK:
+        raise RuntimeError(
+            "EyeLink hardware code path invoked but pylink is not installed. "
+            "Install the EyeLink SDK (uv sync --extra eyelink) to use a real "
+            "EyeLink, or use MockEyeTracker via NB_MOCK_DEVICES=EyeTracker "
+            "for hardware-less testing."
+        )
 
 
 class Pursuit(Eyelink_HostPC):
@@ -108,7 +131,9 @@ class Pursuit(Eyelink_HostPC):
         self.sendMessage(f"!V TRIAL_VAR amp_x {amp_x:.2f}")
         self.sendMessage(f"!V TRIAL_VAR amp_y {amp_y:.2f}")
         self.sendMessage(f"!V TRIAL_VAR phase_x {phase_x:.2f}")
-        pylink.pumpDelay(1)  # give the tracker a break
+        if self.eye_tracker is not None:
+            _require_pylink()
+            pylink.pumpDelay(1)  # give the tracker a break
         self.sendMessage(f"!V TRIAL_VAR phase_y {phase_y:.2f}")
         self.sendMessage(f"!V TRIAL_VAR freq_x {freq_x:.2f}")
         self.sendMessage(f"!V TRIAL_VAR freq_y {freq_y:.2f}")


### PR DESCRIPTION
## Summary

Follow-up to #771. That PR guarded the eager-import path (`tasks/__init__.py` → `task_eyetracker.py`); this PR guards the **dynamic-import path** that ACQ takes when handling a `PrepareRequest`:

```
server_acq.py:111   meta.build_tasks_for_collection
metadator.py:703    build_task
metadator.py:727    str_fileid_to_eval(task_constructor, ...)
metadator.py:98     importlib.import_module("neurobooth_os.tasks.<X>")
```

For a collection containing saccade or smooth-pursuit tasks, that dynamic import landed in `saccade_task.py` or `pursuit_task.py`, both of which had unguarded module-level `import pylink`. ACQ machines without the EyeLink SDK installed therefore raised `ModuleNotFoundError` mid-handler and failed to prepare the session — even though ACQ never executes EyeLink tasks (STM does).

Symptom observed: ACQ on merrimac (running v0.91.1) errors out when preparing a session.

## Fix

Mirrors the #771 pattern. In each file:

```python
try:
    import pylink
    _HAS_PYLINK = True
except ImportError:
    pylink = None
    _HAS_PYLINK = False

def _require_pylink() -> None:
    if not _HAS_PYLINK: raise RuntimeError(...)
```

The single runtime use in each file — `pylink.pumpDelay(1)` ("give the tracker a break") — is gated by `if self.eye_tracker is not None:`, matching the implicit pattern in the rest of these files. Every other pylink-related call in saccade_task / pursuit_task already routes through `self.eye_tracker.tk.*`, all of which short-circuit when `eye_tracker is None`. The `pumpDelay` call was the one that didn't follow the pattern. `_require_pylink()` runs inside that branch as defense in depth.

## Why `EyeLinkCoreGraphicsPsychoPy.py` is not touched

That file has the same unguarded `import pylink` plus a class that inherits from `pylink.EyeLinkCustomDisplay` at **class-definition time**, which can't be guarded without a stub-class trick. But it's not on the merrimac error path:

- It is not a task constructor, so `build_tasks_for_collection` does not pull it in.
- The only importer is `iout/eyelink_tracker.py:211`, which lazy-imports it from inside `calibrate()` — called only on STM, where pylink is installed.

So leaving it unguarded does not affect ACQ. Touching it requires a stub-class refactor that is out of scope for the merrimac fix.

## Test plan

- [x] `uv run ruff check` — clean.
- [x] Reproduction: `uv pip uninstall sr-research-pylink` then `importlib.import_module('neurobooth_os.tasks.saccade.saccade_task')` and `...smooth_pursuit.pursuit_task` — previously raised `ModuleNotFoundError`, now both succeed.
- [x] `_HAS_PYLINK == False` and `pylink is None` in both modules when the SDK is absent.
- [ ] Operator: redeploy on merrimac ACQ (does *not* need pylink installed); confirm `PrepareRequest` no longer errors.
- [ ] Real-EyeLink behavior on STM: with pylink installed, both `saccade` and `smooth-pursuit` task runs should be byte-identical to pre-PR (the `_HAS_PYLINK == True` path is a strict no-op vs. before).

Refs #771.
