### PR TITLE
Ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ server_pids.txt
 .gemini/
 GEMINI.md
 CLAUDE.local.md
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.local.json` to `.gitignore`. The file holds per-user Claude Code permissions and local harness state and should not be shared via the repo.
- Sits with the existing AI-tooling block alongside `CLAUDE.local.md` and `.gemini/`.

## Test plan

- [x] `git status` no longer lists `.claude/settings.local.json` as untracked on a workstation that has the file present.