### PR TITLE
Fix server-launch mechanism in wang system diagram

### DIFF
--- a/docs/arch/wang_system_diagram.md
+++ b/docs/arch/wang_system_diagram.md
@@ -16,7 +16,7 @@
 |  |  |  - Session orchestration   |  |  |  |  Process with threads:     |  ||
 |  |  |  - LSL recording -> XDF    |  |  |  |  - Main (message loop)     |  ||
 |  |  |  - Remote server launch    |  |  |  |  - DeviceManager threads   |  ||
-|  |  |    (via WMI)               |  |  |  |  - SystemResourceLogger    |  ||
+|  |  |    (via SCHTASKS)          |  |  |  |  - SystemResourceLogger    |  ||
 |  |  |  - Data transfer (robo-    |  |  |  |                             |  ||
 |  |  |    copy to Z: drive)       |  |  |  |  Devices:                   |  ||
 |  |  |                            |  |  |  |   Intel_D455_1 [037522..]   |  ||


### PR DESCRIPTION
## Summary

- `docs/arch/wang_system_diagram.md` described remote server launch as `(via WMI)`, but server launch from CTR actually goes through `SCHTASKS` (Task Scheduler).
- WMI / `Get-CimInstance` is only used for process inventory and cleanup in `neurobooth_os/netcomm/client.py` — not for launching servers.
- `docs/single_machine_testing.md` already states this correctly: *"ACQ and STM servers are started by the GUI through Windows `SCHTASKS`."* This change aligns the diagram with the rest of the docs and the code.

Surfaced while closing out #760 (WMIC → Get-CimInstance rewrite). Not a code-touching change; pure doc fix.

## Test plan

- [x] `git diff --stat` shows only `docs/arch/wang_system_diagram.md` (1 line changed).
- [x] ASCII-art box alignment preserved (28-char inner cell width, verified by eye against adjacent rows).