### PR TITLE
Log all LSL streams visible to CTR at session start (diagnostic for #791)

### DIFF
--- a/neurobooth_os/session_controller.py
+++ b/neurobooth_os/session_controller.py
@@ -441,6 +441,24 @@ class SessionController:
     def start_lsl_session(self, folder: str) -> None:
         """Create an LSL recording session."""
         import liesl
+        import pylsl
+
+        # Diagnostic snapshot: log everything CTR's pylsl can see on the
+        # LSL network at session-start time, alongside the inlets we have
+        # registered via DeviceInitialization messages. Tracking #791 — if
+        # an expected stream is missing from state.inlets but visible to
+        # resolve_streams, the failure is in DeviceInitialization routing;
+        # if it's missing from BOTH, the failure is in LSL transmission
+        # itself (the bundled-liblsl theory).
+        try:
+            visible = pylsl.resolve_streams(wait_time=2)
+            visible_summary = sorted(f"{s.name()}@{s.hostname()}" for s in visible)
+        except Exception as e:
+            visible_summary = [f"<resolve_streams failed: {type(e).__name__}: {e}>"]
+        self.logger.info(
+            f"LSL streams visible to CTR: {visible_summary}; "
+            f"inlets registered: {sorted(self.state.inlets.keys())}"
+        )
 
         # Refuse to start if the Marker inlet failed to register on CTR
         # despite the marker being configured. Without "Marker" in


### PR DESCRIPTION
## Summary

Adds a single info-level log entry in `SessionController.start_lsl_session` that records both:

- (a) Every LSL stream `pylsl.resolve_streams` can discover at that moment.
- (b) The inlets registered via `DeviceInitialization` messages (i.e. `state.inlets`).

The log line lands in `log_application` automatically for every session — no operator interaction during the session, no shell access needed on CTR.

## Why

#785 narrowed the missing-Marker regression to "STM creates the outlet, but it doesn't show up in the XDF." The remaining question is *where* in the chain it gets lost:

| (a) visible to `resolve_streams`? | (b) in `state.inlets`? | Diagnosis |
|---|---|---|
| yes | yes | inlet is registered; issue is downstream (LabRecorderCLI stream selection at recording start) |
| yes | no | LSL discovery works, `DeviceInitialization` routing or `create_lsl_inlets` is the failure |
| no | no | LSL transmission itself is broken — supports the bundled-`liblsl` theory in #791 |
| no | yes | inconsistent — shouldn't happen, but would itself be a signal worth chasing |

We currently can't distinguish these without coordinating a live shell on CTR mid-session. This log line gives us the data automatically.

## Implementation

Inserted at the top of `start_lsl_session`, before the existing fail-loud Marker check from #786 (so we capture the visibility snapshot even on sessions that get refused).

`resolve_streams` runs with `wait_time=2` — long enough for healthy multicast advertisers to surface, short enough not to add meaningful delay to session start. Wrapped in `try/except` so a `pylsl` failure cannot block session start; the recovery path logs the exception text in place of the stream list.

## Test plan

- [ ] After deploy, run any session on Wang. Confirm a single `INFO`-level entry appears in `log_application` of the form:
  ```
  LSL streams visible to CTR: ['Audio@acq', 'FlirFrameIndex@acq', ..., 'Marker@stm', 'EyeLink@stm', ...]; inlets registered: ['Audio', 'FlirFrameIndex', ..., 'Marker', 'EyeLink', ...]
  ```
- [ ] Compare the two lists across pre-deploy (Wang on v0.90.4) and post-deploy (Wang on v0.91.2+) sessions to localize the failure in the table above.

## Removal plan

Once #791 is resolved and we have confidence the LSL pipeline is healthy, this log line can be removed (or downgraded to debug). It's intentionally lightweight so it doesn't matter much if it's left in, but it's not load-bearing for production.

## Related

- Refs #785, #791
- Independent of #786 (which is already merged)