### PR TITLE
Use python instead of ipython in transfer/postprocess bats (#781)

### DIFF
--- a/extras/postprocess_split_xdf.bat
+++ b/extras/postprocess_split_xdf.bat
@@ -1,2 +1,2 @@
 call %NB_INSTALL%\.venv\Scripts\activate.bat
-call start /W ipython %NB_INSTALL%\extras\run_xdf_split_postproces.py
+call start /W python %NB_INSTALL%\extras\run_xdf_split_postproces.py

--- a/neurobooth_os/transfer_data.bat
+++ b/neurobooth_os/transfer_data.bat
@@ -1,3 +1,3 @@
 call %NB_INSTALL%\.venv\Scripts\activate.bat
-start /W ipython %NB_INSTALL%\extras\dump_iphone_video.py
-start /W ipython %NB_INSTALL%\neurobooth_os\transfer_data.py
+start /W python %NB_INSTALL%\extras\dump_iphone_video.py
+start /W python %NB_INSTALL%\neurobooth_os\transfer_data.py


### PR DESCRIPTION
## Summary

- Swap `ipython` → `python` in `neurobooth_os/transfer_data.bat` and `extras/postprocess_split_xdf.bat`.
- Fixes the end-of-day scheduled task failures at Wang reported in #781.

## Why this is the right fix

The three scripts these bats launch — `transfer_data.py`, `dump_iphone_video.py`, `run_xdf_split_postproces.py` — do not use any IPython feature (no magics, no `get_ipython`, no `IPython` import). `ipython script.py` here is equivalent to `python script.py` but with a much heavier startup path.

## Why ipython was breaking post-#758

The console output captured on STM:

```
ImportError: DLL load failed while importing _sqlite3: The specified module could not be found.
```

Reading the traceback paths:

- `runpy.py` and `sqlite3\__init__.py` resolve under `C:\Users\STM\anaconda3\lib\...`
- `IPython\*` resolves under `.venv\lib\site-packages\IPython\...`

On Windows, a venv shares the **stdlib** of the interpreter it was created from. The uv-managed `.venv` on Wang was created against base anaconda3, and base anaconda3's `_sqlite3.pyd` fails to load (DLL dependency missing). `ipython` imports `sqlite3` at startup via `IPython.core.history.HistoryManager`, so it crashes before reaching the script body — matching the "console flashes and dies, no log entries, no transfer" symptom.

Plain `python script.py` never imports `sqlite3` for these scripts, so it sidesteps the broken DLL entirely. This also explains the differential noted in #781: `server_*.bat` (which run `python`) work fine; only the `ipython`-launched bats fail.

Pre-#758 this also worked because the bats activated the conda env `neurobooth-os`, whose stdlib lives under `anaconda3\envs\neurobooth-os\` — separate from the broken base anaconda3 stdlib.

## Scope

Minimal — only the two bats. The stray leading `call ` before `start /W` in `postprocess_split_xdf.bat` is left as-is (harmless; outside the scope of this fix).

The broken `_sqlite3` in base anaconda3 on Wang is a real machine-level issue but is not on the critical path for these scheduled tasks once they stop using ipython. It can be addressed separately if/when anything else needs sqlite3.

## Test plan

- [ ] On Wang STM: `cmd /K "%NB_INSTALL%\neurobooth_os\transfer_data.bat"` — console stays open, no `_sqlite3` ImportError, iPhone dump no-ops cleanly, transfer runs.
- [ ] On Wang ACQ: `cmd /K "%NB_INSTALL%\neurobooth_os\transfer_data.bat"` — same, with the iPhone dump actually running.
- [ ] On Wang CTR: `cmd /K "%NB_INSTALL%\extras\postprocess_split_xdf.bat"` — `run_xdf_split_postproces.py` runs and splits xdf for a recent session.
- [ ] Re-trigger the end-of-day scheduled task on each machine and confirm `log_application` shows the expected entries and the NAS receives the session data.