### PR TITLE
Commit Win11 readiness baseline JSONs and populate summary doc

### DIFF
--- a/docs/win11_readiness_summary.md
+++ b/docs/win11_readiness_summary.md
@@ -6,14 +6,16 @@ The source of truth is the per-booth JSON in [`extras/perf/baselines/win11_readi
 
 ## How to populate this doc
 
-1. On each booth (CTR, STM, ACQ, plus any spare/staging hardware), run:
+1. On each booth (CTR, STM, ACQ, plus any spare/staging hardware), open an **elevated** PowerShell (right-click → Run as Administrator) and run:
 
    ```
-   python extras/perf/win11_readiness.py --role <CTR|STM|ACQ|spare>
+   uv run python extras/perf/win11_readiness.py --role <CTR|STM|ACQ|spare>
    ```
+
+   Admin is required because `Confirm-SecureBootUEFI` and the `root\CIMV2\Security\MicrosoftTpm` namespace are ACL'd to Administrators. A non-elevated run returns a false `UPGRADEABLE` verdict with a misleading remediation hint, even on a booth that is genuinely `PASS`.
 
 2. Commit the resulting `extras/perf/baselines/win11_readiness/<hostname>.json`.
-3. Add a row to the table below; copy the `verdict.category` and `verdict.reasons` from the JSON.
+3. Add a row to the table below; copy the `verdict.category` from the JSON.
 4. For `UPGRADEABLE` booths, fill in the firmware-toggle notes section.
 5. For `HARDWARE_FAIL` booths, fill in the escalation-log section.
 
@@ -31,17 +33,25 @@ CPU classification is not done by the script because Microsoft's supported-CPU l
 
 | Booth role | Hostname | Verdict | Reasons (short) | JSON | Date captured |
 |---|---|---|---|---|---|
-| _CTR_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| _STM_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
-| _ACQ_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| CTR | ctr | PASS | None (see CPU note below) | [ctr.json](../extras/perf/baselines/win11_readiness/ctr.json) | 2026-05-14 |
+| STM | stm | PASS | None (see CPU note below) | [stm.json](../extras/perf/baselines/win11_readiness/stm.json) | 2026-05-14 |
+| ACQ | acq | PASS | None (see CPU note below) | [acq.json](../extras/perf/baselines/win11_readiness/acq.json) | 2026-05-14 |
+
+**CPU compatibility (manual check):** the script appends `"CPU not auto-classified -- compare CPU name to Microsoft's Win11 supported list"` to every verdict's `reasons` array by design (Microsoft's list moves and is not hard-coded). All three booth CPUs were verified against Microsoft's published Win11 supported-CPU list:
+
+- CTR: `Intel(R) Core(TM) i7-10700` (10th-gen Comet Lake) — supported
+- STM: `Intel(R) Core(TM) i7-10700K` (10th-gen Comet Lake) — supported
+- ACQ: `Intel(R) Core(TM) i7-10700K` (10th-gen Comet Lake) — supported
+
+All other floor items (TPM 2.0 present + enabled + activated, Secure Boot supported + enabled, BIOS in UEFI mode, RAM ≥ 4 GiB, system disk ≥ 64 GiB free) are verified in the per-booth JSONs above. None of the booths required firmware toggles or hardware replacement.
 
 ## Firmware toggles for UPGRADEABLE booths
 
-_Empty until first UPGRADEABLE booth is recorded. Format suggestion: one subsection per booth, listing the BIOS menu paths the operator used to enable TPM / Secure Boot / UEFI mode._
+All booths passed at first elevated run; no firmware-toggle work needed.
 
 ## Escalation log for HARDWARE_FAIL booths
 
-_Empty until first HARDWARE_FAIL booth is recorded. Format suggestion: one subsection per booth, listing the failing requirement, the inferred replacement need (motherboard / CPU / whole machine), and the date the budget conversation started._
+All booths passed; no escalation needed.
 
 ## Out of scope
 

--- a/extras/perf/baselines/win11_readiness/acq.json
+++ b/extras/perf/baselines/win11_readiness/acq.json
@@ -1,0 +1,252 @@
+{
+  "schema_version": 1,
+  "schema_name": "win11_readiness",
+  "captured_at": "2026-05-14T16:09:09.894469+00:00",
+  "machine": {
+    "hostname": "acq",
+    "role": "ACQ",
+    "os_caption": "Microsoft Windows 10 Home",
+    "os_version": "10.0.19045",
+    "os_build": "19045",
+    "os_arch": "64-bit"
+  },
+  "win11_floor": {
+    "tpm": {
+      "present": true,
+      "ready": true,
+      "enabled": true,
+      "activated": true,
+      "owned": true,
+      "spec_version": "2.0, 0, 1.38",
+      "manufacturer_version": "500.14.0.0",
+      "manufacturer_id": "INTC"
+    },
+    "secure_boot": {
+      "supported": true,
+      "enabled": true
+    },
+    "bios_mode": "UEFI",
+    "cpu": {
+      "name": "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+      "manufacturer": "GenuineIntel",
+      "cores": 8,
+      "threads": 16,
+      "max_clock_mhz": 3792,
+      "description": "Intel64 Family 6 Model 165 Stepping 5",
+      "processor_id": "BFEBFBFF000A0655"
+    },
+    "ram_bytes": 68544954368,
+    "disks": [
+      {
+        "drive": "C:",
+        "free_bytes": 372427051008,
+        "size_bytes": 614521106432
+      },
+      {
+        "drive": "D:",
+        "free_bytes": 7440341102592,
+        "size_bytes": 7993333641216
+      },
+      {
+        "drive": "E:",
+        "free_bytes": 167015837696,
+        "size_bytes": 379691462656
+      }
+    ],
+    "gpus": [
+      {
+        "name": "NVIDIA GeForce RTX 3070",
+        "driver_version": "32.0.15.6094",
+        "driver_date": "2024-08-14T00:00:00+00:00",
+        "video_ram_bytes": 4293918720,
+        "video_processor": "NVIDIA GeForce RTX 3070",
+        "video_mode": "1920 x 1080 x 4294967296 colors"
+      },
+      {
+        "name": "Intel(R) UHD Graphics 630",
+        "driver_version": "27.20.100.9127",
+        "driver_date": "2021-01-04T00:00:00+00:00",
+        "video_ram_bytes": 1073741824,
+        "video_processor": "Intel(R) UHD Graphics Family",
+        "video_mode": null
+      }
+    ]
+  },
+  "neurobooth_extras": {
+    "bluetooth": [
+      {
+        "name": "Device Information Service",
+        "instance_id": "BTHLEDEVICE\\{0000180A-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D1A\\8&119FB612&0&000C",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Bluetooth LE Generic Attribute Service",
+        "instance_id": "BTHLEDEVICE\\{0000180F-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D1A\\8&119FB612&0&001B",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Microsoft Bluetooth Enumerator",
+        "instance_id": "BTH\\MS_BTHBRB\\6&DD6F3D2&0&1",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Device Identification Service",
+        "instance_id": "BTHENUM\\{00001200-0000-1000-8000-00805F9B34FB}_VID&0002046D_PID&B342\\7&1FD99FD9&0&F473353CD397_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Microsoft Bluetooth LE Enumerator",
+        "instance_id": "BTH\\MS_BTHLE\\6&DD6F3D2&0&3",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Generic Access Profile",
+        "instance_id": "BTHLEDEVICE\\{00001800-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D1A\\8&119FB612&0&0001",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Bluetooth LE Generic Attribute Service",
+        "instance_id": "BTHLEDEVICE\\{00010000-0000-1000-8000-011F2000046D}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D1A\\8&119FB612&0&003E",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Service Discovery Service",
+        "instance_id": "BTHENUM\\{00001000-0000-1000-8000-00805F9B34FB}_VID&0002046D_PID&B342\\7&1FD99FD9&0&F473353CD397_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Generic Attribute Profile",
+        "instance_id": "BTHLEDEVICE\\{00001801-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D1A\\8&119FB612&0&0008",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Bluetooth Device (RFCOMM Protocol TDI)",
+        "instance_id": "BTH\\MS_RFCOMM\\6&DD6F3D2&0&0",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "ASUS USB-BT500",
+        "instance_id": "USB\\VID_0B05&PID_190E\\00E04C239987",
+        "manufacturer": "Realtek Semiconductor Corp.",
+        "driver_version": "1.6.1015.3018",
+        "driver_date": "2021-04-01T00:00:00+00:00"
+      },
+      {
+        "name": "Keyboard K380",
+        "instance_id": "BTHENUM\\DEV_F473353CD397\\7&1FD99FD9&0&BLUETOOTHDEVICE_F473353CD397",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "M720 Triathlon",
+        "instance_id": "BTHLE\\DEV_E738F6461D1A\\7&21EEB9F5&0&E738F6461D1A",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      }
+    ],
+    "vendor_software": [
+      {
+        "name": "Apple Mobile Device Support",
+        "version": "16.0.0.25",
+        "publisher": "Apple Inc.",
+        "install_date": "20220923"
+      },
+      {
+        "name": "Intel RealSense SDK 2.0 version 2.50.0.3785",
+        "version": "2.50.0.3785",
+        "publisher": "Intel",
+        "install_date": "20220801"
+      },
+      {
+        "name": "Spinnaker Binaries 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Spinnaker Documentation 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Spinnaker Drivers 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Spinnaker GenICam 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Spinnaker GenTL 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Spinnaker SourceCode 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Teledyne Common Components 1.02.01.1030",
+        "version": "1.02.01.1030",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Teledyne DALSA GenICam 3.20",
+        "version": "3.20",
+        "publisher": "Teledyne DALSA",
+        "install_date": "20240301"
+      },
+      {
+        "name": "Teledyne GigE Vision Interface 7.00.01.1702",
+        "version": "7.00.01.1702",
+        "publisher": "Teledyne",
+        "install_date": "20260509"
+      },
+      {
+        "name": "Teledyne Spinnaker SDK 4.3.0.190 (x64)",
+        "version": "4.3.0.190",
+        "publisher": "Teledyne",
+        "install_date": null
+      }
+    ]
+  },
+  "verdict": {
+    "category": "PASS",
+    "reasons": [
+      "CPU not auto-classified -- compare CPU name to Microsoft's Win11 supported list"
+    ],
+    "remediation_hints": []
+  },
+  "collection_errors": []
+}

--- a/extras/perf/baselines/win11_readiness/ctr.json
+++ b/extras/perf/baselines/win11_readiness/ctr.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": 1,
+  "schema_name": "win11_readiness",
+  "captured_at": "2026-05-14T16:08:37.722188+00:00",
+  "machine": {
+    "hostname": "ctr",
+    "role": "CTR",
+    "os_caption": "Microsoft Windows 10 Home",
+    "os_version": "10.0.19043",
+    "os_build": "19043",
+    "os_arch": "64-bit"
+  },
+  "win11_floor": {
+    "tpm": {
+      "present": true,
+      "ready": true,
+      "enabled": true,
+      "activated": true,
+      "owned": true,
+      "spec_version": "2.0, 0, 1.38",
+      "manufacturer_version": "500.16.0.0",
+      "manufacturer_id": "INTC"
+    },
+    "secure_boot": {
+      "supported": true,
+      "enabled": true
+    },
+    "bios_mode": "UEFI",
+    "cpu": {
+      "name": "Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz",
+      "manufacturer": "GenuineIntel",
+      "cores": 8,
+      "threads": 16,
+      "max_clock_mhz": 2904,
+      "description": "Intel64 Family 6 Model 165 Stepping 5",
+      "processor_id": "BFEBFBFF000A0655"
+    },
+    "ram_bytes": 17102606336,
+    "disks": [
+      {
+        "drive": "C:",
+        "free_bytes": 316864712704,
+        "size_bytes": 511030849536
+      },
+      {
+        "drive": "D:",
+        "free_bytes": 972393619456,
+        "size_bytes": 972634976256
+      }
+    ],
+    "gpus": [
+      {
+        "name": "Citrix Indirect Display Adapter",
+        "driver_version": "12.40.44.247",
+        "driver_date": "2019-01-23T00:00:00+00:00",
+        "video_ram_bytes": 0,
+        "video_processor": null,
+        "video_mode": null
+      },
+      {
+        "name": "NVIDIA GeForce RTX 2060",
+        "driver_version": "27.21.14.5751",
+        "driver_date": "2020-11-22T00:00:00+00:00",
+        "video_ram_bytes": 4293918720,
+        "video_processor": "GeForce RTX 2060",
+        "video_mode": "1920 x 1080 x 4294967296 colors"
+      }
+    ]
+  },
+  "neurobooth_extras": {
+    "bluetooth": [
+      {
+        "name": "Bluetooth LE Generic Attribute Service",
+        "instance_id": "BTHLEDEVICE\\{0000180F-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D16\\8&27D4CEDD&0&001B",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Microsoft Bluetooth LE Enumerator",
+        "instance_id": "BTH\\MS_BTHLE\\6&392675EB&0&3",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "M720 Triathlon",
+        "instance_id": "BTHLE\\DEV_E738F6461D16\\7&CDD7037&0&E738F6461D16",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Device Identification Service",
+        "instance_id": "BTHENUM\\{00001200-0000-1000-8000-00805F9B34FB}_VID&0002046D_PID&B342\\7&2392B99F&0&F473353CD397_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.2364",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "WH-1000XM3",
+        "instance_id": "BTHENUM\\DEV_CC988BB6B685\\7&2392B99F&0&BLUETOOTHDEVICE_CC988BB6B685",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.2364",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Generic Access Profile",
+        "instance_id": "BTHLEDEVICE\\{00001800-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D16\\8&27D4CEDD&0&0001",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Bluetooth LE Generic Attribute Service",
+        "instance_id": "BTHLEDEVICE\\{00010000-0000-1000-8000-011F2000046D}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D16\\8&27D4CEDD&0&003E",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Spark 06 Avrcp Transport",
+        "instance_id": "BTHENUM\\{0000110C-0000-1000-8000-00805F9B34FB}_VID&000105D6_PID&000A\\7&2392B99F&0&8B42D18618DE_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.1",
+        "driver_date": "2019-12-06T00:00:00+00:00"
+      },
+      {
+        "name": "Service Discovery Service",
+        "instance_id": "BTHENUM\\{00001000-0000-1000-8000-00805F9B34FB}_VID&0002046D_PID&B342\\7&2392B99F&0&F473353CD397_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.2364",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Spark 06",
+        "instance_id": "BTHENUM\\DEV_8B42D18618DE\\7&2392B99F&0&BLUETOOTHDEVICE_8B42D18618DE",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.2364",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Spark 06 Avrcp Transport",
+        "instance_id": "BTHENUM\\{0000110E-0000-1000-8000-00805F9B34FB}_VID&000105D6_PID&000A\\7&2392B99F&0&8B42D18618DE_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.1",
+        "driver_date": "2019-12-06T00:00:00+00:00"
+      },
+      {
+        "name": "Microsoft Bluetooth Enumerator",
+        "instance_id": "BTH\\MS_BTHBRB\\6&392675EB&0&1",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.2364",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Generic Attribute Profile",
+        "instance_id": "BTHLEDEVICE\\{00001801-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D16\\8&27D4CEDD&0&0008",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Intel(R) Wireless Bluetooth(R)",
+        "instance_id": "USB\\VID_8087&PID_0029\\5&1006EDDF&0&9",
+        "manufacturer": "Intel Corporation",
+        "driver_version": "22.40.0.2",
+        "driver_date": "2021-02-16T00:00:00+00:00"
+      },
+      {
+        "name": "Bluetooth Device (RFCOMM Protocol TDI)",
+        "instance_id": "BTH\\MS_RFCOMM\\6&392675EB&0&0",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.1",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "WH-1000XM3 Avrcp Transport",
+        "instance_id": "BTHENUM\\{0000110C-0000-1000-8000-00805F9B34FB}_VID&0002054C_PID&0CD3\\7&2392B99F&0&CC988BB6B685_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.1",
+        "driver_date": "2019-12-06T00:00:00+00:00"
+      },
+      {
+        "name": "WH-1000XM3 Avrcp Transport",
+        "instance_id": "BTHENUM\\{0000110E-0000-1000-8000-00805F9B34FB}_VID&0002054C_PID&0CD3\\7&2392B99F&0&CC988BB6B685_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.1",
+        "driver_date": "2019-12-06T00:00:00+00:00"
+      },
+      {
+        "name": "Device Information Service",
+        "instance_id": "BTHLEDEVICE\\{0000180A-0000-1000-8000-00805F9B34FB}_DEV_VID&02046D_PID&B015_REV&0013_E738F6461D16\\8&27D4CEDD&0&000C",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.488",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Keyboard K380",
+        "instance_id": "BTHENUM\\DEV_F473353CD397\\7&2392B99F&0&BLUETOOTHDEVICE_F473353CD397",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.2364",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      }
+    ],
+    "vendor_software": []
+  },
+  "verdict": {
+    "category": "PASS",
+    "reasons": [
+      "CPU not auto-classified -- compare CPU name to Microsoft's Win11 supported list"
+    ],
+    "remediation_hints": []
+  },
+  "collection_errors": []
+}

--- a/extras/perf/baselines/win11_readiness/stm.json
+++ b/extras/perf/baselines/win11_readiness/stm.json
@@ -1,0 +1,163 @@
+{
+  "schema_version": 1,
+  "schema_name": "win11_readiness",
+  "captured_at": "2026-05-14T16:09:48.725062+00:00",
+  "machine": {
+    "hostname": "stm",
+    "role": "STM",
+    "os_caption": "Microsoft Windows 10 Home",
+    "os_version": "10.0.19045",
+    "os_build": "19045",
+    "os_arch": "64-bit"
+  },
+  "win11_floor": {
+    "tpm": {
+      "present": true,
+      "ready": true,
+      "enabled": true,
+      "activated": true,
+      "owned": true,
+      "spec_version": "2.0, 0, 1.38",
+      "manufacturer_version": "500.14.0.0",
+      "manufacturer_id": "INTC"
+    },
+    "secure_boot": {
+      "supported": true,
+      "enabled": true
+    },
+    "bios_mode": "UEFI",
+    "cpu": {
+      "name": "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+      "manufacturer": "GenuineIntel",
+      "cores": 8,
+      "threads": 16,
+      "max_clock_mhz": 3792,
+      "description": "Intel64 Family 6 Model 165 Stepping 5",
+      "processor_id": "BFEBFBFF000A0655"
+    },
+    "ram_bytes": 68544954368,
+    "disks": [
+      {
+        "drive": "C:",
+        "free_bytes": 362084970496,
+        "size_bytes": 614521106432
+      },
+      {
+        "drive": "D:",
+        "free_bytes": 379468546048,
+        "size_bytes": 379692511232
+      }
+    ],
+    "gpus": [
+      {
+        "name": "NVIDIA GeForce RTX 3070",
+        "driver_version": "32.0.15.6094",
+        "driver_date": "2024-08-14T00:00:00+00:00",
+        "video_ram_bytes": 4293918720,
+        "video_processor": "NVIDIA GeForce RTX 3070",
+        "video_mode": "1920 x 1080 x 4294967296 colors"
+      },
+      {
+        "name": "Intel(R) UHD Graphics 630",
+        "driver_version": "27.20.100.9127",
+        "driver_date": "2021-01-04T00:00:00+00:00",
+        "video_ram_bytes": 1073741824,
+        "video_processor": "Intel(R) UHD Graphics Family",
+        "video_mode": null
+      }
+    ]
+  },
+  "neurobooth_extras": {
+    "bluetooth": [
+      {
+        "name": "Microsoft Bluetooth Enumerator",
+        "instance_id": "BTH\\MS_BTHBRB\\6&DD6F3D2&0&1",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Device Identification Service",
+        "instance_id": "BTHENUM\\{00001200-0000-1000-8000-00805F9B34FB}_VID&0002046D_PID&B342\\7&1FD99FD9&0&F473353CD397_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Microsoft Bluetooth LE Enumerator",
+        "instance_id": "BTH\\MS_BTHLE\\6&DD6F3D2&0&3",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.3636",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Service Discovery Service",
+        "instance_id": "BTHENUM\\{00001000-0000-1000-8000-00805F9B34FB}_VID&0002046D_PID&B342\\7&1FD99FD9&0&F473353CD397_C00000000",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "Bluetooth Device (RFCOMM Protocol TDI)",
+        "instance_id": "BTH\\MS_RFCOMM\\6&DD6F3D2&0&0",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      },
+      {
+        "name": "ASUS USB-BT500",
+        "instance_id": "USB\\VID_0B05&PID_190E\\00E04C239987",
+        "manufacturer": "Realtek Semiconductor Corp.",
+        "driver_version": "1.9.1038.3001",
+        "driver_date": "2021-09-29T00:00:00+00:00"
+      },
+      {
+        "name": "Keyboard K380",
+        "instance_id": "BTHENUM\\DEV_F473353CD397\\7&1FD99FD9&0&BLUETOOTHDEVICE_F473353CD397",
+        "manufacturer": "Microsoft",
+        "driver_version": "10.0.19041.5848",
+        "driver_date": "2006-06-21T00:00:00+00:00"
+      }
+    ],
+    "vendor_software": [
+      {
+        "name": "Apple Mobile Device Support",
+        "version": "14.5.0.7",
+        "publisher": "Apple Inc.",
+        "install_date": "20220401"
+      },
+      {
+        "name": "EyeLink DataViewer 64bit 4.2.1",
+        "version": "4.2.1",
+        "publisher": "SR Research Ltd.",
+        "install_date": "20210727"
+      },
+      {
+        "name": "EyeLink DataViewer 64bit 4.2.1",
+        "version": "",
+        "publisher": "",
+        "install_date": ""
+      },
+      {
+        "name": "EyeLink Developer's Kit 2.1.1.0",
+        "version": "2.1.1.0",
+        "publisher": "SR Research Ltd.",
+        "install_date": "20210723"
+      },
+      {
+        "name": "EyeLink Developer's Kit 2.1.1.0",
+        "version": "2.1.1.0",
+        "publisher": "SR Research Ltd.",
+        "install_date": "20210723"
+      }
+    ]
+  },
+  "verdict": {
+    "category": "PASS",
+    "reasons": [
+      "CPU not auto-classified -- compare CPU name to Microsoft's Win11 supported list"
+    ],
+    "remediation_hints": []
+  },
+  "collection_errors": []
+}


### PR DESCRIPTION
## Summary

Follow-up to #767 (closed): commits the per-booth admin-mode snapshots that the issue's close-out comment originally said would not be retained, and populates `docs/win11_readiness_summary.md` from them.

**Reversal rationale:** the JSONs are cheap retain-it-while-we-have-it data and useful as a pre-upgrade reference for the #769 Win11 pilot diff (driver versions, vendor SDK versions, Bluetooth radio + paired-device inventory, USB device shapes), even though #768 still owns the formal baseline lockdown across all four harnesses.

## What's in

**Three JSONs under `extras/perf/baselines/win11_readiness/`** — all `PASS`, captured 2026-05-14 from elevated PowerShell:

- **ctr.json** — Intel i7-10700 (no K suffix), 16 GiB RAM, RTX 2060 + Citrix Indirect Display Adapter, no neurobooth vendor software.
- **stm.json** — Intel i7-10700K, 64 GiB RAM, RTX 3070 + Intel UHD 630, EyeLink Developer's Kit 2.1.1.0 (matches the SR Research SDK version pinned in `pyproject.toml`) + EyeLink DataViewer 4.2.1 + Apple Mobile Device Support 14.5.0.7.
- **acq.json** — Intel i7-10700K, 64 GiB RAM, RTX 3070 + Intel UHD 630, Teledyne Spinnaker SDK 4.3.0.190 stack + Intel RealSense SDK 2.50.0.3785 + Apple Mobile Device Support 16.0.0.25.

All three are Win10 Home 19045/19043 with UEFI BIOS, TPM 2.0 (Intel PTT, `INTC` manufacturer, spec_version `2.0, 0, 1.38`), and Secure Boot supported + enabled.

**One small correction:** `stm.json`'s `machine.role` was captured as `"ACQ"` due to a copy-paste of the `--role` flag at runtime. Corrected to `"STM"` before commit. The hostname is authoritative; role is operator-supplied metadata, so the correction does not falsify any booth-reported data.

**`docs/win11_readiness_summary.md`:**

- Booth inventory table now has three real `PASS` rows linking to the JSONs above.
- Manual CPU-compatibility check captured inline: `i7-10700` and `i7-10700K` are both 10th-gen Comet Lake and on Microsoft's Win11 supported-CPU list. The script appends a *"CPU not auto-classified"* reason to every verdict by design — Microsoft's list moves and is intentionally not hard-coded.
- **"How to populate" section updated to require elevated PowerShell.** `Confirm-SecureBootUEFI` and the `root\CIMV2\Security\MicrosoftTpm` namespace are ACL'd to Administrators; non-elevated runs return a false `UPGRADEABLE` with a misleading remediation hint. Switched the example command to `uv run python ...` to match the booth deploy pattern.
- Firmware-toggle and `HARDWARE_FAIL` sections collapsed to *"no work needed"* notes since all booths passed at first elevated run.

## Post-merge follow-ups (separate, not in this PR)

- Post a follow-up comment on #767 and update the prior #759 update to note the JSONs are now committed (both currently say "intentionally NOT committed") and correct the CPU detail (the prior close-out implied all three booths were `i7-10700K`; CTR is actually `i7-10700`).

## Test plan

Data-only / docs-only PR; no runtime behavior change. Manual verification:

- [ ] JSONs parse as valid JSON (no trailing comma / encoding issues from the paste-and-save path).
- [ ] Summary doc table links resolve (`../extras/perf/baselines/win11_readiness/<role>.json`).
- [ ] `stm.json` `machine.role` now reads `"STM"`.

## Refs

- #759 (Win11 upgrade umbrella, concern #9)
- #767 (closed — this PR is a follow-up to the closing comment)
- #768 (formal baseline lockdown; will use these snapshots as inputs)
- #769 (Win11 pilot; will diff post-upgrade snapshots against these)