### PR TITLE
Replace remaining ipython usage in bat files; delete legacy upload bat

### DIFF
--- a/docs/code_audit.md
+++ b/docs/code_audit.md
@@ -365,7 +365,7 @@ The mock infrastructure (PRs #737, #738) is the biggest lift: tests run on a har
 
 ### 4.5 ~~Low: Deployment-test Batch Scripts Still Hardcoded~~ RESOLVED
 
-**Resolved by:** uv migration (#632) -- `tests/deployment-test/run_timing_tests*.bat` now activate `%NB_INSTALL%\.venv\Scripts\activate.bat` instead of the hardcoded `C:\Users\CTR\anaconda3` path. Same fix applied to `extras/reset_mbients.bat` and `extras/serv_acq_upload - neurobooth_OS.bat`.
+**Resolved by:** uv migration (#632) -- `tests/deployment-test/run_timing_tests*.bat` now activate `%NB_INSTALL%\.venv\Scripts\activate.bat` instead of the hardcoded `C:\Users\CTR\anaconda3` path. Same fix applied to `extras/reset_mbients.bat`.
 
 ---
 

--- a/extras/add_subject.bat
+++ b/extras/add_subject.bat
@@ -1,2 +1,2 @@
 call %NB_INSTALL%\.venv\Scripts\activate.bat
-start /W ipython --pdb %NB_INSTALL%\extras\add_subject.py
+start /W python %NB_INSTALL%\extras\add_subject.py

--- a/extras/serv_acq_upload - neurobooth_OS.bat
+++ b/extras/serv_acq_upload - neurobooth_OS.bat
@@ -1,4 +1,0 @@
-call %NB_INSTALL%\.venv\Scripts\activate.bat
-call start /W ipython %NB_INSTALL%\extras\dump_iphone_video.py
-robocopy  /MOVE  D:\neurobooth\neurobooth_data Z:\data /e
-mkdir D:\neurobooth\neurobooth_data

--- a/tests/deployment-test/run_timing_tests.bat
+++ b/tests/deployment-test/run_timing_tests.bat
@@ -1,2 +1,2 @@
 call %NB_INSTALL%\.venv\Scripts\activate.bat
-call start/W ipython --pdb -i %NB_INSTALL%\extras\synch_frame_mean_rgb.py
+call start /W python -i %NB_INSTALL%\extras\synch_frame_mean_rgb.py

--- a/tests/deployment-test/run_timing_tests_plotting.bat
+++ b/tests/deployment-test/run_timing_tests_plotting.bat
@@ -1,2 +1,2 @@
 call %NB_INSTALL%\.venv\Scripts\activate.bat
-call start/W ipython --pdb -i %NB_INSTALL%\extras\plot_timing_test_sync.py -- -i "100064_2022-11-09" -t "_20h-02m-48s"
+call start /W python -i %NB_INSTALL%\extras\plot_timing_test_sync.py -- -i "100064_2022-11-09" -t "_20h-02m-48s"


### PR DESCRIPTION
## Summary

#784 fixed the ipython/sqlite3 issue in `transfer_data.bat` and `postprocess_split_xdf.bat`, but a grep through master surfaced four additional bat files still invoking `ipython`. All four share the same exposure on any machine whose anaconda3 base has the broken `_sqlite3` DLL (Wang STM/ACQ specifically — see #781 for the original failure mode).

## Changes

| File | Before | After | Rationale |
|---|---|---|---|
| `extras/add_subject.bat` | `ipython --pdb add_subject.py` | `python add_subject.py` | Drops the pdb-on-exception fallback; non-issue for an operator-facing tool. |
| `tests/deployment-test/run_timing_tests.bat` | `ipython --pdb -i synch_frame_mean_rgb.py` | `python -i synch_frame_mean_rgb.py` | Preserves the post-script interactive prompt the dev workflow expects. Drops `--pdb` (plain python has no equivalent flag; `python -m pdb script.py` is the manual alternative when a dev wants debugger fallback). |
| `tests/deployment-test/run_timing_tests_plotting.bat` | `ipython --pdb -i plot_timing_test_sync.py ...` | `python -i plot_timing_test_sync.py ...` | Same. |
| `extras/serv_acq_upload - neurobooth_OS.bat` | (legacy) | **deleted** | See below. |

Also normalized the `start/W` typo to `start /W` (the cmd-standard form) in the two deployment-test bats while making the swap.

## Why `serv_acq_upload - neurobooth_OS.bat` is deleted, not fixed

1. **Filename has spaces** — directly violates the CLAUDE.md rule: *"Never create files with spaces or numeric suffixes."*
2. **Hard-codes `D:\neurobooth\neurobooth_data`** — env-specific, doesn't work on most machines.
3. **Duplicates `transfer_data.bat`'s functionality** — `transfer_data.bat` already does the dump-iphone-then-robocopy flow in a config-driven way (via `transfer_data.py`'s `cfg.neurobooth_config.current_server().local_data_dir`).
4. **Legacy and unreferenced** — git history shows the file was added in 2020 and only touched substantively during the conda→uv migration (#758). The only reference in the codebase is a historical note in `docs/code_audit.md`, which is also updated in this PR to drop the reference.

The bat is therefore strictly worse than the `transfer_data.bat` we already have, and removing it eliminates the rule-violating filename.

## Out of scope

`ipython` stays declared in `pyproject.toml` because `examples/Neurobooth_data_visualizer.ipynb` imports `IPython.display`. Nothing else in the production code path uses it. Removing the dep entirely would require dropping Jupyter notebook support, which isn't worth it.

## Test plan

- [ ] On any Wang machine after deploy, manually run `extras/add_subject.bat` (or skip — low-risk, identical behavior on success).
- [ ] On a dev machine, run a `tests/deployment-test/run_timing_tests*.bat` and confirm the script still runs and drops into the interactive prompt afterward. The `-i` flag should preserve the REPL.
- [ ] Confirm nothing in the deployment scripts references `serv_acq_upload - neurobooth_OS.bat` (already verified by grep across the repo).

## Related

- #781 — original failure mode that exposed this pattern.
- #784 — earlier ipython→python swap in transfer/postprocess bats. This PR completes that cleanup for the remaining bat files.