### PR TITLE
Surface missing-Marker failure loudly + bump LSL resolve timeout (compensating, not root-fix)

### DIFF
--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -940,7 +940,17 @@ def gui(logger):
                     write_output(window, "\nSession complete: OK to terminate", 'blue')
 
             elif event == 'devices_connected':
-                controller.start_lsl_session(state.sess_info["subject_id_date"])
+                try:
+                    controller.start_lsl_session(state.sess_info["subject_id_date"])
+                except RuntimeError as e:
+                    # start_lsl_session refuses to proceed when an expected
+                    # stream (e.g. Marker) is missing from CTR's state.inlets.
+                    # Surface the failure to the operator as a dismissable
+                    # popup so the GUI stays alive and they can act on it
+                    # (e.g. restart STM and retry).
+                    sg.popup_error(str(e), title="Cannot start session",
+                                   location=get_popup_location(window))
+                    continue
                 enable_frame_preview(window, state.frame_preview_devices)
                 if not state.start_pressed:
                     window['Start'].update(disabled=False)

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -190,11 +190,24 @@ class DeviceManager:
             with register_lock:
                 self.streams[device_id] = device
 
+        # Bring up SESSION_LEVEL devices (today: marker) before anything else.
+        # Their LSL outlets need to be advertised and resolvable on CTR before
+        # any hardware-heavy device contends for the network — otherwise CTR's
+        # 1s resolve_byprop() in create_lsl_inlets can miss them, the inlet
+        # never gets registered, and LabRecorderCLI is not told to record the
+        # stream. Pre-dde7f47 the marker was hard-coded to start first; this
+        # restores that ordering under the config-driven path.
+        for device_id in self.assigned_devices:
+            if device_id in session_device_args:
+                start_and_register_device(session_device_args[device_id])
+
         with ThreadPoolExecutor(max_workers=N_ASYNC_THREADS) as executor:
             futures = []
             for device_id in self.assigned_devices:
                 if device_id not in all_device_args:
                     continue
+                if device_id in session_device_args:
+                    continue  # Already started above
                 device_args = all_device_args[device_id]
                 if device_id in ASYNC_STARTUP:
                     futures.append(executor.submit(start_and_register_device, device_args))

--- a/neurobooth_os/iout/lsl_streamer.py
+++ b/neurobooth_os/iout/lsl_streamer.py
@@ -190,24 +190,11 @@ class DeviceManager:
             with register_lock:
                 self.streams[device_id] = device
 
-        # Bring up SESSION_LEVEL devices (today: marker) before anything else.
-        # Their LSL outlets need to be advertised and resolvable on CTR before
-        # any hardware-heavy device contends for the network — otherwise CTR's
-        # 1s resolve_byprop() in create_lsl_inlets can miss them, the inlet
-        # never gets registered, and LabRecorderCLI is not told to record the
-        # stream. Pre-dde7f47 the marker was hard-coded to start first; this
-        # restores that ordering under the config-driven path.
-        for device_id in self.assigned_devices:
-            if device_id in session_device_args:
-                start_and_register_device(session_device_args[device_id])
-
         with ThreadPoolExecutor(max_workers=N_ASYNC_THREADS) as executor:
             futures = []
             for device_id in self.assigned_devices:
                 if device_id not in all_device_args:
                     continue
-                if device_id in session_device_args:
-                    continue  # Already started above
                 device_args = all_device_args[device_id]
                 if device_id in ASYNC_STARTUP:
                     futures.append(executor.submit(start_and_register_device, device_args))

--- a/neurobooth_os/realtime/lsl_plotter.py
+++ b/neurobooth_os/realtime/lsl_plotter.py
@@ -15,9 +15,6 @@ import threading
 from neurobooth_os.log_manager import APP_LOG_NAME
 
 
-LSL_RESOLVE_TIMEOUT_S = 5.0
-
-
 def create_lsl_inlets(stream_ids):
     """Create LSL inlets on CTR computer.
 
@@ -30,23 +27,21 @@ def create_lsl_inlets(stream_ids):
     -------
     dict of StreamInlet
         The inlet streams. A missing entry means the corresponding outlet
-        could not be resolved within ``LSL_RESOLVE_TIMEOUT_S`` and will not
-        be recorded by LabRecorderCLI; a warning is logged in that case so
-        the silent-drop is observable in ``log_application``.
+        could not be resolved within the timeout and will not be recorded
+        by LabRecorderCLI; a warning is logged in that case so the silent
+        drop is observable in ``log_application``.
     """
     logger = logging.getLogger(APP_LOG_NAME)
     inlets = {}
     for outlet_name, id_stream in stream_ids.items():
-        stream = pylsl.resolve_byprop("source_id", id_stream,
-                                      timeout=LSL_RESOLVE_TIMEOUT_S)
+        stream = pylsl.resolve_byprop("source_id", id_stream, timeout=1)
         if stream:
             inlet = pylsl.StreamInlet(stream[0])
             inlets[stream[0].name()] = inlet
         else:
             logger.warning(
                 f"create_lsl_inlets: outlet '{outlet_name}' (source_id={id_stream}) "
-                f"not resolvable within {LSL_RESOLVE_TIMEOUT_S}s; stream will NOT "
-                f"be recorded by LabRecorderCLI."
+                f"not resolvable; stream will NOT be recorded by LabRecorderCLI."
             )
     return inlets
 

--- a/neurobooth_os/realtime/lsl_plotter.py
+++ b/neurobooth_os/realtime/lsl_plotter.py
@@ -3,12 +3,19 @@
 Plots device output in realtime
 """
 
+import logging
+
 import numpy as np
 import pylsl
 import matplotlib.pyplot as plt
 import matplotlib
 import cv2
 import threading
+
+from neurobooth_os.log_manager import APP_LOG_NAME
+
+
+LSL_RESOLVE_TIMEOUT_S = 5.0
 
 
 def create_lsl_inlets(stream_ids):
@@ -22,14 +29,25 @@ def create_lsl_inlets(stream_ids):
     Returns
     -------
     dict of StreamInlet
-        The inlet streams.
+        The inlet streams. A missing entry means the corresponding outlet
+        could not be resolved within ``LSL_RESOLVE_TIMEOUT_S`` and will not
+        be recorded by LabRecorderCLI; a warning is logged in that case so
+        the silent-drop is observable in ``log_application``.
     """
+    logger = logging.getLogger(APP_LOG_NAME)
     inlets = {}
-    for id_stream in stream_ids.values():
-        stream = pylsl.resolve_byprop("source_id", id_stream, timeout=1)
+    for outlet_name, id_stream in stream_ids.items():
+        stream = pylsl.resolve_byprop("source_id", id_stream,
+                                      timeout=LSL_RESOLVE_TIMEOUT_S)
         if stream:
             inlet = pylsl.StreamInlet(stream[0])
             inlets[stream[0].name()] = inlet
+        else:
+            logger.warning(
+                f"create_lsl_inlets: outlet '{outlet_name}' (source_id={id_stream}) "
+                f"not resolvable within {LSL_RESOLVE_TIMEOUT_S}s; stream will NOT "
+                f"be recorded by LabRecorderCLI."
+            )
     return inlets
 
 

--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -441,6 +441,24 @@ class SessionController:
     def start_lsl_session(self, folder: str) -> None:
         """Create an LSL recording session."""
         import liesl
+
+        # Refuse to start if the Marker inlet failed to register on CTR
+        # despite the marker being configured. Without "Marker" in
+        # state.inlets LabRecorderCLI is never told to record it and the
+        # XDF lands with no task event annotations — only visible later
+        # when postprocess_xdf_split trips an IndexError. Gate on the
+        # config so deployments that legitimately do not run a marker
+        # are not affected.
+        marker_expected = "marker" in cfg.neurobooth_config.presentation.devices
+        if marker_expected and "Marker" not in self.state.inlets:
+            msg = (
+                "Marker event stream is missing — refusing to start "
+                "recording. Without the Marker stream, session data would "
+                "have no task annotations. Restart STM and try again."
+            )
+            self.logger.critical(msg)
+            raise RuntimeError(msg)
+
         streamargs = [{"name": n} for n in list(self.state.inlets)]
         self.state.session = liesl.Session(
             prefix=folder,


### PR DESCRIPTION
## Summary

Defensive measures for the missing-`Marker`-stream symptom described in #785. **This PR does not fix the root cause** — STM is creating the marker LSL outlet successfully on every Wang session; the failure is in LSL transmission/visibility between STM and CTR's LabRecorderCLI, most likely a consequence of the bundled-`liblsl` swap introduced by the conda → uv migration (#758) and deployed at Wang on 2026-05-09. The real fix is `liblsl` pinning, tracked in #791.

Two small changes:

### 1. `realtime/lsl_plotter.create_lsl_inlets`: warn-on-miss

Previously, when `pylsl.resolve_byprop` returned empty for an outlet, the `if stream:` branch silently dropped it — LabRecorderCLI was handed a `streamargs` list missing those entries, the XDF landed without those streams, and nothing logged anywhere. Now an `else` branch logs a warning naming the missing outlet (`source_id` and outlet name), so any silent inlet-resolve failure is observable in `log_application` instead of leaving us to discover it from a missing-stream XDF symptom hours later. The 1s timeout is unchanged from the original.

### 2. `session_controller.start_lsl_session` + `gui.py` event handler: fail-loud with operator popup

If `"Marker"` is missing from `state.inlets` at the moment LSL recording would start, *and* the marker is configured in `presentation.devices` for this deployment, `start_lsl_session` now logs `CRITICAL` and raises `RuntimeError` with an operator-readable message: *"Marker event stream is missing — refusing to start recording. Without the Marker stream, session data would have no task annotations. Restart STM and try again."*

The `devices_connected` event handler in `gui.py` catches the `RuntimeError` and surfaces it via `sg.popup_error` (matching the pattern already used elsewhere for operator-facing refusals like "Study and Collection are required fields"). The GUI stays alive; the operator gets a dismissable dialog with the message and can act on it (restart STM, retry). Without this popup catch, the raise would propagate out of the event loop and crash the GUI entirely, which is worse than the silent-markerless-XDF status quo.

The check is gated on `"marker" in cfg.neurobooth_config.presentation.devices` so deployments that legitimately do not run a marker stream are unaffected.

## What's been removed from this branch

Earlier versions of this branch contained:

- A "marker-first ordering" change in `DeviceManager.create_streams`. Reverted in commit `83bd6b3` — direct inspection of Wang STM logs shows STM successfully brings up the marker outlet on every session, so the ordering theory is contradicted by data.
- A 5s `resolve_byprop` timeout bump in `create_lsl_inlets`. Reverted in commit `b37571e` — motivated by a "slow discovery race" theory that the data has now contradicted (six months of clean sessions on the 1s timeout pre-deploy, sharp deterministic failure post-deploy). The bump was a guess with no supporting evidence; 4 extra seconds per missing outlet adds nothing if the outlet is genuinely undiscoverable.

Net diff vs. master is now ~30 lines across three files.

## Honest framing

This PR addresses **observability** and **operator UX**, not the underlying transmission bug:

- The warn-on-miss makes silent inlet drops visible in `log_application`. Useful regardless of root cause; provides diagnostic signal for #791.
- The fail-loud + popup converts a silent markerless-XDF outcome into a session-start refusal with an operator-readable message. Replaces "session runs, data is bad, nobody notices until tomorrow's split" with "session refuses to start, operator restarts STM."

Neither change recovers the data when STM-CTR LSL transmission is broken. That's #791's job.

## Files changed

- `neurobooth_os/realtime/lsl_plotter.py` — add `import logging`, import `APP_LOG_NAME`, change `.values()` → `.items()` to expose `outlet_name`, add `else` branch with warning log.
- `neurobooth_os/session_controller.py` — `start_lsl_session` checks for the configured-but-missing-Marker case and raises with a critical-level log.
- `neurobooth_os/gui.py` — `devices_connected` handler wraps the `start_lsl_session` call in try/except + `sg.popup_error`.

## Test plan

Live verification on Wang after deploy:

- [ ] Run a session. Inspect the new XDF: `pyxdf.load_xdf(...)` should ideally return a stream with `info.name == ['Marker']`. **If it does not** — which is likely until #791 lands — the operator should have seen the `"Marker event stream is missing"` popup at session-prep time and chosen whether to retry. Either outcome is information.
- [ ] `log_application` query for `create_lsl_inlets:` warning entries since deploy. Every such entry is direct evidence of CTR-side inlet-resolve failure for a specific outlet and is itself valuable for #791 diagnosis.
- [ ] (Negative test, optional) Temporarily rename `marker.yml` and confirm the popup appears at `'devices_connected'` time and the operator can dismiss it.

I can't run any of these locally — the booth machines are in active use and the failure mode only manifests under the live multi-machine session flow.

## Not in this PR

- The actual fix: pinning / shipping a known-good `liblsl` build to replace the PyPI-wheel-bundled one. Tracked in #791.
- Cleaning up the stale CTR `split_xdf_backlog.csv` entries from the orchestration gap. Tracked in #787.
- Closing the transfer/split orchestration gap. Tracked in #788.
- General "verify all expected inlets present" gate (this PR only protects `Marker`).

## Related

- Refs #785
- Resolves the operator-visibility side of #781; the actual data-loss fix is #791.
