### PR TITLE
Add Win10/Win11 timing-regression harness (#761)

### DIFF
--- a/docs/timing_summary.md
+++ b/docs/timing_summary.md
@@ -19,9 +19,16 @@ the operational roll-up only.
 
 | Tool | Strategy test | What it produces | Lab needed |
 |---|---|---|---|
-| [`extras/perf/timing_baseline.py`](../extras/perf/timing_baseline.py) | **C** (clock microbench) + optional flip-jitter probe | `baselines/timing/<os>/<hostname>.json` — per-primitive mean/SD/p95/p99/max error; optional PsychoPy flip-interval jitter + dropped flips | No |
-| [`extras/perf/timing_session_metrics.py`](../extras/perf/timing_session_metrics.py) | **D** (passive session metrics) | Win10-vs-Win11 A/B from the production DB — cross-device start skew, marker→first-sample latency, per-device coarse span | No (remote, SSH tunnel) |
-| [`extras/perf/compare_timing.py`](../extras/perf/compare_timing.py) | A/B comparator (§6) | Delta table between a locked Win10 baseline JSON and a Win11 pilot JSON; every raw delta plus a flagged-for-review verdict | No |
+| [`extras/perf/timing_baseline.py`](../extras/perf/timing_baseline.py) | **C** (clock microbench) + optional flip-jitter probe | `<log_dir>/timing/<os>/<hostname>.json` — per-primitive mean/SD/p95/p99/max error; optional PsychoPy flip-interval jitter + dropped flips | No |
+| [`extras/perf/timing_session_metrics.py`](../extras/perf/timing_session_metrics.py) | **D** (passive session metrics) | `<log_dir>/timing/session_ab_*.json` — Win10-vs-Win11 A/B from the production DB: cross-device start skew, marker→first-sample latency, per-device coarse span | No (remote, SSH tunnel) |
+| [`extras/perf/compare_timing.py`](../extras/perf/compare_timing.py) | A/B comparator (§6) | `<log_dir>/timing/compare_<hostname>.json` — every raw delta between a locked Win10 baseline and a Win11 pilot, plus a flagged-for-review verdict | No |
+
+`<log_dir>` is the neurobooth config `local_log_dir` (same place the
+crash/startup logs go), with an `NB_INSTALL` → home fallback — resolved via
+`neurobooth_os.log_manager._get_log_dir`. Run artefacts deliberately stay
+**out of the repo working tree**; `--out` / `--json` override the path.
+"Locking" a baseline is the explicit step of copying a chosen run into the
+version-controlled `extras/perf/baselines/timing/` tree and committing it.
 
 `timing_baseline.py` and `compare_timing.py` are the routine loop (C). It is
 quantitative, replicable, remote, and auto-summarized. `timing_session_metrics
@@ -29,19 +36,22 @@ quantitative, replicable, remote, and auto-summarized. `timing_session_metrics
 
 ## How to populate this doc (the #759 phased plan)
 
+Execution is tracked, per site, in **#801** (parent) → **#802 Merrimack**,
+**#803 Wang**, **#804 CTRU**. The procedure below is the summary; those
+issues are the checklist.
+
 ### Phase 2 — lock the Win10 baseline (do this *before* any Win11 work)
 
-1. On each booth (CTR, STM, ACQ, plus any spare), on the **current Win10**
-   install, with the booth otherwise idle (GUI closed, no recording):
+1. On each booth machine (CTR, STM, ACQ, plus any spare), on the **current
+   Win10** install, booth otherwise idle (GUI closed, no recording):
 
    ```
    uv run python extras/perf/timing_baseline.py --role <CTR|STM|ACQ|spare>
    ```
 
-   Repeat **≥3 times per booth** so single-run noise does not masquerade as
-   an OS effect. Keep the cleanest run (verdict `CAPTURED`, no
-   `collection_errors`); commit it as
-   `extras/perf/baselines/timing/win10/<hostname>.json`.
+   This writes to `<log_dir>/timing/win10/<hostname>.json` (the config log
+   dir, **not** the repo). Repeat **≥3 times per machine** so single-run
+   noise does not masquerade as an OS effect.
 
 2. Optionally add the display-jitter probe (needs a display, best-effort):
 
@@ -49,29 +59,39 @@ quantitative, replicable, remote, and auto-summarized. `timing_session_metrics
    uv run python extras/perf/timing_baseline.py --role STM --with-flip-stats
    ```
 
-3. Lock the historical-session A/B baseline remotely (zero booth time):
+3. Capture the historical-session A/B baseline remotely (zero booth time):
 
    ```
    uv run python extras/perf/timing_session_metrics.py \
        --baseline-from <win10-window-start> --baseline-to <win10-window-end> \
-       --pilot-from <placeholder> --pilot-to <placeholder> \
-       --json extras/perf/baselines/timing/session_ab_win10_locked.json
+       --pilot-from <placeholder> --pilot-to <placeholder>
    ```
 
-4. Fill in the **Win10 baseline** table below from the committed JSONs.
+   Writes `<log_dir>/timing/session_ab_<...>.json`.
+
+4. **Lock it.** Pick the cleanest microbench run per machine (verdict
+   `CAPTURED`, no `collection_errors`), copy that JSON from the log dir into
+   `extras/perf/baselines/timing/win10/<hostname>.json`, and commit. Do the
+   same for the session-metrics JSON. This copy-and-commit is the only step
+   that puts a run under version control — deliberate, not automatic.
+
+5. Fill in the **Win10 baseline** table below from the committed JSONs.
 
 ### Phase 3 — Win11 pilot diff
 
-1. On the Win11 pilot booth, re-run step 1; commit as
+1. On the Win11 pilot booth, re-run step 1 (it auto-writes under
+   `<log_dir>/timing/win11/<hostname>.json`); lock it into
    `extras/perf/baselines/timing/win11/<hostname>.json`.
-2. Diff:
+2. Diff the two locked baselines:
 
    ```
    uv run python extras/perf/compare_timing.py \
        extras/perf/baselines/timing/win10/<hostname>.json \
-       extras/perf/baselines/timing/win11/<hostname>.json \
-       --json extras/perf/baselines/timing/compare_<hostname>.json
+       extras/perf/baselines/timing/win11/<hostname>.json
    ```
+
+   The delta JSON lands in `<log_dir>/timing/compare_<hostname>.json`; lock
+   it alongside the baselines if you want it version-controlled.
 3. Re-run `timing_session_metrics.py` with the real `--pilot-*` window.
 4. Fill in the **Win10→Win11 comparison** table; a `REVIEW` verdict means a
    human inspects the flagged numbers — it is **not** a failure.
@@ -140,13 +160,18 @@ These are stated plainly because the strategy doc requires it, not buried:
   `plot_timing_test_sync.py` bugs). The strategy demotes the
   saccades/clapping tests to a **one-time confirmatory run per OS baseline**,
   so rebuilding that pipeline is deliberately not part of the routine loop.
-- **The documented recording fixture** (#761 step 5 / audit §4 step 5):
-  duration, scene, lighting, operator posture, acceptance criteria for the
-  one confirmatory physical run. This is non-code work requiring input from
-  someone who runs the booth; it gates the one physical baseline, not the
-  routine loop.
-- **The actual Win10 baseline capture and Win11 pilot runs** (#761 step 6 /
-  #769): operator work, scheduled against real booths.
+- **The documented recording fixture** — defined in
+  [`timing_test_recording_audit.md`](timing_test_recording_audit.md) **§4
+  item 5** and **§1.4** (which study/collection, duration, scene, lighting,
+  operator posture, acceptance criteria for the one confirmatory physical
+  run). It is non-code work requiring input from someone who runs the booth,
+  and it gates only the physical saccades run — **not** the C+D routine
+  loop. (Note: issue #761's *body* numbers its suggested approach
+  differently; the audit doc §4 / the #761 audit comment are the
+  authoritative numbering for this item.)
+- **The actual Win10 baseline capture and Win11 pilot runs** — operator
+  work, tracked in **#801** (→ #802 Merrimack, #803 Wang, #804 CTRU) and
+  #769; scheduled against real booths.
 
 ## References
 
@@ -155,4 +180,6 @@ These are stated plainly because the strategy doc requires it, not buried:
 - Convention mirrored: [`win11_readiness_summary.md`](win11_readiness_summary.md)
 - Change-over-time table format precedent:
   [`perf/inter-task times [2026-04-03].md`](perf/inter-task%20times%20%5B2026-04-03%5D.md)
-- Issues: #759 (umbrella, concern #3), #761 (this harness), #769 (Win11 pilot)
+- Issues: #759 (umbrella, concern #3), #761 (this harness), #801 (Win10
+  baseline execution → #802 Merrimack, #803 Wang, #804 CTRU), #769 (Win11
+  pilot)

--- a/docs/timing_summary.md
+++ b/docs/timing_summary.md
@@ -155,11 +155,11 @@ These are stated plainly because the strategy doc requires it, not buried:
 
 ## Deferred / out of scope (intentionally not built)
 
-- **The heavyweight bag-file post-processing rebuild** (#761 step 2 / audit
-  §4 step 1: de-hardcode the 2022 `Z:\` scripts, fix the two
-  `plot_timing_test_sync.py` bugs). The strategy demotes the
+- **The heavyweight bag-file post-processing rebuild** (audit §4 step 1:
+  de-hardcode the 2022 `Z:\` scripts, fix the two `plot_timing_test_sync.py`
+  bugs) — **won't-do**, decided on #761. The strategy demotes the
   saccades/clapping tests to a **one-time confirmatory run per OS baseline**,
-  so rebuilding that pipeline is deliberately not part of the routine loop.
+  so rebuilding that pipeline is out of scope by decision, not omission.
 - **The documented recording fixture** — tracked in **#805**; defined in
   [`timing_test_recording_audit.md`](timing_test_recording_audit.md) **§4
   item 5** and **§1.4** (which study/collection, duration, scene, lighting,

--- a/docs/timing_summary.md
+++ b/docs/timing_summary.md
@@ -160,7 +160,7 @@ These are stated plainly because the strategy doc requires it, not buried:
   `plot_timing_test_sync.py` bugs). The strategy demotes the
   saccades/clapping tests to a **one-time confirmatory run per OS baseline**,
   so rebuilding that pipeline is deliberately not part of the routine loop.
-- **The documented recording fixture** — defined in
+- **The documented recording fixture** — tracked in **#805**; defined in
   [`timing_test_recording_audit.md`](timing_test_recording_audit.md) **§4
   item 5** and **§1.4** (which study/collection, duration, scene, lighting,
   operator posture, acceptance criteria for the one confirmatory physical
@@ -180,6 +180,6 @@ These are stated plainly because the strategy doc requires it, not buried:
 - Convention mirrored: [`win11_readiness_summary.md`](win11_readiness_summary.md)
 - Change-over-time table format precedent:
   [`perf/inter-task times [2026-04-03].md`](perf/inter-task%20times%20%5B2026-04-03%5D.md)
-- Issues: #759 (umbrella, concern #3), #761 (this harness), #801 (Win10
-  baseline execution → #802 Merrimack, #803 Wang, #804 CTRU), #769 (Win11
-  pilot)
+- Issues: #759 (umbrella, concern #3), #761 (this harness), #805 (recording
+  fixture, non-code), #801 (Win10 baseline execution → #802 Merrimack, #803
+  Wang, #804 CTRU), #769 (Win11 pilot)

--- a/docs/timing_summary.md
+++ b/docs/timing_summary.md
@@ -1,0 +1,158 @@
+# Timing Baseline Summary
+
+One-page roll-up of the booth timing-regression instrument called for by
+issue #761 (concern #3 of #759). It answers one question: **did recording
+timing regress between Windows 10 and Windows 11?**
+
+The source of truth is the per-artefact JSON under
+[`extras/perf/baselines/timing/`](../extras/perf/baselines/timing/), produced
+by the three tools below. This document summarizes those JSONs for humans;
+**if the doc and a JSON ever disagree, the JSON wins** (same convention as
+[`win11_readiness_summary.md`](win11_readiness_summary.md)).
+
+Strategy and rationale live in
+[`timing_test_strategy.md`](timing_test_strategy.md); the code-state audit is
+[`timing_test_recording_audit.md`](timing_test_recording_audit.md). This is
+the operational roll-up only.
+
+## The instrument
+
+| Tool | Strategy test | What it produces | Lab needed |
+|---|---|---|---|
+| [`extras/perf/timing_baseline.py`](../extras/perf/timing_baseline.py) | **C** (clock microbench) + optional flip-jitter probe | `baselines/timing/<os>/<hostname>.json` — per-primitive mean/SD/p95/p99/max error; optional PsychoPy flip-interval jitter + dropped flips | No |
+| [`extras/perf/timing_session_metrics.py`](../extras/perf/timing_session_metrics.py) | **D** (passive session metrics) | Win10-vs-Win11 A/B from the production DB — cross-device start skew, marker→first-sample latency, per-device coarse span | No (remote, SSH tunnel) |
+| [`extras/perf/compare_timing.py`](../extras/perf/compare_timing.py) | A/B comparator (§6) | Delta table between a locked Win10 baseline JSON and a Win11 pilot JSON; every raw delta plus a flagged-for-review verdict | No |
+
+`timing_baseline.py` and `compare_timing.py` are the routine loop (C). It is
+quantitative, replicable, remote, and auto-summarized. `timing_session_metrics
+.py` is the representative corroborator (D) — see "Known limits".
+
+## How to populate this doc (the #759 phased plan)
+
+### Phase 2 — lock the Win10 baseline (do this *before* any Win11 work)
+
+1. On each booth (CTR, STM, ACQ, plus any spare), on the **current Win10**
+   install, with the booth otherwise idle (GUI closed, no recording):
+
+   ```
+   uv run python extras/perf/timing_baseline.py --role <CTR|STM|ACQ|spare>
+   ```
+
+   Repeat **≥3 times per booth** so single-run noise does not masquerade as
+   an OS effect. Keep the cleanest run (verdict `CAPTURED`, no
+   `collection_errors`); commit it as
+   `extras/perf/baselines/timing/win10/<hostname>.json`.
+
+2. Optionally add the display-jitter probe (needs a display, best-effort):
+
+   ```
+   uv run python extras/perf/timing_baseline.py --role STM --with-flip-stats
+   ```
+
+3. Lock the historical-session A/B baseline remotely (zero booth time):
+
+   ```
+   uv run python extras/perf/timing_session_metrics.py \
+       --baseline-from <win10-window-start> --baseline-to <win10-window-end> \
+       --pilot-from <placeholder> --pilot-to <placeholder> \
+       --json extras/perf/baselines/timing/session_ab_win10_locked.json
+   ```
+
+4. Fill in the **Win10 baseline** table below from the committed JSONs.
+
+### Phase 3 — Win11 pilot diff
+
+1. On the Win11 pilot booth, re-run step 1; commit as
+   `extras/perf/baselines/timing/win11/<hostname>.json`.
+2. Diff:
+
+   ```
+   uv run python extras/perf/compare_timing.py \
+       extras/perf/baselines/timing/win10/<hostname>.json \
+       extras/perf/baselines/timing/win11/<hostname>.json \
+       --json extras/perf/baselines/timing/compare_<hostname>.json
+   ```
+3. Re-run `timing_session_metrics.py` with the real `--pilot-*` window.
+4. Fill in the **Win10→Win11 comparison** table; a `REVIEW` verdict means a
+   human inspects the flagged numbers — it is **not** a failure.
+
+## Verdict categories
+
+| Tool | Category | Meaning |
+|---|---|---|
+| `timing_baseline` | `CAPTURED` | Clean single-run capture. A single run never says "regressed" — that needs the comparator. |
+| `timing_baseline` | `CAPTURED_WITH_ERRORS` | Captured, but `collection_errors` present (e.g. flip probe unavailable). Usable; read the errors. |
+| `compare_timing` | `MATCH` | No proposed threshold tripped. Raw deltas are still printed in full. |
+| `compare_timing` | `REVIEW` | ≥1 proposed threshold tripped → a human reviews with the numbers in hand. Never auto-fail. |
+| `timing_session_metrics` | `CAPTURED` | Tier-1 DB A/B captured. Sample-level metrics are deferred (see `metrics.sample_level`). |
+
+Thresholds in `compare_timing.py` (jitter-SD ratio, microbench-p99 ratio,
+new-dropped-flips) are **proposals to be ratified by whoever owns the timing
+budget, not measured facts**, and every one is CLI-overridable. Raw deltas
+are printed regardless of whether a threshold trips.
+
+## Win10 baseline
+
+_Not yet captured — Phase 2 is operator work (≥3 runs per booth). No numbers
+are entered here until the JSONs are committed; this table is the shape, not
+data._
+
+| Booth | Hostname | Verdict | Microbench p99 (worst primitive) | Flip SD (ms) | JSON | Date |
+|---|---|---|---|---|---|---|
+| CTR | _ctr_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+| STM | _stm_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+| ACQ | _acq_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+
+## Win10 → Win11 comparison
+
+_Not yet run — Phase 3 follows the Win11 pilot (#769). Populated from
+`compare_timing.py` output._
+
+| Booth | OS transition | Verdict | Flags | Comparison JSON | Date |
+|---|---|---|---|---|---|
+| CTR | _Win10 → Win11_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+| STM | _Win10 → Win11_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+| ACQ | _Win10 → Win11_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+
+## Known limits (read before relying on this)
+
+These are stated plainly because the strategy doc requires it, not buried:
+
+1. **Test D is a corroborator, not the causal instrument.** Comparing
+   sessions across calendar time confounds the OS with subjects, room,
+   driver versions, software release, and USB/BLE wear (strategy §6.1.2).
+   The microbench (C) is the clean causal probe; if C and D disagree, that
+   disagreement is signal.
+2. **Sample-level jitter / native-vs-LSL drift (ppm) / dropped-duplicated
+   frames are deferred.** Those need the per-device HDF5 sample timestamps
+   (not in Postgres) and a methodology review before any number is trusted
+   (strategy §6.1.1). `timing_session_metrics.py` emits an explicit
+   `deferred` sentinel for them rather than a fabricated value.
+3. **Absolute end-to-end analog latency (G2) cannot be measured remotely.**
+   It needs a physical sensor in the loop and is measured **once per OS
+   baseline, not every run** (strategy §7). A hardware sync box would make
+   it cheap but is net-new procurement, out of scope here.
+
+## Deferred / out of scope (intentionally not built)
+
+- **The heavyweight bag-file post-processing rebuild** (#761 step 2 / audit
+  §4 step 1: de-hardcode the 2022 `Z:\` scripts, fix the two
+  `plot_timing_test_sync.py` bugs). The strategy demotes the
+  saccades/clapping tests to a **one-time confirmatory run per OS baseline**,
+  so rebuilding that pipeline is deliberately not part of the routine loop.
+- **The documented recording fixture** (#761 step 5 / audit §4 step 5):
+  duration, scene, lighting, operator posture, acceptance criteria for the
+  one confirmatory physical run. This is non-code work requiring input from
+  someone who runs the booth; it gates the one physical baseline, not the
+  routine loop.
+- **The actual Win10 baseline capture and Win11 pilot runs** (#761 step 6 /
+  #769): operator work, scheduled against real booths.
+
+## References
+
+- Strategy: [`timing_test_strategy.md`](timing_test_strategy.md)
+- Audit: [`timing_test_recording_audit.md`](timing_test_recording_audit.md)
+- Convention mirrored: [`win11_readiness_summary.md`](win11_readiness_summary.md)
+- Change-over-time table format precedent:
+  [`perf/inter-task times [2026-04-03].md`](perf/inter-task%20times%20%5B2026-04-03%5D.md)
+- Issues: #759 (umbrella, concern #3), #761 (this harness), #769 (Win11 pilot)

--- a/docs/timing_test_strategy.md
+++ b/docs/timing_test_strategy.md
@@ -1,0 +1,522 @@
+# Timing-test strategy: goals, the existing tests, and a low-effort path
+
+Audience: neurobooth lead, deciding how to validate recording timing across the
+Windows 10 → Windows 11 upgrade (issue #759 umbrella, concern #3, tracked in
+#761). This document answers four questions:
+
+1. What are the timing tests actually *for*?
+2. What does each existing test do, in detail?
+3. How important is each, specifically for the Win10/Win11 question?
+4. Can the work be made remote, automated, quantitative, and replicable — and
+   if some part of it genuinely cannot, where exactly is that line?
+
+It is a **strategy and feasibility** document. It does not change code. The
+companion [`timing_test_recording_audit.md`](timing_test_recording_audit.md)
+owns the *code-state* picture (what exists, what is orphaned, what is broken);
+this document owns *what we should run, why, and whether the low-effort approach
+is viable*. Where the two overlap, the audit is the authority on code state.
+
+> **Bottom line up front.** For the question that actually matters for #759 —
+> *"did recording timing regress between Win10 and Win11?"* — a remote,
+> automated, quantitative suite is achievable and is the right primary
+> instrument. It is built almost entirely from patterns the repo already
+> proves out. The **two tests you remember (the rubber-band/tap test and the
+> flashing-dots test) are the wrong instruments for routine regression work**:
+> they are the only two that require a lab visit, and one of them also requires
+> reconfiguring the booth and produces a multi-GB bag file. Exactly one timing
+> property — the *absolute* photons-/sound-to-sample latency — cannot be
+> measured remotely by anything we have. That property is also the *least*
+> likely to move across an OS upgrade on unchanged hardware. The honest
+> recommendation is to measure it **once per OS baseline, not every run**, and
+> to treat everything else as automated. Section 7 states the limits without
+> softening them.
+
+---
+
+## 1. What the timing tests are for
+
+Neurobooth records on the order of a dozen devices at once (3 Intel D455, 5
+Mbient IMUs, FLIR Blackfly, Yeti microphone, EyeLink, iPhone — the production
+fan-out for the timing tasks is enumerated in
+`examples/split_task_device_map.yml:276-302`). Every device timestamps its
+samples onto a shared Lab Streaming Layer (LSL) clock. The scientific value of
+the dataset depends entirely on being able to put a sample from one device next
+to a sample from another and trust that "same timestamp" means "same moment."
+
+The timing tests exist to validate, and to detect regressions in, five
+properties:
+
+| ID | Property | Plain-language question |
+|----|----------|-------------------------|
+| **G1** | Cross-device synchronization | Do two devices that saw the same instant get (nearly) the same LSL timestamp, with a small, stable, known offset? |
+| **G2** | End-to-end latency | From a real event (photon, sound, limb motion) to the timestamp on the sample that captured it — what is the fixed delay, per device? |
+| **G3** | Sampling regularity / jitter | Does each device actually deliver samples at its nominal rate — bounded jitter, no dropped or duplicated frames, no clock drift over a session? |
+| **G4** | Stimulus-to-data alignment | When a marker says "stimulus at T," did the stimulus physically happen at T (display/audio presentation latency *and its variance*)? |
+| **G5** | **Regression detection across a change** | After an OS upgrade / driver update / hardware swap, did any of G1–G4 move — by how much, which direction, is it within tolerance? |
+
+G5 is the entire reason this is on the #759 critical path. The booths run
+Win10; replacement hardware ships Win11; PsychoPy display timing under the
+Win11 Desktop Window Manager (DWM) compositor, the LSL software clock, and the
+USB/BLE stacks are all OS-sensitive. The question is not "is timing good in the
+absolute" — it has been validated historically — it is **"did it change?"**
+That reframing matters: a *difference* measurement against a locked Win10
+baseline is far cheaper and more sensitive than re-deriving absolute latency
+from scratch, and most of the difference signal is reachable without a lab.
+
+Why this gates the dataset: if G1/G2 drift silently, every cross-device
+analysis (IMU-onset vs gaze, audio onset vs video, etc.) is biased by the drift
+amount, and the bias is invisible in the data itself. Timing validation is the
+thing that lets the rest of the data be trusted.
+
+---
+
+## 2. The tests, in detail
+
+There are **four** distinct ways timing is, or can be, measured here. You
+described the two heavyweight physical ones. The other two already exist in the
+repo in latent form and are the key to the low-effort path, so they are
+documented at equal depth.
+
+### 2.1 Test A — "Flashing dots / saccades-with-sound" (`timing_test_obs`)
+
+**This is the one you described as flashing dots, requiring an Intel camera to
+be repointed at the screen, and producing a very large bag file.** It is not
+the "clapping" test; it is the saccades-with-synchronized-tone test.
+
+**Stimulus.** `neurobooth_os/tasks/test_timing/saccades_sounds.py`, class
+`Saccade_synch`. Per trial it cycles a target through four positions
+`[(0,0), (-480,0), (0,0), (480,0)]` and the full screen through a colour
+sequence (`saccades_sounds.py:50`, `:46-48`). At each transition it:
+
+- draws the target and sets the new screen colour,
+- schedules a tone to play *exactly at the next screen flip*
+  (`tone.play(when=self.win.getFutureFlipTime(clock="ptb"))`,
+  `saccades_sounds.py:69-70`),
+- flips the window,
+- sends LSL markers: `marker_task_start` / `marker_trial_start` /
+  `send_target_loc` (`saccades_sounds.py:63,72-73,84`),
+- busy-waits `wait_center` seconds on `pylsl.local_clock`
+  (`saccades_sounds.py:14-19,75`).
+
+The marker stream itself is a string LSL stream that also embeds a wall-clock
+timestamp in the payload (`tasks/test_timing/marker.py:9-22`,
+`"Stream-created_0_{time.time()}"`).
+
+**What it uniquely measures.** A full-screen colour change is a bright,
+unambiguous visual event with a *known stimulus-clock time* (the marker). A
+camera physically repointed from the subject to the screen records the
+luminance step; the microphone records the tone that was bolted to the same
+flip; EyeLink records the saccade. Comparing marker time vs. camera
+mean-RGB-step time vs. mic-onset time vs. gaze-onset time yields **G2
+(absolute display + audio → capture latency)** and **G4 (stimulus-to-data
+alignment)**, plus per-camera frame jitter (G3) and cross-device skew (G1).
+Nothing else we have measures absolute display latency at all.
+
+**How it is run today.** Per `timing_test_recording_audit.md` §1.3 the
+production path is *inferred, not documented*: an operator launches the CTR
+GUI, selects a study/collection whose deployed YAML wires `timing_test_obs` to
+`Saccade_synch`, repoints an Intel D455 at the screen, and records all 12
+devices. The deployed YAML that wires this is **not in the repo**. The only
+in-repo entry point, `saccades_sounds.test_script()`
+(`saccades_sounds.py:94-98`), runs the *stimulus alone* with no device capture
+and needs a `timing_test_task_1` config that no in-repo YAML defines.
+
+**What it outputs today.** Raw RealSense `.bag` files (a multi-GB artifact
+— raw depth+RGB of a screen), post-processed by 2022-vintage scripts
+with hardcoded `Z:\data` / `Z:\processed_data` paths and a hardcoded 2022
+session id (`extras/synch_frame_mean_rgb.py`,
+`extras/synch_frame_mean_rgb_flir_iphone.py`,
+`extras/convert_bag2vid_timestamps.py`, `extras/plot_timing_test_sync.py:44,54`).
+Output is a **visual matplotlib overlay**, normalized per device, read by eye.
+It contains two known bugs (audit §2.2): an inverted `if chunk_len % 2` audio
+gate (`plot_timing_test_sync.py:166`) and an Mbient branch copy-pasted from the
+EyeLink branch (`plot_timing_test_sync.py:139-159`). There is **no numeric
+metric and no Win10/Win11 comparator**.
+
+**Effort profile.** Lab visit • booth reconfiguration (repoint a camera that is
+normally on the subject) • multi-GB bag per run • manual/REPL post-processing
+(`tests/deployment-test/run_timing_tests*.bat` use `python -i`) • eyeball
+output. This is the single heaviest test and one to avoid running routinely.
+
+### 2.2 Test B — "Rubber band / tap" (`clapping_test_obs`)
+
+**This is the test with a rubber band around the five Mbients, tapped
+on the table.** 
+
+**Stimulus.** None in code. `clapping_test_obs` is a *recording configuration*
+(same 12-device fan-out, `split_task_device_map.yml:276-288`); the "stimulus"
+is the operator's physical tap during the recording. There is no clapping task
+class — `saccades_sounds.py` and the orphaned `audio_video_test.py` are the
+only `test_timing` tasks.
+
+**What it uniquely measures.** Banding the five IMUs together and tapping makes
+one physical impact that is genuinely simultaneous across all five
+accelerometers *and* produces an audible transient the Yeti records. So the tap
+is a shared ground-truth event visible to two independent subsystems. Overlaying
+their LSL timestamps (`extras/clapping_test_plotting.py:61` overlays
+`Eyelink, Mic, Mbient_RH` plus the three Intel cameras from processed RGB)
+exposes: **IMU↔IMU agreement** (do all five spikes land together → G1 within
+the Mbient set) and **audio↔IMU offset** (does the mic transient land at the
+same LSL time as the accelerometer spike → G1/G2 for the audio path). It is an
+audio-vs-IMU synchronization check with the microphone as the device whose
+latency is least trusted — hence your "microphone latency" memory.
+
+**How it is run / output.** Same inferred GUI path as Test A.
+`extras/clapping_test_plotting.py` carries the same hardcoded `Z:\data` /
+`Z:\processed_data` paths and a hardcoded 2022 session id
+(`clapping_test_plotting.py:37-39,42`), and again produces a **visual overlay**,
+no metrics, no comparator.
+
+**Effort profile.** Lab visit • physical action required (the tap) • no booth
+reconfiguration (cameras stay put) • 12-device
+production recording • manual post-processing • eyeball output.
+
+### 2.3 Test C — Software clock microbenchmark (latent: `extras/time_clocks*.py`)
+
+**This is the highest value-per-effort test for the OS question and currently has no driver — it just prints.**
+
+`extras/time_clocks.py` times 10 000 repetitions of a 0.5 ms wait implemented
+five ways — `pylsl.local_clock` busy-wait, `time.time` busy-wait,
+`time.sleep`, `psychopy.core.wait`, and `core.wait(hogCPUperiod=...)` — and
+prints five totals. `extras/time_clocks_variance.py` does 100 reps and prints
+the per-primitive mean ± SD error vs. the requested interval.
+
+**What it uniquely measures.** The accuracy and variance of the timing
+primitives the whole stack is built on. This is a direct probe of the **OS
+scheduler and timer resolution** — precisely the layer most likely to change
+between Win10 and Win11, and the layer underneath every other timing property.
+No devices, no lab, no camera, no subject. It runs headless on a booth in
+seconds.
+
+**State.** Orphaned (audit §2.3): no `__main__` driver wiring, no JSON, no
+baseline, output is `print()`. Trivially wrappable into a metrics emitter.
+
+### 2.4 Test D — Passive timing from already-collected session data (latent: the `extras/perf/` DB harness)
+
+**This is the highest value overall for regression detection and requires zero lab effort, because the data already exists.**
+
+Every real clinical session already records the timing signal: the LSL marker
+stream (`marker.py`), per-device HDF5 with both LSL timestamps and
+device-native timestamps, and the `log_sensor_file` / `log_application`
+database tables (per-device `file_start_time`/`file_end_time`; timestamped
+lifecycle events). The repo already mines this **remotely** through an
+SSH-tunnel + Postgres harness:
+
+- `extras/perf/_db.py:28-46` — opens an SSH tunnel to the production DB from
+  anywhere with the credentials file and key. This is what makes "remote"
+  literally true: it runs from your machine, not the lab.
+- `extras/perf/mbient_timing.py` — derives Mbient BLE connect and reset timing
+  distributions purely from `log_application`.
+- `extras/perf/intertask_report.py` — derives per-device inter-task gap
+  statistics from `log_sensor_file`.
+- `extras/perf/mbient_timing_before_after.py` — **a direct precedent for an OS
+  A/B**: it splits the same metric on a cutover date (`CUTOVER = "2026-03-04"`)
+  and prints Before vs. After distributions side by side. Swap "cutover date"
+  for "Win10 vs Win11 machine" and the pattern is exactly what #759 needs.
+
+**What it can measure from data we already have**, per device, per session,
+trended over time, with no special recording: sampling-interval mean / SD /
+p95 / p99, dropped and duplicated frames, LSL-vs-device-native clock drift
+(ppm), marker-to-first-sample latency, and cross-device start skew (G1, G3, and
+the *variance* component of G4). It cannot see absolute analog latency (G2) —
+that requires a physical event of known truth, which production tasks do not
+provide. That single gap is the subject of Section 7.
+
+---
+
+## 3. Importance and recommendation, per test
+
+Rated for the **Win10/Win11 regression** purpose specifically (G5), not in the
+abstract. "Unique signal" = does anything else give you this number.
+
+| Test | Unique signal | Importance for #759 | Current effort | Remote / automatable today | Recommendation |
+|------|---------------|:---:|:---:|:---:|----------------|
+| **C — Clock microbenchmark** | Scheduler/timer accuracy & jitter — the root layer | **Critical** | Trivial (orphaned) | Yes, after a thin wrapper | **Make it the backbone.** Wrap to emit JSON; run on every booth, every baseline. |
+| **D — Passive session metrics** | Real production-path jitter/drift/drops/skew on real sessions | **Critical** | Low (DB harness exists) | **Yes, fully, today** | **Make it the backbone.** Generalize the before/after pattern to OS A/B. |
+| **A — Saccades/sounds (`timing_test_obs`)** | Absolute display + audio → capture latency (G2) — *nothing else gives this* | **Medium (confirmatory)** | Very high (lab + reconfig + multi-GB bag + manual) | No | **Demote to one-time confirmatory** per OS baseline, not per change. Rebuild post-processing into metrics per audit §4. |
+| **B — Clapping (`clapping_test_obs`)** | Absolute audio↔IMU offset | **Low** | High (lab + physical action + manual) | No | **Retire as routine.** Its IMU↔IMU and audio-jitter questions are covered by D; its one unique number (absolute mic-vs-IMU offset) can ride along on the single confirmatory run of A. |
+
+Reasoning for the two demotions, stated plainly:
+
+- **Test A is scientifically important but is the wrong cadence.** Absolute
+  display/audio latency is a real number you need *once* on a locked Win10
+  baseline and *once* on the Win11 pilot to confirm it did not jump. Running it
+  on every change is high cost for a quantity that, on unchanged hardware,
+  rarely moves (Section 7 argues this physically). Keep it; run it rarely;
+  still rebuild its output into numbers (audit §4 steps 1–4) so the one run you
+  do produces a comparable artifact rather than a plot read by eye.
+
+- **Test B carries the least unique information for the OS question relative to
+  its cost.** IMU-set agreement and audio jitter fall out of Test D from
+  ordinary sessions. The only thing B adds over A is an absolute mic-vs-IMU
+  offset, and A already exercises the audio path against a known event. If a
+  physical run is being done for A anyway, band the Mbients and tap during it;
+  that captures B's unique number at zero marginal lab trips. A standalone
+  clapping campaign is not justified for #759.
+
+---
+
+## 4. The effort question, scored against the criteria
+
+There are four things to avoid. Scoring each test against them, plus the two
+desirable properties  (quantitative output, replicable):
+
+| Criterion (yours) | A: Saccades/sounds | B: Clapping | C: Microbench | D: Passive DB |
+|---|:---:|:---:|:---:|:---:|
+| (a) Needs booth reconfiguration | **Yes** (repoint camera) | No | No | No |
+| (b) Needs physical presence | **Yes** | **Yes** (the tap) | No | No |
+| (c) Needs special manual app to analyze | **Yes** (REPL/eyeball) | **Yes** | No (after wrapper) | No |
+| (d) Auto-feeds an OS-comparison summary | No (today) | No (today) | Achievable | **Achievable now** |
+| Produces quantitative output | No (today) | No (today) | Yes | Yes |
+| Practically replicable per run | **No** (undocumented fixture) | **No** | Yes | Yes |
+
+"Practically replicable: No" for A and B is not a guess — `timing_test_recording_audit.md`
+§1.4 documents that the recording fixture (duration, scene, lighting, operator
+posture, acceptance criteria) is *undefined anywhere*. Two operators on two
+OSes cannot currently produce comparable A/B inputs by hand. That is a
+reproducibility failure independent of effort.
+
+C and D score clean on every one of your criteria. They are the suite.
+
+### The proposed low-effort suite (reuses three patterns the repo already proves)
+
+Nothing here is novel architecture; each piece mirrors something that already
+works in this codebase, which is why it is low-risk:
+
+1. **`extras/perf/timing_baseline.py`** — a metrics emitter modeled
+   field-for-field on `extras/perf/win11_readiness.py`. On a booth it:
+   - runs Test C (the microbench) and records per-primitive mean/SD/p95/p99;
+   - optionally runs Test A's *stimulus alone, single machine, no cameras*
+     (`Saccade_synch` already runs standalone) and captures PsychoPy's own
+     requested-vs-actual flip-interval statistics and dropped-flip count — this
+     yields the **display-timing-jitter** part of G4 with **no camera, no bag
+     file, remotely** (it does not yield absolute latency — see §7);
+   - emits one JSON to
+     `extras/perf/baselines/timing/<os>/<hostname>.json`, using the exact
+     envelope `win11_readiness.py:480-499` already uses: `schema_version`,
+     `schema_name`, `captured_at`, `machine{hostname,role,os_caption,os_version,os_build}`,
+     a `metrics` block, a derived `verdict{category,reasons,remediation_hints}`,
+     and `collection_errors`.
+
+2. **`extras/perf/timing_session_metrics.py`** — generalizes the
+   `mbient_timing_before_after.py` cutover pattern from "date" to "OS / machine
+   set," pulling per-device interval/drift/drop/skew statistics from the DB for
+   a date range. Pure `_db.py` SSH-tunnel; runs from your remote machine.
+
+3. **`extras/perf/compare_timing.py`** — ingests two baseline JSONs (Win10
+   locked baseline vs Win11 pilot) and emits a delta table with explicit,
+   quantitative thresholds (Section 6). This is the "tells me how timing
+   changed between OS versions" artifact you asked for.
+
+4. **`docs/timing_summary.md`** — a human roll-up in the exact style of
+   `docs/win11_readiness_summary.md`: it points at the authoritative JSONs and
+   states "if the doc and the JSON disagree, the JSON wins." The
+   change-over-time table format is already demonstrated by
+   `docs/perf/inter-task times [2026-04-03].md` (grouped ranges, summary
+   mean/median/SD/min/max, per-transition deltas, observations) — that document
+   was produced from DB data, remotely, automatically, and is the template for
+   what a timing summary should look like.
+
+Pieces 2 and 4 are runnable **today, remotely, with zero lab effort**, against
+historical Win10 sessions, to lock the baseline now (Phase 2 of the #759 plan).
+Pieces 1 and 3 are small wrappers over code that already exists.
+
+---
+
+## 5. Replicability
+
+Two senses, both of which the suite must satisfy and the physical tests fail:
+
+- **Reproducible (same input → same number).** C is deterministic given a
+  machine. D is deterministic given a fixed date range and query. A and B are
+  not: per audit §1.4 the fixture is undocumented, and B additionally depends
+  on an unstandardized human tap. A normalized matplotlib overlay read by eye
+  is not a reproducible measurement.
+- **Replicable in practice (cheap to repeat).** C: one command, seconds, no
+  hardware. D: one command from your desk, no hardware. A/B: a lab trip, a
+  reconfiguration (A), a multi-GB transfer, and manual analysis — repeating
+  this every change is exactly the burden you flagged.
+
+The suite makes the *routine loop* fully replicable in both senses. The single
+physical confirmatory run (A, once per baseline) is made *reproducible* by the
+non-code deliverable the audit already calls out: a written, fixed fixture
+(duration / scene / lighting / posture / acceptance criteria). That document is
+the one genuinely operator-dependent item and gates the baseline; it is small
+but it is not optional, and it cannot be produced from code alone.
+
+---
+
+## 6. Quantitative outputs, with verdict derived *from* the numbers
+
+We want numbers, not pass/fail, but also value flagged concerns. The
+established repo pattern already does exactly this and should be copied:
+`win11_readiness.py:409-477` keeps the full measured payload *and* derives a
+`verdict` with human-readable `reasons[]` from it; the JSON is authoritative,
+the verdict is a convenience. Apply the same shape here — emit every number;
+derive a verdict so a glance tells you if something moved; never discard the
+number behind a boolean.
+
+Metric set (all quantitative, all diffable Win10 vs Win11):
+
+- **Microbench (C):** per-primitive mean, SD, p95, p99, max of the error vs the
+  requested interval.
+- **Display jitter (A-stimulus-only):** mean/SD of (actual − requested) frame
+  interval; dropped-flip count; tone-schedule miss distribution.
+- **Per-device, from sessions (D):** sampling-interval mean/SD/p95/p99;
+  dropped-frame count and rate; duplicated-sample count; LSL-vs-native clock
+  drift in ppm; marker→first-sample latency; cross-device start skew.
+- **One-time confirmatory (A/B, per baseline):** absolute display→camera
+  latency; absolute audio→sample latency; absolute audio↔IMU offset; IMU↔IMU
+  spread.
+
+Proposed starting thresholds for `compare_timing.py` — these are **proposals to
+be ratified by whoever owns the timing budget, not measured facts**, and the
+raw deltas must be printed regardless of whether a threshold trips:
+
+- jitter SD regression > 25 % vs Win10 baseline → flag;
+- any new dropped/duplicated frames where the baseline had effectively none →
+  flag;
+- clock drift change > a small fixed ppm bound → flag;
+- microbench p99 worse by > 2× baseline → flag;
+- absolute latency (the rare confirmatory run) moved by more than one frame
+  interval / one audio block → flag.
+
+Flag means "a human looks, with the numbers in hand," not "fail."
+
+### 6.1 Where this strategy is weak (read before relying on it)
+
+Three caveats that the rest of this document, if read alone, would understate:
+
+1. **The risk is the metric math, not the plumbing.** The SSH-tunnel DB
+   harness, the JSON envelope, and the summary-doc convention are proven repo
+   patterns and are genuinely low-risk to reuse. The per-device timing
+   *metrics* — native-vs-LSL drift in ppm, dropped/duplicated-frame detection,
+   cross-device skew — are **new and unproven here**; the existing perf scripts
+   compute coarse durations (connect times, inter-task gaps), not sample-level
+   jitter or drift. The inputs are confirmed present every session
+   (`camera_intel.py:122-127`, `flir_cam.py:150-153`, `iphone.py:631-635`
+   record the device-native clock and frame counter alongside the LSL
+   timestamp), so the metrics are *computable* — but a subtly wrong metric
+   definition yields confident, wrong A/B deltas, which is the worst failure
+   mode here. These definitions need a methodology review before any number is
+   trusted; "thin wrapper" describes the plumbing, not the analysis.
+2. **C and D are not co-equal and must not be read as one instrument.** The
+   microbench (C) is hermetic: it isolates the OS variable cleanly and can be
+   run many times for statistical power. The passive session metrics (D) are
+   representative of the real production path but, compared across calendar
+   time, confound the OS with subjects, room, driver versions, software
+   release, and USB/BLE wear — the same weakness the
+   `mbient_timing_before_after.py` date-cutover precedent carries. The #759
+   clean-pilot plan mitigates this but does not remove it. Treat C as the
+   causal instrument and D as the representative corroborator; if they
+   disagree, that disagreement is signal, not noise.
+3. **"Retire the clapping test" means "fold its tap into the one saccades
+   confirmatory run" — an operator action that must actually be scheduled.**
+   It is not an automatic consequence. If that folding does not happen, the
+   only *direct* absolute audio↔IMU cross-check is lost (the saccades test
+   exercises the audio path against a visual event, not against the IMUs).
+
+---
+
+## 7. The honest limit: what cannot be done remotely, and why it is acceptable anyway
+
+You asked to be told if good results are not possible with the kind of tests
+you want. Here is the unsoftened answer.
+
+**What the remote suite (C + D + the stimulus-only flip log) gives you:** G1,
+G3, the variance part of G4, and a direct read on the most OS-sensitive layer
+(G5 via C). For the literal #759 question — *did timing regress between OS
+versions* — this is sufficient and is the correct primary instrument. It is
+quantitative, replicable, remote, and auto-summarized. This part is a clear
+"yes, achievable."
+
+**The one thing it cannot give you:** absolute end-to-end analog latency
+(G2) — the fixed millisecond gap between photons leaving the panel and the
+camera's sample timestamp, and between the speaker and the mic's sample
+timestamp. Measuring that requires an event whose true time is known
+independently of the computer, which by definition needs a physical sensor in
+the loop. Production data does not contain it; no remote method can recover it.
+
+**Why this is an acceptable limit, not a blocker — three reasons, in order of
+weight:**
+
+1. **It is largely OS-insensitive, with one named exception — and the remote
+   suite still *detects* that exception even though it cannot *calibrate* it.**
+   The audio and IMU/mechanical offsets are genuinely hardware-bound (sound
+   card, cable, sensor, driver) and an OS upgrade on the same machine does not
+   move them. The **display path is the exception**: Win11's DWM compositor can
+   shift the *mean* present latency (e.g. if PsychoPy's present path changes
+   between exclusive and composited), so that offset is not purely hardware.
+   The rescue is that such a change also leaves a jitter / dropped-flip
+   signature, and the stimulus-only flip-interval log (Test A, single machine,
+   no camera) captures that signature remotely — so the suite would *flag* a
+   Win11 display-path regression. What it cannot do is put an exact millisecond
+   number on the offset: the flip log is software-reported and can be
+   systematically optimistic about a clean, low-jitter fixed offset. So the
+   correct claim is narrower than "least OS-sensitive": *detection of
+   display-path change is remote; absolute calibration of the offset is the one
+   thing that needs the camera run.* Spending a lab trip every change to
+   re-calibrate a number that is hardware-bound for audio/IMU and only
+   *detectably* (not precisely) perturbable for display is still poor
+   allocation.
+2. **It only needs measuring twice.** Once on the locked Win10 baseline, once
+   on the Win11 pilot. That is two physical runs total for the whole upgrade
+   decision, not two per change. At that cadence the heavyweight test's cost is
+   tolerable, and only Test A is needed (it exercises the audio path against a
+   known event, so a separate clapping campaign adds little — see §3).
+3. **It is the only gap, and it is named and bounded.** Not a fog of "remote
+   testing is unreliable" — one specific quantity, measured rarely.
+
+**The only way to make absolute latency cheap and automated** would be a
+hardware sync box: a photodiode taped to a screen corner plus an audio loopback,
+feeding a known electrical edge into a recorded channel, so display/audio
+latency becomes a deterministic number with no camera, no bag file, and no
+operator judgement. Be aware this is **net-new hardware that does not exist in
+this project today** — a code-wide search finds zero photodiode / trigger-box /
+parallel-port references; the camera-films-the-screen method is currently the
+*only* way absolute display latency is obtained. A sync box is the right
+long-term answer if absolute latency ever needs to be routine, but it is a
+procurement plus a one-time physical install, not a software change, and it is
+out of scope for getting #759 moving. I am flagging it rather than burying it.
+
+**Net verdict.** Good quantitative results *are* achievable with the kind of
+tests you asked for, for the question that matters. Stand up C + D now (both run
+remotely against existing data and need only thin wrappers), lock the Win10
+baseline from historical sessions immediately (Phase 2), and budget exactly one
+physical confirmatory run per OS for the one number that genuinely needs the
+lab. The two tests you remembered should not be in the routine loop — not
+because timing does not matter, but because the cheap methods cover the part of
+timing that actually changes across an OS upgrade, and the expensive methods
+should be spent only on the part that does not.
+
+---
+
+## References (all verifiable in-repo)
+
+- `examples/split_task_device_map.yml:276-302` — `clapping_test_obs` /
+  `timing_test_obs` 12-device fan-out
+- `neurobooth_os/tasks/test_timing/saccades_sounds.py` — Test A stimulus;
+  tone-on-flip `:69-70`; markers `:63,72-73,84`; sole entry point `:94-98`
+- `neurobooth_os/tasks/test_timing/marker.py:9-31` — marker stream format
+- `neurobooth_os/tasks/test_timing/audio_video_test.py` — orphaned task (audit §1.2)
+- `extras/clapping_test_plotting.py:37-42,61` — Test B analysis, hardcoded paths
+- `extras/plot_timing_test_sync.py:44,54,139-159,166` — Test A analysis,
+  hardcoded paths and the two known bugs
+- `extras/synch_frame_mean_rgb.py`, `extras/synch_frame_mean_rgb_flir_iphone.py`,
+  `extras/convert_bag2vid_timestamps.py` — bag → RGB post-processing chain
+- `extras/time_clocks.py`, `extras/time_clocks_variance.py` — Test C, orphaned
+- `extras/perf/_db.py:28-46` — remote SSH-tunnel DB access
+- `extras/perf/mbient_timing.py`, `extras/perf/intertask_report.py` — Test D
+  precedents
+- `extras/perf/mbient_timing_before_after.py` — before/after A/B precedent
+- `extras/perf/win11_readiness.py:409-499` — metrics-emitter + verdict + JSON
+  envelope to copy
+- `extras/perf/baselines/win11_readiness/{ctr,stm,acq}.json` — baseline-JSON
+  convention
+- `docs/win11_readiness_summary.md` — summary-doc convention (JSON authoritative)
+- `docs/perf/inter-task times [2026-04-03].md` — change-over-time summary
+  format, produced remotely from DB data
+- `docs/timing_test_recording_audit.md` — code-state audit; §1.3 inferred
+  production path, §1.4 undocumented fixture, §3 gap list, §4 rebuild steps
+- Issue #759 (umbrella, concern #3), #761 (timing subtask); Phase 2 = lock
+  Win10 baseline, Phase 3 = Win11 pilot diff

--- a/extras/perf/_baseline_common.py
+++ b/extras/perf/_baseline_common.py
@@ -1,0 +1,189 @@
+"""Shared helpers for booth baseline-snapshot tools.
+
+Single source of truth for the pieces every baseline artefact shares:
+
+* PowerShell invocation and JSON parsing (OS / hardware probes),
+* the machine / OS identity block,
+* the :class:`CollectionError` accumulator,
+* the JSON envelope shape.
+
+Both ``extras/perf/win11_readiness.py`` (Win11 hardware floor, issue #767)
+and ``extras/perf/timing_baseline.py`` (timing microbench, issue #761) emit
+the same envelope, so the ``baselines/`` tree, the summary docs, and a single
+reader/comparator convention stay uniform across artefact kinds.
+
+This module is import-only; it has no ``__main__``. It is loaded the same way
+``_db.py`` is -- the perf scripts run from ``extras/perf/`` so a bare
+``from _baseline_common import ...`` resolves.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import socket
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+def run_powershell(script: str, timeout: int = 60) -> str:
+    """Execute a PowerShell snippet and return its stdout.
+
+    Args:
+        script: PowerShell source to run via ``powershell -Command``.
+        timeout: Seconds before the call is killed.
+
+    Returns:
+        Captured stdout, stripped of trailing whitespace.
+
+    Raises:
+        subprocess.CalledProcessError: PowerShell exited non-zero.
+        subprocess.TimeoutExpired: ``timeout`` elapsed.
+    """
+    completed = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            "powershell",
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    return completed.stdout.strip()
+
+
+def ps_json(script: str, timeout: int = 60) -> Any:
+    """Run a PowerShell snippet that pipes through ``ConvertTo-Json`` and parse it.
+
+    Args:
+        script: PowerShell source. The caller is responsible for the
+            ``ConvertTo-Json`` pipe; ``-Depth 5`` is recommended.
+        timeout: Forwarded to :func:`run_powershell`.
+
+    Returns:
+        Parsed JSON value, or ``None`` if PowerShell produced empty output.
+    """
+    raw = run_powershell(script, timeout=timeout)
+    if not raw:
+        return None
+    return json.loads(raw)
+
+
+def parse_ps_date(value: Any) -> Any:
+    """Convert PowerShell's ``/Date(ms)/`` JSON representation to ISO-8601.
+
+    Returns the input unchanged if it isn't a ``/Date(...)/`` string.
+    """
+    if not isinstance(value, str) or not value.startswith("/Date("):
+        return value
+    try:
+        ms_token = value.split("(")[1].split(")")[0]
+        ms = int(ms_token.split("+")[0].split("-")[0])
+        return dt.datetime.fromtimestamp(ms / 1000, tz=dt.timezone.utc).isoformat()
+    except Exception:  # noqa: BLE001
+        return value
+
+
+@dataclass
+class CollectionError:
+    """A single non-fatal failure during data collection."""
+
+    field: str
+    message: str
+
+    @classmethod
+    def from_exception(cls, where: str, exc: BaseException) -> "CollectionError":
+        """Build a :class:`CollectionError` from a caught exception.
+
+        Args:
+            where: Dotted path of the field that failed to collect.
+            exc: The exception that was trapped.
+        """
+        return cls(field=where, message=f"{type(exc).__name__}: {exc}")
+
+
+def collect_os_identity(
+    role: Optional[str] = None,
+) -> "tuple[dict, list[CollectionError]]":
+    """Return the standard ``machine`` block plus any collection errors.
+
+    The block carries hostname, optional booth role, and the OS caption /
+    version / build / architecture, matching the ``machine`` object the
+    win11_readiness envelope established so one reader convention spans both
+    tools. OS identity is best-effort: a PowerShell failure is recorded as a
+    :class:`CollectionError` rather than raised, so the caller can still emit
+    a useful artefact.
+
+    Args:
+        role: Optional booth role (e.g. ``"CTR"``) recorded for triage.
+
+    Returns:
+        ``(machine_block, errors)``.
+    """
+    machine: dict = {"hostname": socket.gethostname()}
+    if role:
+        machine["role"] = role
+    errors: list = []
+    try:
+        info = ps_json(
+            "Get-CimInstance Win32_OperatingSystem | "
+            "Select-Object Caption, Version, BuildNumber, OSArchitecture | "
+            "ConvertTo-Json -Depth 3"
+        )
+        if isinstance(info, dict):
+            machine["os_caption"] = info.get("Caption")
+            machine["os_version"] = info.get("Version")
+            machine["os_build"] = info.get("BuildNumber")
+            machine["os_arch"] = info.get("OSArchitecture")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(CollectionError.from_exception("machine.os", exc))
+    return machine, errors
+
+
+def build_envelope(
+    *,
+    schema_name: str,
+    schema_version: int,
+    machine: dict,
+    blocks: dict,
+    verdict: dict,
+    errors: "list[CollectionError]",
+) -> "dict[str, Any]":
+    """Assemble the canonical baseline JSON payload.
+
+    The envelope is intentionally identical in shape to the one
+    win11_readiness.py established: ``schema_version``, ``schema_name``,
+    ``captured_at`` (UTC ISO-8601), ``machine``, the tool-specific data
+    ``blocks`` spread at the top level, ``verdict``, then
+    ``collection_errors``. Key order is preserved so committed artefacts
+    diff cleanly across tools.
+
+    Args:
+        schema_name: Stable identifier for the artefact kind.
+        schema_version: Integer bumped on any breaking schema change.
+        machine: The machine / OS identity block.
+        blocks: Tool-specific top-level keys (e.g. ``{"metrics": {...}}``).
+        verdict: ``{"category", "reasons", "remediation_hints"}``.
+        errors: Non-fatal collection failures.
+
+    Returns:
+        A JSON-serializable dict.
+    """
+    payload: dict = {
+        "schema_version": schema_version,
+        "schema_name": schema_name,
+        "captured_at": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
+        "machine": machine,
+    }
+    payload.update(blocks)
+    payload["verdict"] = verdict
+    payload["collection_errors"] = [
+        {"field": e.field, "message": e.message} for e in errors
+    ]
+    return payload

--- a/extras/perf/_baseline_common.py
+++ b/extras/perf/_baseline_common.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 import socket
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional
 
 
@@ -187,3 +189,50 @@ def build_envelope(
         {"field": e.field, "message": e.message} for e in errors
     ]
     return payload
+
+
+def resolved_log_dir(subfolder: Optional[str] = None) -> Path:
+    """Return the configured neurobooth log directory (optionally a subfolder).
+
+    Runtime artefacts the timing tools produce belong in the booth's log
+    directory, not in the repo working tree. This reuses the project's one
+    canonical resolver, ``neurobooth_os.log_manager._get_log_dir`` -- the
+    same function the crash/startup logs use -- so the location follows
+    ``local_log_dir`` from the loaded neurobooth config, with the project's
+    own ``NB_INSTALL`` / home fallback when no config is present.
+
+    Everything is best-effort and import-light: ``neurobooth_os`` is imported
+    lazily inside the function so dependency-light tools that only need the
+    JSON envelope (``win11_readiness``) never pull the neurobooth stack, and
+    a dev box / CI without the package still gets a sane directory. The
+    config is loaded (without path validation) only if it has not been
+    loaded already, matching the pattern in ``intertask_report.py``; if
+    ``NB_CONFIG`` is unset the load is skipped and the fallback applies.
+
+    Args:
+        subfolder: Optional child directory appended to the resolved root
+            (e.g. ``"timing"``). Not created here; the caller's
+            ``mkdir(parents=True)`` does that.
+
+    Returns:
+        The resolved directory as a :class:`pathlib.Path`.
+    """
+    base: Optional[str] = None
+    try:
+        import neurobooth_os.config as _cfg
+        from neurobooth_os.log_manager import _get_log_dir
+
+        if _cfg.neurobooth_config is None:
+            try:
+                _cfg.load_config(validate_paths=False)
+            except Exception:  # noqa: BLE001
+                pass  # NB_CONFIG unset / no config file -> use the fallback
+        base = _get_log_dir()
+    except Exception:  # noqa: BLE001
+        base = None  # neurobooth_os not importable (dev box / CI)
+
+    if not base:
+        base = os.environ.get("NB_INSTALL") or os.path.expanduser("~")
+
+    root = Path(base)
+    return root / subfolder if subfolder else root

--- a/extras/perf/baselines/timing/README.md
+++ b/extras/perf/baselines/timing/README.md
@@ -1,21 +1,32 @@
-# Timing baseline artefacts
+# Locked timing baseline artefacts
 
-Committed JSON artefacts for the Win10/Win11 timing-regression instrument
-(issue #761, concern #3 of #759). Layout:
+Version-controlled JSON artefacts for the Win10/Win11 timing-regression
+instrument (issue #761, concern #3 of #759; execution tracked in #801).
+
+**The tools do not write here by default.** `timing_baseline.py`,
+`timing_session_metrics.py`, and `compare_timing.py` write their runs to the
+configured neurobooth log directory (`<local_log_dir>/timing/...`, with an
+`NB_INSTALL` → home fallback) so routine run output stays out of the repo
+working tree.
+
+This directory is the destination for a **deliberately locked** baseline:
+the operator reviews the runs in the log dir, picks the cleanest, and
+*copies* it here and commits it. Layout once populated:
 
 ```
 baselines/timing/
-  win10/<hostname>.json   # timing_baseline.py on the locked Win10 install
-  win11/<hostname>.json   # timing_baseline.py on the Win11 pilot
-  session_ab_*.json        # timing_session_metrics.py DB A/B (optional)
-  compare_<hostname>.json  # compare_timing.py delta (optional)
+  win10/<hostname>.json    # locked Win10 microbench baseline
+  win11/<hostname>.json    # locked Win11 pilot
+  session_ab_*.json        # locked timing_session_metrics DB A/B
+  compare_<hostname>.json  # locked compare_timing delta (optional)
 ```
 
 `<hostname>` and the `win10` / `win11` segment are chosen automatically by
-`extras/perf/timing_baseline.py` from the OS build (Win11 = build ≥ 22000).
+`timing_baseline.py` from the OS build (Win11 = build ≥ 22000).
 
-These JSONs are the source of truth. The human roll-up is
+These committed JSONs are the source of truth. The human roll-up is
 [`docs/timing_summary.md`](../../../../docs/timing_summary.md); if the two
-disagree, the JSON wins. Capture procedure is in that doc (the #759 phased
-plan). Nothing is committed here until Phase 2 (operator work, ≥3 runs per
-booth) is done — this README keeps the directory tracked until then.
+disagree, the JSON wins. The capture-and-lock procedure is in that doc (the
+#759 phased plan / #801). Nothing is committed here until Phase 2 (operator
+work, ≥3 runs per machine) is done — this README keeps the directory tracked
+until then.

--- a/extras/perf/baselines/timing/README.md
+++ b/extras/perf/baselines/timing/README.md
@@ -1,0 +1,21 @@
+# Timing baseline artefacts
+
+Committed JSON artefacts for the Win10/Win11 timing-regression instrument
+(issue #761, concern #3 of #759). Layout:
+
+```
+baselines/timing/
+  win10/<hostname>.json   # timing_baseline.py on the locked Win10 install
+  win11/<hostname>.json   # timing_baseline.py on the Win11 pilot
+  session_ab_*.json        # timing_session_metrics.py DB A/B (optional)
+  compare_<hostname>.json  # compare_timing.py delta (optional)
+```
+
+`<hostname>` and the `win10` / `win11` segment are chosen automatically by
+`extras/perf/timing_baseline.py` from the OS build (Win11 = build ≥ 22000).
+
+These JSONs are the source of truth. The human roll-up is
+[`docs/timing_summary.md`](../../../../docs/timing_summary.md); if the two
+disagree, the JSON wins. Capture procedure is in that doc (the #759 phased
+plan). Nothing is committed here until Phase 2 (operator work, ≥3 runs per
+booth) is done — this README keeps the directory tracked until then.

--- a/extras/perf/compare_timing.py
+++ b/extras/perf/compare_timing.py
@@ -25,7 +25,12 @@ Usage::
         extras/perf/baselines/timing/win10/stm.json \\
         extras/perf/baselines/timing/win11/stm.json \\
         [--sd-regression-ratio 1.25] [--p99-ratio 2.0] \\
-        [--json delta.json] [--strict]
+        [--json PATH] [--no-json] [--strict]
+
+The comparison JSON defaults to ``<log_dir>/timing/compare_<hostname>.json``
+(log_dir from the neurobooth config local_log_dir; NB_INSTALL/home
+fallback). ``--json`` overrides the path; ``--no-json`` prints the table
+only.
 """
 
 from __future__ import annotations
@@ -37,7 +42,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from _baseline_common import build_envelope
+from _baseline_common import build_envelope, resolved_log_dir
 
 SCHEMA_VERSION = 1
 SCHEMA_NAME = "timing_comparison"
@@ -436,7 +441,15 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         f"flagged (default {DEFAULT_MAX_NEW_DROPPED}).",
     )
     p.add_argument(
-        "--json", type=Path, help="Also write the comparison as an envelope JSON."
+        "--json",
+        type=Path,
+        help="Comparison-JSON output path. Default: "
+        "<log_dir>/timing/compare_<hostname>.json.",
+    )
+    p.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Do not write the JSON file (print the delta table only).",
     )
     p.add_argument(
         "--strict",
@@ -461,7 +474,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     print(render(comparison))
 
-    if args.json:
+    if not args.no_json:
         verdict = to_verdict(comparison)
         payload = build_envelope(
             schema_name=SCHEMA_NAME,
@@ -471,11 +484,13 @@ def main(argv: Optional[List[str]] = None) -> int:
             verdict=verdict,
             errors=[],
         )
-        args.json.parent.mkdir(parents=True, exist_ok=True)
-        args.json.write_text(
+        host = comparison.get("pilot_machine", {}).get("hostname", "unknown")
+        out_path = args.json or (resolved_log_dir("timing") / f"compare_{host}.json")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
             json.dumps(payload, indent=2, default=str), encoding="utf-8"
         )
-        print(f"Wrote: {args.json}", file=sys.stderr)
+        print(f"Wrote: {out_path}", file=sys.stderr)
 
     if args.strict and comparison["flags"]:
         return 1

--- a/extras/perf/compare_timing.py
+++ b/extras/perf/compare_timing.py
@@ -1,0 +1,486 @@
+"""Diff two timing baselines (Win10 locked vs Win11 pilot) into a delta table.
+
+Strategy doc (``docs/timing_test_strategy.md``) §4 piece 3 / §6: ingest two
+``timing_baseline.py`` artefacts and emit *every* raw delta, then derive a
+verdict from the numbers. The numbers are authoritative; the verdict is a
+convenience so a glance tells you whether something moved.
+
+Design rules taken verbatim from the strategy doc:
+
+* **Raw deltas are always printed**, for every metric, whether or not any
+  threshold trips. Nothing is hidden behind a boolean.
+* The thresholds below are **proposals to be ratified by whoever owns the
+  timing budget -- not measured facts.** They are named constants and every
+  one is CLI-overridable.
+* A tripped threshold means **"flag: a human looks, with the numbers in
+  hand"** -- never an automatic "fail". The process exits 0 even when
+  flagged, unless ``--strict`` is given (for callers that want a hard gate).
+
+Pure stdlib (json/argparse/pathlib/socket): no DB, no pandas, no PsychoPy,
+so it runs anywhere and is fully unit-testable.
+
+Usage::
+
+    uv run python extras/perf/compare_timing.py \\
+        extras/perf/baselines/timing/win10/stm.json \\
+        extras/perf/baselines/timing/win11/stm.json \\
+        [--sd-regression-ratio 1.25] [--p99-ratio 2.0] \\
+        [--json delta.json] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from _baseline_common import build_envelope
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "timing_comparison"
+
+# --- Proposed thresholds (strategy §6). NOT measured facts. CLI-overridable.
+# A trip means "a human looks", not "fail".
+DEFAULT_SD_REGRESSION_RATIO = 1.25  # jitter SD regression > 25% vs baseline
+DEFAULT_P99_RATIO = 2.0  # microbench p99 worse by > 2x baseline
+DEFAULT_MAX_NEW_DROPPED = 0  # new dropped flips where baseline had ~none
+
+# Below this (seconds / count) a baseline value is "effectively zero", so a
+# ratio is meaningless and we fall back to an absolute "new regression" rule.
+_EPS = 1e-9
+
+_MICROBENCH_STATS = ("mean", "sd", "p95", "p99", "max")
+
+
+def load_baseline(path: Path) -> Dict[str, Any]:
+    """Read and JSON-parse one baseline artefact.
+
+    Raises:
+        FileNotFoundError / json.JSONDecodeError: surfaced to the caller; a
+        comparator that silently swallowed a bad input would be worse than
+        one that stops.
+    """
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ratio(base: Optional[float], pilot: Optional[float]) -> Optional[float]:
+    """``pilot / base`` or ``None`` when base is missing / ~zero."""
+    if base is None or pilot is None or abs(base) <= _EPS:
+        return None
+    return pilot / base
+
+
+def _delta(base: Optional[float], pilot: Optional[float]) -> Optional[float]:
+    """``pilot - base`` or ``None`` if either side is missing."""
+    if base is None or pilot is None:
+        return None
+    return pilot - base
+
+
+def _cmp_scalar(
+    base: Optional[float], pilot: Optional[float]
+) -> Dict[str, Optional[float]]:
+    """Raw comparison cell: baseline, pilot, delta, ratio (no judgement)."""
+    return {
+        "baseline": base,
+        "pilot": pilot,
+        "delta": _delta(base, pilot),
+        "ratio": _ratio(base, pilot),
+    }
+
+
+def _os_label(machine: Dict[str, Any]) -> str:
+    """Human OS label from a ``machine`` block."""
+    cap = machine.get("os_caption")
+    build = machine.get("os_build")
+    if cap and build:
+        return f"{cap} (build {build})"
+    return str(cap or build or "unknown")
+
+
+def compare_microbench(
+    base_mb: Dict[str, Any],
+    pilot_mb: Dict[str, Any],
+    sd_ratio_limit: float,
+    p99_ratio_limit: float,
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Per-primitive raw deltas + SD/p99 regression flags.
+
+    Args:
+        base_mb: ``metrics.microbench`` from the baseline artefact.
+        pilot_mb: same from the pilot artefact.
+        sd_ratio_limit: Flag if ``pilot.sd / baseline.sd`` exceeds this.
+        p99_ratio_limit: Flag if ``pilot.p99 / baseline.p99`` exceeds this.
+
+    Returns:
+        ``(table, flags)`` -- ``table`` keeps every stat for every primitive;
+        ``flags`` are human-readable lines for the verdict.
+    """
+    table: Dict[str, Any] = {}
+    flags: List[str] = []
+    all_primitives = sorted(set(base_mb) | set(pilot_mb))
+
+    for prim in all_primitives:
+        b = base_mb.get(prim) or {}
+        p = pilot_mb.get(prim) or {}
+        if not b or not p:
+            table[prim] = {
+                "status": "not_comparable",
+                "reason": f"missing in {'baseline' if not b else 'pilot'}",
+            }
+            flags.append(
+                f"microbench '{prim}': present in only one artefact "
+                f"-- not comparable."
+            )
+            continue
+
+        cell = {s: _cmp_scalar(b.get(s), p.get(s)) for s in _MICROBENCH_STATS}
+
+        sd_r = cell["sd"]["ratio"]
+        sd_b, sd_p = b.get("sd"), p.get("sd")
+        if sd_r is not None and sd_r > sd_ratio_limit:
+            cell["sd"]["flagged"] = True
+            flags.append(
+                f"microbench '{prim}' jitter SD x{sd_r:.2f} "
+                f"({sd_b:.3e}s -> {sd_p:.3e}s) > x{sd_ratio_limit} proposed."
+            )
+        elif (
+            sd_r is None
+            and (sd_b is not None and abs(sd_b) <= _EPS)
+            and (sd_p is not None and sd_p > _EPS)
+        ):
+            cell["sd"]["flagged"] = True
+            flags.append(
+                f"microbench '{prim}' jitter SD rose from ~0 to {sd_p:.3e}s "
+                f"(baseline effectively zero)."
+            )
+
+        p99_r = cell["p99"]["ratio"]
+        p99_b, p99_p = b.get("p99"), p.get("p99")
+        if p99_r is not None and p99_r > p99_ratio_limit:
+            cell["p99"]["flagged"] = True
+            flags.append(
+                f"microbench '{prim}' p99 x{p99_r:.2f} "
+                f"({p99_b:.3e}s -> {p99_p:.3e}s) > x{p99_ratio_limit} proposed."
+            )
+
+        table[prim] = cell
+
+    return table, flags
+
+
+def compare_flip_stats(
+    base_fs: Optional[Dict[str, Any]],
+    pilot_fs: Optional[Dict[str, Any]],
+    sd_ratio_limit: float,
+    max_new_dropped: int,
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Flip-jitter raw deltas + SD-regression and new-dropped-flip flags.
+
+    The flip probe is optional, so either side may be absent; that is
+    reported as ``not_comparable`` (with a reason), never silently passed.
+    """
+    if not base_fs or not pilot_fs:
+        which = "baseline" if not base_fs else "pilot"
+        return (
+            {
+                "status": "not_comparable",
+                "reason": f"flip_stats absent in {which} "
+                f"(optional --with-flip-stats probe)",
+            },
+            [],
+        )
+
+    flags: List[str] = []
+    fields = ("mean_ms", "sd_ms", "p95_ms", "p99_ms", "max_ms")
+    table: Dict[str, Any] = {
+        f: _cmp_scalar(base_fs.get(f), pilot_fs.get(f)) for f in fields
+    }
+    table["dropped_flips"] = _cmp_scalar(
+        base_fs.get("dropped_flips"), pilot_fs.get("dropped_flips")
+    )
+    table["requested_hz"] = _cmp_scalar(
+        base_fs.get("requested_hz"), pilot_fs.get("requested_hz")
+    )
+
+    sd_r = table["sd_ms"]["ratio"]
+    if sd_r is not None and sd_r > sd_ratio_limit:
+        table["sd_ms"]["flagged"] = True
+        flags.append(
+            f"flip-interval jitter SD x{sd_r:.2f} "
+            f"({base_fs.get('sd_ms'):.3f}ms -> {pilot_fs.get('sd_ms'):.3f}ms) "
+            f"> x{sd_ratio_limit} proposed."
+        )
+
+    b_drop = base_fs.get("dropped_flips") or 0
+    p_drop = pilot_fs.get("dropped_flips") or 0
+    if b_drop <= max_new_dropped and p_drop > max_new_dropped:
+        table["dropped_flips"]["flagged"] = True
+        flags.append(
+            f"dropped flips rose {b_drop} -> {p_drop} "
+            f"(baseline within proposed {max_new_dropped})."
+        )
+
+    return table, flags
+
+
+def build_comparison(
+    baseline: Dict[str, Any],
+    pilot: Dict[str, Any],
+    *,
+    sd_ratio_limit: float = DEFAULT_SD_REGRESSION_RATIO,
+    p99_ratio_limit: float = DEFAULT_P99_RATIO,
+    max_new_dropped: int = DEFAULT_MAX_NEW_DROPPED,
+) -> Dict[str, Any]:
+    """Assemble the full structured comparison. Pure; the unit-test seam.
+
+    Args:
+        baseline: Parsed Win10 ``timing_baseline`` artefact.
+        pilot: Parsed Win11 ``timing_baseline`` artefact.
+        sd_ratio_limit: Proposed jitter-SD regression ratio.
+        p99_ratio_limit: Proposed microbench-p99 regression ratio.
+        max_new_dropped: Proposed tolerated dropped-flip baseline.
+
+    Returns:
+        A JSON-serializable comparison: schema check, OS transition, every
+        raw delta, the thresholds used, and the human ``flags`` list.
+    """
+    b_machine = baseline.get("machine", {})
+    p_machine = pilot.get("machine", {})
+
+    schema_ok = baseline.get("schema_name") == pilot.get("schema_name") == (
+        "timing_baseline"
+    ) and baseline.get("schema_version") == pilot.get("schema_version")
+
+    flags: List[str] = []
+    if not schema_ok:
+        flags.append(
+            "schema mismatch: "
+            f"{baseline.get('schema_name')}/v{baseline.get('schema_version')} "
+            f"vs {pilot.get('schema_name')}/v{pilot.get('schema_version')} "
+            "-- comparing overlapping fields only."
+        )
+
+    b_metrics = baseline.get("metrics", {})
+    p_metrics = pilot.get("metrics", {})
+
+    mb_table, mb_flags = compare_microbench(
+        b_metrics.get("microbench", {}),
+        p_metrics.get("microbench", {}),
+        sd_ratio_limit,
+        p99_ratio_limit,
+    )
+    fs_table, fs_flags = compare_flip_stats(
+        b_metrics.get("flip_stats"),
+        p_metrics.get("flip_stats"),
+        sd_ratio_limit,
+        max_new_dropped,
+    )
+    flags += mb_flags + fs_flags
+
+    interval_b = b_metrics.get("requested_interval_s")
+    interval_p = p_metrics.get("requested_interval_s")
+    if interval_b != interval_p:
+        flags.append(
+            f"requested microbench interval differs "
+            f"({interval_b}s baseline vs {interval_p}s pilot) -- ratios still "
+            f"shown but compare with care."
+        )
+
+    return {
+        "baseline_machine": b_machine,
+        "pilot_machine": p_machine,
+        "os_transition": {
+            "from": _os_label(b_machine),
+            "to": _os_label(p_machine),
+        },
+        "schema": {
+            "baseline": (
+                f"{baseline.get('schema_name')}" f"/v{baseline.get('schema_version')}"
+            ),
+            "pilot": (f"{pilot.get('schema_name')}" f"/v{pilot.get('schema_version')}"),
+            "compatible": bool(schema_ok),
+        },
+        "thresholds": {
+            "sd_regression_ratio": sd_ratio_limit,
+            "p99_ratio": p99_ratio_limit,
+            "max_new_dropped": max_new_dropped,
+            "_note": (
+                "proposals to be ratified by the timing-budget owner, "
+                "not measured facts (strategy doc §6)"
+            ),
+        },
+        "microbench": mb_table,
+        "flip_stats": fs_table,
+        "flags": flags,
+    }
+
+
+def to_verdict(comparison: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive the convenience verdict. ``REVIEW`` if anything was flagged.
+
+    Never ``FAIL``. The standing first reason restates that thresholds are
+    proposals and that a flag means a human looks.
+    """
+    flags = comparison.get("flags", [])
+    reasons = [
+        "Thresholds are proposals (strategy §6), not measured facts. A flag "
+        "means a human reviews with the numbers in hand -- not a failure.",
+    ]
+    reasons += flags
+    return {
+        "category": "REVIEW" if flags else "MATCH",
+        "reasons": reasons,
+        "remediation_hints": (
+            [
+                "Inspect the flagged metrics in the delta table; re-run the "
+                "pilot on an idle booth if a single run looks contaminated."
+            ]
+            if flags
+            else []
+        ),
+    }
+
+
+def _fmt(v: Optional[float]) -> str:
+    """Compact fixed/scientific formatting for the text table."""
+    if v is None:
+        return "    n/a"
+    if v == 0:
+        return "  0.000"
+    if abs(v) < 1e-3 or abs(v) >= 1e5:
+        return f"{v:.3e}"
+    return f"{v:.4f}"
+
+
+def render(comparison: Dict[str, Any]) -> str:
+    """Render the comparison as the familiar perf-script text table."""
+    out: List[str] = []
+    ot = comparison["os_transition"]
+    out.append("=" * 78)
+    out.append("TIMING COMPARISON  --  Win10 baseline -> Win11 pilot")
+    out.append(f"  {ot['from']}  ->  {ot['to']}")
+    if not comparison["schema"]["compatible"]:
+        out.append(
+            f"  SCHEMA: {comparison['schema']['baseline']} vs "
+            f"{comparison['schema']['pilot']}  (overlap only)"
+        )
+    out.append("=" * 78)
+
+    out.append("\nMicrobench -- absolute error vs requested interval (seconds)")
+    hdr = f"  {'primitive':<20s}{'stat':<6s}{'baseline':>12s}{'pilot':>12s}{'delta':>12s}{'ratio':>9s}"
+    out.append(hdr)
+    out.append("  " + "-" * (len(hdr) - 2))
+    for prim, cell in comparison["microbench"].items():
+        if cell.get("status") == "not_comparable":
+            out.append(f"  {prim:<20s}(not comparable: {cell['reason']})")
+            continue
+        for stat in _MICROBENCH_STATS:
+            c = cell[stat]
+            r = c.get("ratio")
+            rs = f"{r:>8.2f}x" if r is not None else "     n/a"
+            flag = "  <== FLAG" if c.get("flagged") else ""
+            out.append(
+                f"  {prim:<20s}{stat:<6s}{_fmt(c['baseline']):>12s}"
+                f"{_fmt(c['pilot']):>12s}{_fmt(c['delta']):>12s}{rs:>9s}{flag}"
+            )
+
+    out.append("\nFlip-interval jitter (milliseconds)")
+    fs = comparison["flip_stats"]
+    if fs.get("status") == "not_comparable":
+        out.append(f"  (not comparable: {fs['reason']})")
+    else:
+        for k, c in fs.items():
+            r = c.get("ratio")
+            rs = f"{r:>8.2f}x" if r is not None else "     n/a"
+            flag = "  <== FLAG" if c.get("flagged") else ""
+            out.append(
+                f"  {k:<16s}{_fmt(c['baseline']):>12s}"
+                f"{_fmt(c['pilot']):>12s}{_fmt(c['delta']):>12s}{rs:>9s}{flag}"
+            )
+
+    verdict = to_verdict(comparison)
+    out.append(f"\nVERDICT: {verdict['category']}")
+    for r in verdict["reasons"]:
+        out.append(f"  - {r}")
+    out.append("")
+    return "\n".join(out)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("baseline", type=Path, help="Win10 timing_baseline JSON")
+    p.add_argument("pilot", type=Path, help="Win11 timing_baseline JSON")
+    p.add_argument(
+        "--sd-regression-ratio",
+        type=float,
+        default=DEFAULT_SD_REGRESSION_RATIO,
+        help=f"Proposed jitter-SD regression ratio "
+        f"(default {DEFAULT_SD_REGRESSION_RATIO}).",
+    )
+    p.add_argument(
+        "--p99-ratio",
+        type=float,
+        default=DEFAULT_P99_RATIO,
+        help=f"Proposed microbench-p99 regression ratio "
+        f"(default {DEFAULT_P99_RATIO}).",
+    )
+    p.add_argument(
+        "--max-new-dropped",
+        type=int,
+        default=DEFAULT_MAX_NEW_DROPPED,
+        help=f"Tolerated baseline dropped-flip count before a rise is "
+        f"flagged (default {DEFAULT_MAX_NEW_DROPPED}).",
+    )
+    p.add_argument(
+        "--json", type=Path, help="Also write the comparison as an envelope JSON."
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if anything was flagged (for hard CI gates). "
+        "Off by default: a flag means review, not fail.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    baseline = load_baseline(args.baseline)
+    pilot = load_baseline(args.pilot)
+
+    comparison = build_comparison(
+        baseline,
+        pilot,
+        sd_ratio_limit=args.sd_regression_ratio,
+        p99_ratio_limit=args.p99_ratio,
+        max_new_dropped=args.max_new_dropped,
+    )
+    print(render(comparison))
+
+    if args.json:
+        verdict = to_verdict(comparison)
+        payload = build_envelope(
+            schema_name=SCHEMA_NAME,
+            schema_version=SCHEMA_VERSION,
+            machine={"hostname": socket.gethostname(), "role": "comparator"},
+            blocks={"comparison": comparison},
+            verdict=verdict,
+            errors=[],
+        )
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(
+            json.dumps(payload, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"Wrote: {args.json}", file=sys.stderr)
+
+    if args.strict and comparison["flags"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/perf/timing_baseline.py
+++ b/extras/perf/timing_baseline.py
@@ -1,0 +1,457 @@
+"""Emit a booth timing-microbenchmark baseline as one JSON artefact.
+
+Strategy doc (``docs/timing_test_strategy.md``) **Test C**: the per-primitive
+accuracy and jitter of the five wait primitives the whole timing stack is
+built on, plus an optional PsychoPy flip-interval jitter probe. This is the
+most OS-scheduler-sensitive layer and the cheapest signal for the Win10 ->
+Win11 regression question (#759 concern #3, issue #761). No lab, no camera,
+no devices, no subject -- it runs headless on a booth in seconds.
+
+The output is the shared baseline envelope, identical in shape to
+``extras/perf/win11_readiness.py`` (same ``machine`` block, ``verdict``,
+``collection_errors``): every measured number is kept; the ``verdict`` is
+*derived from* the numbers as a convenience and never replaces them. A single
+run cannot say "regressed" -- that is a comparison, done by
+``extras/perf/compare_timing.py`` against a locked Win10 baseline. This tool
+only *captures*.
+
+Usage::
+
+    uv run python extras/perf/timing_baseline.py [--role CTR|STM|ACQ|spare]
+        [--reps N] [--interval SECONDS] [--with-flip-stats]
+        [--flip-frames N] [--out PATH] [--stdout]
+
+By default writes ``extras/perf/baselines/timing/<os>/<hostname>.json``,
+where ``<os>`` is ``win10`` / ``win11`` / ``unknown`` derived from the OS
+build, so the Win10 baseline and the Win11 pilot land in sibling trees ready
+for the comparator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from _baseline_common import (
+    CollectionError,
+    build_envelope,
+    collect_os_identity,
+)
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "timing_baseline"
+
+# Win11's first build is 22000; anything below is Win10 for our booths.
+WIN11_MIN_BUILD = 22000
+
+# Sanity bounds for the single-run verdict. These are NOT pass/fail
+# thresholds for the OS question -- that is compare_timing.py's job against a
+# real Win10 baseline. They only flag a run that is obviously broken (e.g.
+# the machine was under heavy load) so it is not silently committed as a
+# baseline. A flag means "a human looks", never "fail".
+SANITY_MEAN_ERROR_FACTOR = 5.0  # mean abs error > 5x requested interval
+SANITY_MAX_ERROR_FACTOR = 50.0  # worst single wait > 50x requested interval
+
+
+def os_segment(machine: Dict[str, Any]) -> str:
+    """Derive the ``win10`` / ``win11`` / ``unknown`` path segment.
+
+    Prefers the OS build number (unambiguous: Win11 >= 22000); falls back to
+    the caption string; returns ``"unknown"`` if neither is conclusive so a
+    misfiled artefact is obvious rather than silently mislabeled.
+
+    Args:
+        machine: The ``machine`` identity block.
+
+    Returns:
+        One of ``"win10"``, ``"win11"``, ``"unknown"``.
+    """
+    build_raw = machine.get("os_build")
+    try:
+        build = int(str(build_raw).strip())
+    except (TypeError, ValueError):
+        build = None
+    if build is not None:
+        return "win11" if build >= WIN11_MIN_BUILD else "win10"
+
+    caption = (machine.get("os_caption") or "").lower()
+    if "windows 11" in caption:
+        return "win11"
+    if "windows 10" in caption:
+        return "win10"
+    return "unknown"
+
+
+def _percentile(sorted_vals: List[float], pct: float) -> float:
+    """Linear-interpolated percentile (numpy 'linear' method), pure-Python.
+
+    Kept dependency-free so the summary layer is unit-testable without the
+    scientific stack and gives bit-stable expected values in tests.
+
+    Args:
+        sorted_vals: Ascending-sorted samples (non-empty).
+        pct: Percentile in [0, 100].
+
+    Returns:
+        The interpolated percentile value.
+    """
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+    rank = (pct / 100.0) * (len(sorted_vals) - 1)
+    low = int(rank)
+    high = min(low + 1, len(sorted_vals) - 1)
+    frac = rank - low
+    return float(sorted_vals[low] * (1.0 - frac) + sorted_vals[high] * frac)
+
+
+def summarize_errors(
+    intervals: Dict[str, List[float]], requested: float
+) -> Dict[str, Dict[str, float]]:
+    """Reduce realized intervals to per-primitive absolute-error statistics.
+
+    Pure function (no I/O, no global state, no heavy imports) so it is
+    directly unit-testable on synthetic data.
+
+    Args:
+        intervals: Primitive name -> list of realized wait durations (s).
+        requested: The requested wait the primitives were asked for (s).
+
+    Returns:
+        Primitive name -> ``{mean, sd, p95, p99, max, n}`` of the absolute
+        error ``|realized - requested|`` in seconds.
+    """
+    summary: Dict[str, Dict[str, float]] = {}
+    for name, realized in intervals.items():
+        errs = sorted(abs(v - requested) for v in realized)
+        n = len(errs)
+        if n == 0:
+            summary[name] = {
+                "mean": 0.0,
+                "sd": 0.0,
+                "p95": 0.0,
+                "p99": 0.0,
+                "max": 0.0,
+                "n": 0,
+            }
+            continue
+        mean = sum(errs) / n
+        var = sum((e - mean) ** 2 for e in errs) / n  # population SD (np.std)
+        summary[name] = {
+            "mean": mean,
+            "sd": var**0.5,
+            "p95": _percentile(errs, 95.0),
+            "p99": _percentile(errs, 99.0),
+            "max": errs[-1],
+            "n": n,
+        }
+    return summary
+
+
+def run_microbench(
+    snap_errors: List[CollectionError],
+    interval: float,
+    reps: int,
+) -> Optional[Dict[str, List[float]]]:
+    """Run Test C, importing the canonical loop from ``time_clocks_variance``.
+
+    The measurement lives in exactly one place (``extras/time_clocks_variance
+    .measure_primitives``); this only locates and invokes it. ``extras/`` is
+    put on ``sys.path`` the same way the other perf scripts cross-tree-import.
+
+    Args:
+        snap_errors: Collection-error accumulator; a failure here is fatal to
+            the artefact (the microbench is the core signal) and re-raised
+            after being recorded.
+        interval: Requested wait per repetition (s).
+        reps: Repetitions per primitive.
+
+    Returns:
+        The raw realized-interval mapping, or ``None`` only if it could not
+        run (after recording the error).
+    """
+    extras_dir = Path(__file__).resolve().parent.parent
+    if str(extras_dir) not in sys.path:
+        sys.path.insert(0, str(extras_dir))
+    try:
+        from time_clocks_variance import measure_primitives
+    except Exception as exc:  # noqa: BLE001
+        snap_errors.append(CollectionError.from_exception("microbench.import", exc))
+        return None
+    try:
+        return measure_primitives(time_period=interval, n_reps=reps)
+    except Exception as exc:  # noqa: BLE001
+        snap_errors.append(CollectionError.from_exception("microbench.run", exc))
+        return None
+
+
+def collect_flip_stats(
+    snap_errors: List[CollectionError],
+    n_frames: int,
+) -> Optional[Dict[str, Any]]:
+    """Best-effort PsychoPy flip-interval jitter probe (display part of G4).
+
+    Opens a PsychoPy window with frame-interval recording on, flips
+    ``n_frames`` times, and returns realized flip-interval statistics plus
+    the dropped-flip count. This is intentionally a *minimal self-contained*
+    flip loop, NOT the full saccades task: the strategy doc demotes the
+    camera/bag saccades run to a one-off confirmatory measurement
+    (``timing_test_recording_audit.md`` §1.1: the in-repo
+    ``Saccade_synch`` entry point also needs a deployed ``timing_test_task_1``
+    config that is not in this repo and an EyeLink). The signal the doc wants
+    here -- requested-vs-actual flip jitter and dropped flips, no camera -- is
+    fully captured by this probe and is far more replicable.
+
+    Entirely optional and best-effort: any failure (no PsychoPy, no display,
+    headless CI) is recorded as a non-fatal ``collection_error`` and ``None``
+    is returned, so the microbench artefact is still emitted.
+
+    Args:
+        snap_errors: Non-fatal collection-error accumulator.
+        n_frames: Number of flips to time.
+
+    Returns:
+        ``{requested_hz, mean_ms, sd_ms, p95_ms, p99_ms, max_ms,
+        dropped_flips, n}`` or ``None`` if the probe could not run.
+    """
+    win = None
+    try:
+        from psychopy import visual
+
+        win = visual.Window(
+            fullscr=False,
+            size=(640, 480),
+            color=(0, 0, 0),
+            allowGUI=False,
+            waitBlanking=True,
+        )
+        measured_hz = win.getActualFrameRate(nIdentical=10, nMaxFrames=240)
+        win.recordFrameIntervals = True
+        for i in range(int(n_frames)):
+            win.color = (1, 1, 1) if i % 2 else (-1, -1, -1)
+            win.flip()
+        intervals_ms = [iv * 1000.0 for iv in win.frameIntervals]
+        dropped = int(getattr(win, "nDroppedFrames", 0))
+    except Exception as exc:  # noqa: BLE001
+        snap_errors.append(CollectionError.from_exception("flip_stats", exc))
+        return None
+    finally:
+        if win is not None:
+            try:
+                win.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    if not intervals_ms:
+        snap_errors.append(
+            CollectionError(
+                field="flip_stats",
+                message="window opened but no frame intervals were recorded",
+            )
+        )
+        return None
+
+    ordered = sorted(intervals_ms)
+    n = len(ordered)
+    mean = sum(ordered) / n
+    var = sum((v - mean) ** 2 for v in ordered) / n
+    return {
+        "requested_hz": (round(float(measured_hz), 3) if measured_hz else None),
+        "mean_ms": mean,
+        "sd_ms": var**0.5,
+        "p95_ms": _percentile(ordered, 95.0),
+        "p99_ms": _percentile(ordered, 99.0),
+        "max_ms": ordered[-1],
+        "dropped_flips": dropped,
+        "n": n,
+    }
+
+
+def derive_verdict(metrics: Dict[str, Any], interval: float) -> Dict[str, Any]:
+    """Derive an honest single-run verdict from the captured numbers.
+
+    A single microbench run cannot answer the #759 question -- that needs an
+    A/B against a locked Win10 baseline (``compare_timing.py``). So the
+    category is always ``CAPTURED``; ``reasons`` records that, plus any
+    primitive whose error is so large the run looks contaminated (machine
+    under load) and should probably be re-taken before being committed as a
+    baseline. Never pass/fail; flags are for human eyes.
+
+    Args:
+        metrics: The assembled ``metrics`` block.
+        interval: The requested microbench interval (s), for sanity scaling.
+
+    Returns:
+        ``{category, reasons, remediation_hints}``.
+    """
+    reasons: List[str] = [
+        "Single-run capture. Regression assessment is a comparison: run "
+        "extras/perf/compare_timing.py against the locked Win10 baseline."
+    ]
+    hints: List[str] = []
+
+    micro = metrics.get("microbench") or {}
+    for name, stats in micro.items():
+        if stats.get("n", 0) == 0:
+            continue
+        if stats["mean"] > SANITY_MEAN_ERROR_FACTOR * interval:
+            reasons.append(
+                f"microbench '{name}' mean error {stats['mean'] * 1000:.2f} ms "
+                f">> requested {interval * 1000:.2f} ms -- run may be "
+                f"contaminated by machine load; consider re-taking."
+            )
+            hints.append("Re-run on an otherwise-idle booth (close GUI, no recording).")
+        elif stats["max"] > SANITY_MAX_ERROR_FACTOR * interval:
+            reasons.append(
+                f"microbench '{name}' worst wait {stats['max'] * 1000:.2f} ms "
+                f"is a large outlier vs requested {interval * 1000:.2f} ms."
+            )
+
+    category = "CAPTURED_WITH_ERRORS" if metrics.get("_had_errors") else "CAPTURED"
+    return {
+        "category": category,
+        "reasons": reasons,
+        "remediation_hints": sorted(set(hints)),
+    }
+
+
+def default_output_path(os_seg: str, hostname: str) -> Path:
+    """Return ``extras/perf/baselines/timing/<os>/<hostname>.json``."""
+    here = Path(__file__).resolve().parent
+    return here / "baselines" / "timing" / os_seg / f"{hostname}.json"
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--role",
+        choices=["CTR", "STM", "ACQ", "spare"],
+        help="Booth role for this machine; recorded in the JSON for triage.",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=100,
+        help="Microbench repetitions per primitive (default: 100).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.01,
+        help="Requested wait per repetition, seconds (default: 0.01).",
+    )
+    parser.add_argument(
+        "--with-flip-stats",
+        action="store_true",
+        help="Also run the optional PsychoPy flip-interval jitter probe "
+        "(needs a display; best-effort, never fatal).",
+    )
+    parser.add_argument(
+        "--flip-frames",
+        type=int,
+        default=600,
+        help="Flips to time when --with-flip-stats is set (default: 600).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Output path. Defaults to "
+        "extras/perf/baselines/timing/<os>/<hostname>.json.",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print JSON to stdout in addition to writing the file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    errors: List[CollectionError] = []
+
+    print("Collecting timing microbenchmark baseline...", file=sys.stderr)
+
+    machine, os_errors = collect_os_identity(args.role)
+    errors.extend(os_errors)
+
+    metrics: Dict[str, Any] = {
+        "requested_interval_s": args.interval,
+        "reps": args.reps,
+    }
+
+    intervals = run_microbench(errors, args.interval, args.reps)
+    if intervals is None:
+        # The microbench is the core signal; without it the artefact is not
+        # a usable baseline. Emit it anyway (with the error recorded) so the
+        # failure is visible, but exit non-zero.
+        metrics["microbench"] = {}
+        metrics["_had_errors"] = True
+        verdict = derive_verdict(metrics, args.interval)
+        metrics.pop("_had_errors", None)
+        payload = build_envelope(
+            schema_name=SCHEMA_NAME,
+            schema_version=SCHEMA_VERSION,
+            machine=machine,
+            blocks={"metrics": metrics},
+            verdict=verdict,
+            errors=errors,
+        )
+        out_path = args.out or default_output_path(
+            os_segment(machine), machine.get("hostname", "unknown")
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(payload, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"Wrote: {out_path}", file=sys.stderr)
+        print("Microbench FAILED -- see collection_errors.", file=sys.stderr)
+        if args.stdout:
+            print(json.dumps(payload, indent=2, default=str))
+        return 1
+
+    metrics["microbench"] = summarize_errors(intervals, args.interval)
+
+    if args.with_flip_stats:
+        flip = collect_flip_stats(errors, args.flip_frames)
+        metrics["flip_stats"] = flip  # None if the probe could not run
+    else:
+        metrics["flip_stats"] = None
+
+    metrics["_had_errors"] = bool(errors)
+    verdict = derive_verdict(metrics, args.interval)
+    metrics.pop("_had_errors", None)
+
+    payload = build_envelope(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        machine=machine,
+        blocks={"metrics": metrics},
+        verdict=verdict,
+        errors=errors,
+    )
+
+    out_path = args.out or default_output_path(
+        os_segment(machine), machine.get("hostname", "unknown")
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+    print(f"Verdict: {verdict['category']}", file=sys.stderr)
+    print(f"Wrote: {out_path}", file=sys.stderr)
+    if errors:
+        print(
+            f"Collection errors: {len(errors)} (see JSON 'collection_errors')",
+            file=sys.stderr,
+        )
+
+    if args.stdout:
+        print(json.dumps(payload, indent=2, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/perf/timing_baseline.py
+++ b/extras/perf/timing_baseline.py
@@ -21,10 +21,14 @@ Usage::
         [--reps N] [--interval SECONDS] [--with-flip-stats]
         [--flip-frames N] [--out PATH] [--stdout]
 
-By default writes ``extras/perf/baselines/timing/<os>/<hostname>.json``,
-where ``<os>`` is ``win10`` / ``win11`` / ``unknown`` derived from the OS
-build, so the Win10 baseline and the Win11 pilot land in sibling trees ready
-for the comparator.
+By default writes ``<log_dir>/timing/<os>/<hostname>.json`` -- ``<log_dir>``
+is the neurobooth ``local_log_dir`` from the loaded config (the same place
+the crash/startup logs go), falling back to ``NB_INSTALL`` then the user
+home. ``<os>`` is ``win10`` / ``win11`` / ``unknown`` from the OS build, so
+the Win10 baseline and Win11 pilot land in sibling trees for the comparator.
+Runtime artefacts stay out of the repo working tree; a locked baseline is a
+deliberate copy into ``extras/perf/baselines/timing/`` (see
+``docs/timing_summary.md``).
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ from _baseline_common import (
     CollectionError,
     build_envelope,
     collect_os_identity,
+    resolved_log_dir,
 )
 
 SCHEMA_VERSION = 1
@@ -317,10 +322,18 @@ def derive_verdict(metrics: Dict[str, Any], interval: float) -> Dict[str, Any]:
     }
 
 
-def default_output_path(os_seg: str, hostname: str) -> Path:
-    """Return ``extras/perf/baselines/timing/<os>/<hostname>.json``."""
-    here = Path(__file__).resolve().parent
-    return here / "baselines" / "timing" / os_seg / f"{hostname}.json"
+def default_output_path(base: Path, os_seg: str, hostname: str) -> Path:
+    """Return ``<base>/<os_seg>/<hostname>.json``.
+
+    Pure (the resolved ``base`` directory is passed in, not discovered here)
+    so it stays unit-testable without touching the real log directory.
+
+    Args:
+        base: Resolved output root (e.g. ``resolved_log_dir("timing")``).
+        os_seg: ``win10`` / ``win11`` / ``unknown``.
+        hostname: Machine hostname.
+    """
+    return Path(base) / os_seg / f"{hostname}.json"
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -358,7 +371,8 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         "--out",
         type=Path,
         help="Output path. Defaults to "
-        "extras/perf/baselines/timing/<os>/<hostname>.json.",
+        "<log_dir>/timing/<os>/<hostname>.json (log_dir from the neurobooth "
+        "config local_log_dir; NB_INSTALL/home fallback).",
     )
     parser.add_argument(
         "--stdout",
@@ -376,6 +390,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     machine, os_errors = collect_os_identity(args.role)
     errors.extend(os_errors)
+
+    out_base = resolved_log_dir("timing")
 
     metrics: Dict[str, Any] = {
         "requested_interval_s": args.interval,
@@ -400,7 +416,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             errors=errors,
         )
         out_path = args.out or default_output_path(
-            os_segment(machine), machine.get("hostname", "unknown")
+            out_base, os_segment(machine), machine.get("hostname", "unknown")
         )
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(
@@ -434,7 +450,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
 
     out_path = args.out or default_output_path(
-        os_segment(machine), machine.get("hostname", "unknown")
+        out_base, os_segment(machine), machine.get("hostname", "unknown")
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")

--- a/extras/perf/timing_session_metrics.py
+++ b/extras/perf/timing_session_metrics.py
@@ -41,7 +41,13 @@ Usage::
         --baseline-from 2025-09-20 --baseline-to 2026-03-03 \\
         --pilot-from 2026-03-15 --pilot-to 2026-05-15 \\
         [--study study1] [--collection mvp_030] [--min-subject 100001] \\
-        [--json extras/perf/baselines/timing/session_ab.json] [--stdout]
+        [--json PATH] [--no-json] [--stdout]
+
+By default the envelope JSON is written to
+``<log_dir>/timing/session_ab_<baseline_from>_<pilot_to>.json`` (log_dir
+from the neurobooth config local_log_dir; NB_INSTALL/home fallback) so run
+output stays out of the repo working tree. ``--json`` overrides the path,
+``--no-json`` suppresses the file.
 """
 
 from __future__ import annotations
@@ -54,7 +60,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
-from _baseline_common import CollectionError, build_envelope, collect_os_identity
+from _baseline_common import (
+    CollectionError,
+    build_envelope,
+    collect_os_identity,
+    resolved_log_dir,
+)
 
 SCHEMA_VERSION = 1
 SCHEMA_NAME = "timing_session_metrics"
@@ -472,7 +483,13 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     p.add_argument(
         "--json",
         type=Path,
-        help="Also write the metric block as a baseline-envelope JSON.",
+        help="Envelope-JSON output path. Default: "
+        "<log_dir>/timing/session_ab_<baseline_from>_<pilot_to>.json.",
+    )
+    p.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Do not write the JSON file (stdout/report only).",
     )
     p.add_argument(
         "--stdout", action="store_true", help="Print the JSON envelope to stdout."
@@ -518,34 +535,38 @@ def main(argv: Optional[List[str]] = None) -> int:
     metrics = compute_metrics(df, baseline, pilot)
     print_report(metrics)
 
-    if args.json or args.stdout:
-        verdict = {
-            "category": "CAPTURED",
-            "reasons": [
-                "Tier-1 DB-derived A/B. Sample-level jitter/drift/drops are "
-                "deferred (see metrics.sample_level).",
-                "Calendar-window A/B confounds OS with subjects/room/drivers/"
-                "release (strategy §6.1.2); treat as the representative "
-                "corroborator, not the causal instrument.",
-            ],
-            "remediation_hints": [],
-        }
-        payload = build_envelope(
-            schema_name=SCHEMA_NAME,
-            schema_version=SCHEMA_VERSION,
-            machine=machine,
-            blocks={"metrics": metrics},
-            verdict=verdict,
-            errors=errors,
+    verdict = {
+        "category": "CAPTURED",
+        "reasons": [
+            "Tier-1 DB-derived A/B. Sample-level jitter/drift/drops are "
+            "deferred (see metrics.sample_level).",
+            "Calendar-window A/B confounds OS with subjects/room/drivers/"
+            "release (strategy §6.1.2); treat as the representative "
+            "corroborator, not the causal instrument.",
+        ],
+        "remediation_hints": [],
+    }
+    payload = build_envelope(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        machine=machine,
+        blocks={"metrics": metrics},
+        verdict=verdict,
+        errors=errors,
+    )
+
+    if not args.no_json:
+        out_path = args.json or (
+            resolved_log_dir("timing")
+            / f"session_ab_{args.baseline_from}_{args.pilot_to}.json"
         )
-        if args.json:
-            args.json.parent.mkdir(parents=True, exist_ok=True)
-            args.json.write_text(
-                json.dumps(payload, indent=2, default=str), encoding="utf-8"
-            )
-            print(f"Wrote: {args.json}", file=sys.stderr)
-        if args.stdout:
-            print(json.dumps(payload, indent=2, default=str))
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(payload, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"Wrote: {out_path}", file=sys.stderr)
+    if args.stdout:
+        print(json.dumps(payload, indent=2, default=str))
 
     return 0
 

--- a/extras/perf/timing_session_metrics.py
+++ b/extras/perf/timing_session_metrics.py
@@ -1,0 +1,554 @@
+"""Win10 vs Win11 timing A/B from already-collected session data.
+
+Strategy doc (``docs/timing_test_strategy.md``) **Test D**: every real
+clinical session already records the timing signal, so the cheapest
+regression instrument for #759 concern #3 (issue #761) reads it back
+remotely -- no lab, no recording, no booth time.
+
+Two clearly separated tiers, by design (strategy §6.1: "the risk is the
+metric math, not the plumbing"):
+
+* **Tier 1 -- implemented here.** Metrics that are genuinely derivable from
+  Postgres and follow patterns this repo already proves: per-device
+  cross-device **start skew**, **marker -> first-sample latency**, and
+  per-device **coarse recording span**, all from ``log_sensor_file`` /
+  ``log_task`` / ``log_session`` exactly as ``intertask_report.py`` queries
+  them. The Win10/Win11 split generalizes the single ``CUTOVER`` date in
+  ``mbient_timing_before_after.py`` to explicit *baseline* and *pilot* date
+  windows (the #759 phased plan: a locked historical Win10 window, then a
+  later Win11-pilot window, with an allowed gap between).
+
+* **Tier 2 -- scaffolded, NOT computed here.** Sample-level frame-interval
+  jitter, native-vs-LSL clock **drift (ppm)**, and dropped/duplicated-frame
+  detection. Those need the *per-sample* timestamps, which live in the
+  per-device **HDF5** files (``Time_RealSense``/``Time_ACQ``,
+  ``Time_FLIR``, ``Time_iPhone`` -- see the device ``StreamInfo`` columns),
+  **not in Postgres**. They are also new, unproven metric definitions; a
+  subtly wrong one yields confident, wrong A/B deltas. Per the strategy
+  doc they are gated behind a methodology review before any number is
+  trusted, so this tool emits an explicit ``deferred`` sentinel for them
+  rather than a fabricated value.
+
+The live database path mirrors ``intertask_report.py`` and
+``mbient_timing_before_after.py`` column-for-column; it has not been run
+against the production DB from a dev machine. The pure transform layer
+(period assignment, skew/latency/span, A/B summary) is unit-tested on
+synthetic frames.
+
+Usage::
+
+    uv run python extras/perf/timing_session_metrics.py \\
+        --baseline-from 2025-09-20 --baseline-to 2026-03-03 \\
+        --pilot-from 2026-03-15 --pilot-to 2026-05-15 \\
+        [--study study1] [--collection mvp_030] [--min-subject 100001] \\
+        [--json extras/perf/baselines/timing/session_ab.json] [--stdout]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from _baseline_common import CollectionError, build_envelope, collect_os_identity
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "timing_session_metrics"
+
+# Per-device, per-task start/end times. Column-for-column the same shape as
+# intertask_report.fetch_session_data so we inherit a query this repo has
+# already exercised against production. Study/collection/min-subject are
+# parameterized rather than hard-coded.
+SESSION_FILES_SQL = """
+SELECT
+    lsf.device_id,
+    lt.log_session_id,
+    ls.date AS session_date,
+    lt.task_id,
+    MIN(lsf.file_start_time) AS task_start,
+    MAX(lsf.file_end_time)   AS task_end
+FROM log_sensor_file lsf
+JOIN log_task    lt ON lsf.log_task_id   = lt.log_task_id
+JOIN log_session ls ON lt.log_session_id = ls.log_session_id
+WHERE ls.study_id = %(study)s
+  AND ls.collection_id = %(collection)s
+  AND lt.subject_id > %(min_subject)s
+  AND lsf.file_start_time IS NOT NULL
+  AND ls.date >= %(date_from)s
+  AND ls.date <= %(date_to)s
+GROUP BY lsf.device_id, lt.log_session_id, ls.date, lt.task_id, lt.log_task_id
+ORDER BY lt.log_session_id, lsf.device_id, MIN(lsf.file_start_time)
+"""
+
+# The LSL marker stream is recorded as a device row like any other; this is
+# the device_id it lands under. Used for marker -> first-sample latency.
+MARKER_DEVICE_ID = "Marker"
+
+# ---------------------------------------------------------------------------
+# Tier 2 -- scaffolded only. See module docstring and strategy §6.1.
+# ---------------------------------------------------------------------------
+
+SAMPLE_LEVEL_DEFERRED: Dict[str, Any] = {
+    "status": "deferred",
+    "reason": (
+        "Per-sample jitter / native-vs-LSL drift / dropped-duplicated-frame "
+        "detection require the per-device HDF5 sample timestamps, which are "
+        "NOT in Postgres, and are new metric definitions that must pass a "
+        "methodology review before any number is trusted."
+    ),
+    "data_source": (
+        "per-device HDF5: Time_RealSense/Time_ACQ (Intel), Time_FLIR (FLIR), "
+        "Time_iPhone/Time_ACQ (iPhone), plus the LSL timestamp column"
+    ),
+    "tracked_by": "issue #761; docs/timing_test_strategy.md §6.1",
+    "metrics_pending": [
+        "frame_interval_mean_sd_p95_p99",
+        "native_vs_lsl_clock_drift_ppm",
+        "dropped_frame_count_and_rate",
+        "duplicated_sample_count",
+    ],
+}
+
+_REVIEW_MSG = (
+    "Tier-2 sample-level metric: deferred pending the methodology review "
+    "required by docs/timing_test_strategy.md §6.1. The data source is the "
+    "per-device HDF5 sample timestamps, not Postgres -- implementing this "
+    "against the DB would silently produce wrong A/B deltas."
+)
+
+
+def frame_interval_jitter_from_hdf5(*_args: Any, **_kwargs: Any) -> None:
+    """Scaffold: per-device frame-interval jitter from HDF5. Not implemented."""
+    raise NotImplementedError(_REVIEW_MSG)
+
+
+def native_vs_lsl_drift_ppm_from_hdf5(*_args: Any, **_kwargs: Any) -> None:
+    """Scaffold: native-vs-LSL clock drift (ppm) from HDF5. Not implemented."""
+    raise NotImplementedError(_REVIEW_MSG)
+
+
+def dropped_duplicated_frames_from_hdf5(*_args: Any, **_kwargs: Any) -> None:
+    """Scaffold: dropped/duplicated-frame detection from HDF5. Not implemented."""
+    raise NotImplementedError(_REVIEW_MSG)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 -- pure transform layer (unit-tested on synthetic frames)
+# ---------------------------------------------------------------------------
+
+
+def assign_period(
+    df: pd.DataFrame,
+    baseline: Tuple[str, str],
+    pilot: Tuple[str, str],
+) -> pd.DataFrame:
+    """Tag each row ``baseline`` / ``pilot`` / ``None`` by ``session_date``.
+
+    Generalizes the single ``CUTOVER`` in ``mbient_timing_before_after.py``
+    to two explicit, possibly non-adjacent windows so a locked Win10 window
+    and a later Win11-pilot window can be compared with a deliberate gap
+    between them (rows in the gap are excluded, not silently bucketed).
+
+    Args:
+        df: Must contain a ``session_date`` column (date or ISO string).
+        baseline: ``(from, to)`` inclusive ISO dates for the Win10 window.
+        pilot: ``(from, to)`` inclusive ISO dates for the Win11 window.
+
+    Returns:
+        A copy of ``df`` with a new ``period`` column.
+    """
+    out = df.copy()
+    sd = out["session_date"].astype(str)
+
+    def _bucket(d: str) -> Optional[str]:
+        if baseline[0] <= d <= baseline[1]:
+            return "baseline"
+        if pilot[0] <= d <= pilot[1]:
+            return "pilot"
+        return None
+
+    out["period"] = sd.map(_bucket)
+    return out
+
+
+def start_skew(df: pd.DataFrame) -> pd.DataFrame:
+    """Cross-device start skew per (session, task).
+
+    Skew = ``max(task_start) - min(task_start)`` across all devices that
+    recorded that task. Large skew means devices did not start together (a
+    G1 cross-device-sync regression signal).
+
+    Args:
+        df: Rows with ``log_session_id``, ``task_id``, ``task_start``,
+            ``session_date``, and (if present) ``period``.
+
+    Returns:
+        One row per (session, task) with ``skew_sec`` and ``n_devices``.
+    """
+    g = df.groupby(["log_session_id", "task_id"], as_index=False).agg(
+        session_date=("session_date", "first"),
+        period=("period", "first") if "period" in df else ("task_id", "size"),
+        first_start=("task_start", "min"),
+        last_start=("task_start", "max"),
+        n_devices=("device_id", "nunique"),
+    )
+    g["skew_sec"] = (
+        pd.to_datetime(g["last_start"]) - pd.to_datetime(g["first_start"])
+    ).dt.total_seconds()
+    return g.drop(columns=["first_start", "last_start"])
+
+
+def marker_first_sample_latency(df: pd.DataFrame) -> pd.DataFrame:
+    """Latency from the Marker stream start to the first device sample.
+
+    Per (session, task): ``min(non-marker device task_start) -
+    marker task_start``. Sessions/tasks without a Marker row are skipped
+    (no baseline to measure against), which is reported, not hidden.
+
+    Args:
+        df: Rows including the marker device (``device_id == "Marker"``).
+
+    Returns:
+        One row per (session, task) with ``marker_latency_sec``.
+    """
+    rows: List[Dict[str, Any]] = []
+    for (sid, task), grp in df.groupby(["log_session_id", "task_id"]):
+        marker = grp[grp["device_id"] == MARKER_DEVICE_ID]
+        others = grp[grp["device_id"] != MARKER_DEVICE_ID]
+        if marker.empty or others.empty:
+            continue
+        m_start = pd.to_datetime(marker["task_start"]).min()
+        first_sample = pd.to_datetime(others["task_start"]).min()
+        rows.append(
+            {
+                "log_session_id": sid,
+                "task_id": task,
+                "session_date": grp["session_date"].iloc[0],
+                "period": grp["period"].iloc[0] if "period" in grp else None,
+                "marker_latency_sec": (first_sample - m_start).total_seconds(),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def device_span(df: pd.DataFrame) -> pd.DataFrame:
+    """Per-device coarse recording span (``task_end - task_start``) per task.
+
+    Coarse by construction -- this is file-level start/end, not per-sample.
+    It is a stable, DB-derivable proxy for "did this device record for the
+    expected duration"; the fine-grained jitter view is the deferred Tier-2
+    work.
+
+    Args:
+        df: Rows with ``task_start`` and ``task_end``.
+
+    Returns:
+        ``df`` plus a ``span_sec`` column.
+    """
+    out = df.copy()
+    out["span_sec"] = (
+        pd.to_datetime(out["task_end"]) - pd.to_datetime(out["task_start"])
+    ).dt.total_seconds()
+    return out
+
+
+def summarize(series: "pd.Series") -> Dict[str, Optional[float]]:
+    """Distribution summary (mirrors the ``ps()`` helper in the perf scripts).
+
+    Args:
+        series: Numeric values.
+
+    Returns:
+        ``{n, mean, median, sd, p25, p75, p95, min, max}``; all-but-``n``
+        are ``None`` for an empty series.
+    """
+    s = series.dropna()
+    if len(s) == 0:
+        return {
+            "n": 0,
+            "mean": None,
+            "median": None,
+            "sd": None,
+            "p25": None,
+            "p75": None,
+            "p95": None,
+            "min": None,
+            "max": None,
+        }
+    return {
+        "n": int(len(s)),
+        "mean": float(s.mean()),
+        "median": float(s.median()),
+        "sd": float(s.std(ddof=0)),
+        "p25": float(s.quantile(0.25)),
+        "p75": float(s.quantile(0.75)),
+        "p95": float(s.quantile(0.95)),
+        "min": float(s.min()),
+        "max": float(s.max()),
+    }
+
+
+def ab_summary(df: pd.DataFrame, value_col: str) -> Dict[str, Any]:
+    """Baseline vs pilot distribution + raw delta for one metric.
+
+    Always reports both distributions and the raw mean/median deltas; it
+    never collapses them to a pass/fail (the strategy doc is explicit:
+    "Flag means a human looks, not fail").
+
+    Args:
+        df: Must contain ``period`` and ``value_col``.
+        value_col: The metric column to summarize.
+
+    Returns:
+        ``{baseline, pilot, delta}`` where ``delta`` is pilot-minus-baseline
+        for ``mean`` and ``median`` (``None`` if either side is empty).
+    """
+    base = summarize(df.loc[df["period"] == "baseline", value_col])
+    pilot = summarize(df.loc[df["period"] == "pilot", value_col])
+
+    def _d(key: str) -> Optional[float]:
+        if base[key] is None or pilot[key] is None:
+            return None
+        return float(pilot[key] - base[key])
+
+    return {
+        "baseline": base,
+        "pilot": pilot,
+        "delta": {"mean": _d("mean"), "median": _d("median")},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live DB path (mirrors intertask_report.py / mbient_timing_before_after.py)
+# ---------------------------------------------------------------------------
+
+
+def fetch_session_files(
+    conn: Any,
+    study: str,
+    collection: str,
+    min_subject: str,
+    date_from: str,
+    date_to: str,
+) -> pd.DataFrame:
+    """Run :data:`SESSION_FILES_SQL`. Spans the full baseline+pilot range."""
+    return pd.read_sql_query(
+        SESSION_FILES_SQL,
+        conn,
+        params={
+            "study": study,
+            "collection": collection,
+            "min_subject": min_subject,
+            "date_from": date_from,
+            "date_to": date_to,
+        },
+    )
+
+
+def compute_metrics(
+    df: pd.DataFrame,
+    baseline: Tuple[str, str],
+    pilot: Tuple[str, str],
+) -> Dict[str, Any]:
+    """Assemble the Tier-1 A/B metric block from a fetched frame.
+
+    Pure given ``df``; this is the seam the unit tests drive with synthetic
+    data so the metric math is covered without a database.
+    """
+    tagged = assign_period(df, baseline, pilot)
+    tagged = tagged[tagged["period"].notna()]
+
+    skew = start_skew(tagged)
+    latency = marker_first_sample_latency(tagged)
+    spans = device_span(tagged)
+
+    per_device_span: Dict[str, Any] = {}
+    for dev, grp in spans.groupby("device_id"):
+        per_device_span[str(dev)] = ab_summary(grp, "span_sec")
+
+    n_base_sessions = int(
+        tagged.loc[tagged["period"] == "baseline", "log_session_id"].nunique()
+    )
+    n_pilot_sessions = int(
+        tagged.loc[tagged["period"] == "pilot", "log_session_id"].nunique()
+    )
+
+    return {
+        "windows": {
+            "baseline": {"from": baseline[0], "to": baseline[1]},
+            "pilot": {"from": pilot[0], "to": pilot[1]},
+        },
+        "session_counts": {
+            "baseline": n_base_sessions,
+            "pilot": n_pilot_sessions,
+        },
+        "cross_device_start_skew_sec": ab_summary(skew, "skew_sec"),
+        "marker_to_first_sample_latency_sec": (
+            ab_summary(latency, "marker_latency_sec")
+            if not latency.empty
+            else {
+                "baseline": summarize(pd.Series([], dtype=float)),
+                "pilot": summarize(pd.Series([], dtype=float)),
+                "delta": {"mean": None, "median": None},
+                "note": "no Marker device rows in range",
+            }
+        ),
+        "per_device_recording_span_sec": per_device_span,
+        "sample_level": SAMPLE_LEVEL_DEFERRED,
+    }
+
+
+def _print_ab(title: str, block: Dict[str, Any]) -> None:
+    """Render one ab_summary block as the familiar perf-script text table."""
+    print(f"\n  {title}")
+    for period in ("baseline", "pilot"):
+        s = block[period]
+        if s["n"] == 0:
+            print(f"    {period:8s}: No data")
+            continue
+        print(
+            f"    {period:8s}: Mean {s['mean']:.3f}s  Median {s['median']:.3f}s"
+            f"  SD {s['sd']:.3f}s  p95 {s['p95']:.3f}s  N={s['n']}"
+        )
+    d = block.get("delta", {})
+    if d.get("mean") is not None:
+        print(f"    delta   : mean {d['mean']:+.3f}s  median {d['median']:+.3f}s")
+
+
+def print_report(metrics: Dict[str, Any]) -> None:
+    """Human A/B report, same UX as the other ``extras/perf`` scripts."""
+    w = metrics["windows"]
+    sc = metrics["session_counts"]
+    print("=" * 75)
+    print("TIMING SESSION METRICS -- Win10 baseline vs Win11 pilot (Test D)")
+    print(
+        f"  baseline {w['baseline']['from']}..{w['baseline']['to']} "
+        f"({sc['baseline']} sessions)   "
+        f"pilot {w['pilot']['from']}..{w['pilot']['to']} "
+        f"({sc['pilot']} sessions)"
+    )
+    print("=" * 75)
+    _print_ab("Cross-device start skew", metrics["cross_device_start_skew_sec"])
+    _print_ab(
+        "Marker -> first-sample latency",
+        metrics["marker_to_first_sample_latency_sec"],
+    )
+    print("\n  Per-device coarse recording span (baseline -> pilot mean):")
+    for dev, blk in sorted(metrics["per_device_recording_span_sec"].items()):
+        b, p = blk["baseline"], blk["pilot"]
+        bm = f"{b['mean']:.2f}s" if b["n"] else "n/a"
+        pm = f"{p['mean']:.2f}s" if p["n"] else "n/a"
+        print(f"    {dev:24s}  {bm:>9s} -> {pm:>9s}")
+    print(
+        "\n  Sample-level jitter/drift/drops: "
+        f"{metrics['sample_level']['status'].upper()} "
+        f"({metrics['sample_level']['tracked_by']})"
+    )
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--baseline-from", required=True, help="Win10 window start (YYYY-MM-DD)"
+    )
+    p.add_argument("--baseline-to", required=True, help="Win10 window end (YYYY-MM-DD)")
+    p.add_argument(
+        "--pilot-from", required=True, help="Win11 window start (YYYY-MM-DD)"
+    )
+    p.add_argument("--pilot-to", required=True, help="Win11 window end (YYYY-MM-DD)")
+    p.add_argument("--study", default="study1", help="study_id (default: study1)")
+    p.add_argument(
+        "--collection", default="mvp_030", help="collection_id (default: mvp_030)"
+    )
+    p.add_argument(
+        "--min-subject",
+        default="100001",
+        help="Exclude subject_id <= this (default: 100001, drops test subjects)",
+    )
+    p.add_argument(
+        "--json",
+        type=Path,
+        help="Also write the metric block as a baseline-envelope JSON.",
+    )
+    p.add_argument(
+        "--stdout", action="store_true", help="Print the JSON envelope to stdout."
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    baseline = (args.baseline_from, args.baseline_to)
+    pilot = (args.pilot_from, args.pilot_to)
+    full_from = min(args.baseline_from, args.pilot_from)
+    full_to = max(args.baseline_to, args.pilot_to)
+
+    errors: List[CollectionError] = []
+    machine, os_errors = collect_os_identity(None)
+    errors.extend(os_errors)
+
+    # _db is imported lazily: the pure transform layer (and its tests) must
+    # not require psycopg2 / sshtunnel just to import this module.
+    from _db import get_conn
+
+    conn, tunnel = get_conn()
+    try:
+        df = fetch_session_files(
+            conn,
+            args.study,
+            args.collection,
+            args.min_subject,
+            full_from,
+            full_to,
+        )
+    finally:
+        conn.close()
+        tunnel.stop()
+
+    print(
+        f"Fetched {len(df)} device-task rows across "
+        f"{df['log_session_id'].nunique() if not df.empty else 0} sessions.",
+        file=sys.stderr,
+    )
+
+    metrics = compute_metrics(df, baseline, pilot)
+    print_report(metrics)
+
+    if args.json or args.stdout:
+        verdict = {
+            "category": "CAPTURED",
+            "reasons": [
+                "Tier-1 DB-derived A/B. Sample-level jitter/drift/drops are "
+                "deferred (see metrics.sample_level).",
+                "Calendar-window A/B confounds OS with subjects/room/drivers/"
+                "release (strategy §6.1.2); treat as the representative "
+                "corroborator, not the causal instrument.",
+            ],
+            "remediation_hints": [],
+        }
+        payload = build_envelope(
+            schema_name=SCHEMA_NAME,
+            schema_version=SCHEMA_VERSION,
+            machine=machine,
+            blocks={"metrics": metrics},
+            verdict=verdict,
+            errors=errors,
+        )
+        if args.json:
+            args.json.parent.mkdir(parents=True, exist_ok=True)
+            args.json.write_text(
+                json.dumps(payload, indent=2, default=str), encoding="utf-8"
+            )
+            print(f"Wrote: {args.json}", file=sys.stderr)
+        if args.stdout:
+            print(json.dumps(payload, indent=2, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/perf/win11_readiness.py
+++ b/extras/perf/win11_readiness.py
@@ -21,14 +21,20 @@ read-only queries used below.
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 import json
-import socket
-import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
+
+from _baseline_common import (
+    CollectionError,
+    build_envelope,
+    collect_os_identity,
+    parse_ps_date,
+    ps_json,
+    run_powershell,
+)
 
 
 SCHEMA_VERSION = 1
@@ -51,14 +57,6 @@ VENDOR_SOFTWARE_KEYWORDS = (
 
 
 @dataclass
-class CollectionError:
-    """A single non-fatal failure during data collection."""
-
-    field: str
-    message: str
-
-
-@dataclass
 class Snapshot:
     """Accumulator for the JSON payload."""
 
@@ -69,75 +67,14 @@ class Snapshot:
     errors: list[CollectionError] = field(default_factory=list)
 
     def record_error(self, where: str, exc: BaseException) -> None:
-        self.errors.append(CollectionError(field=where, message=f"{type(exc).__name__}: {exc}"))
-
-
-def run_powershell(script: str, timeout: int = 60) -> str:
-    """Execute a PowerShell snippet and return its stdout.
-
-    Args:
-        script: PowerShell source to run via ``powershell -Command``.
-        timeout: Seconds before the call is killed.
-
-    Returns:
-        Captured stdout, stripped of trailing whitespace.
-
-    Raises:
-        subprocess.CalledProcessError: PowerShell exited non-zero.
-        subprocess.TimeoutExpired: ``timeout`` elapsed.
-    """
-    completed = subprocess.run(
-        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
-    if completed.returncode != 0:
-        raise subprocess.CalledProcessError(
-            completed.returncode,
-            "powershell",
-            output=completed.stdout,
-            stderr=completed.stderr,
-        )
-    return completed.stdout.strip()
-
-
-def ps_json(script: str, timeout: int = 60) -> Any:
-    """Run a PowerShell snippet that pipes through ``ConvertTo-Json`` and parse it.
-
-    Args:
-        script: PowerShell source. The caller is responsible for the
-            ``ConvertTo-Json`` pipe; ``-Depth 5`` is recommended.
-        timeout: Forwarded to :func:`run_powershell`.
-
-    Returns:
-        Parsed JSON value, or ``None`` if PowerShell produced empty output.
-    """
-    raw = run_powershell(script, timeout=timeout)
-    if not raw:
-        return None
-    return json.loads(raw)
+        self.errors.append(CollectionError.from_exception(where, exc))
 
 
 def collect_machine(snap: Snapshot, role: Optional[str]) -> None:
     """Populate :attr:`Snapshot.machine` with hostname, role, and OS identity."""
-    snap.machine["hostname"] = socket.gethostname()
-    if role:
-        snap.machine["role"] = role
-    try:
-        info = ps_json(
-            "Get-CimInstance Win32_OperatingSystem | "
-            "Select-Object Caption, Version, BuildNumber, OSArchitecture | "
-            "ConvertTo-Json -Depth 3"
-        )
-        if isinstance(info, dict):
-            snap.machine["os_caption"] = info.get("Caption")
-            snap.machine["os_version"] = info.get("Version")
-            snap.machine["os_build"] = info.get("BuildNumber")
-            snap.machine["os_arch"] = info.get("OSArchitecture")
-    except Exception as exc:  # noqa: BLE001
-        snap.record_error("machine.os", exc)
+    machine, errors = collect_os_identity(role)
+    snap.machine.update(machine)
+    snap.errors.extend(errors)
 
 
 def collect_tpm(snap: Snapshot) -> None:
@@ -304,7 +241,7 @@ def collect_gpu(snap: Snapshot) -> None:
                 {
                     "name": entry.get("Name"),
                     "driver_version": entry.get("DriverVersion"),
-                    "driver_date": _parse_ps_date(entry.get("DriverDate")),
+                    "driver_date": parse_ps_date(entry.get("DriverDate")),
                     "video_ram_bytes": int(entry.get("AdapterRAM") or 0),
                     "video_processor": entry.get("VideoProcessor"),
                     "video_mode": entry.get("VideoModeDescription"),
@@ -313,21 +250,6 @@ def collect_gpu(snap: Snapshot) -> None:
         snap.win11_floor["gpus"] = gpus
     except Exception as exc:  # noqa: BLE001
         snap.record_error("win11_floor.gpus", exc)
-
-
-def _parse_ps_date(value: Any) -> Any:
-    """Convert PowerShell's ``/Date(ms)/`` JSON representation to ISO-8601.
-
-    Returns the input unchanged if it isn't a ``/Date(...)/`` string.
-    """
-    if not isinstance(value, str) or not value.startswith("/Date("):
-        return value
-    try:
-        ms_token = value.split("(")[1].split(")")[0]
-        ms = int(ms_token.split("+")[0].split("-")[0])
-        return dt.datetime.fromtimestamp(ms / 1000, tz=dt.timezone.utc).isoformat()
-    except Exception:  # noqa: BLE001
-        return value
 
 
 def collect_bluetooth(snap: Snapshot) -> None:
@@ -359,7 +281,7 @@ def collect_bluetooth(snap: Snapshot) -> None:
                     "instance_id": entry.get("InstanceId"),
                     "manufacturer": entry.get("Manufacturer"),
                     "driver_version": entry.get("DriverVersion"),
-                    "driver_date": _parse_ps_date(entry.get("DriverDate")),
+                    "driver_date": parse_ps_date(entry.get("DriverDate")),
                 }
             )
         snap.neurobooth_extras["bluetooth"] = radios
@@ -479,18 +401,17 @@ def derive_verdict(snap: Snapshot) -> None:
 
 def to_payload(snap: Snapshot) -> dict[str, Any]:
     """Assemble the final JSON-serializable payload."""
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "schema_name": SCHEMA_NAME,
-        "captured_at": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
-        "machine": snap.machine,
-        "win11_floor": snap.win11_floor,
-        "neurobooth_extras": snap.neurobooth_extras,
-        "verdict": snap.verdict,
-        "collection_errors": [
-            {"field": e.field, "message": e.message} for e in snap.errors
-        ],
-    }
+    return build_envelope(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        machine=snap.machine,
+        blocks={
+            "win11_floor": snap.win11_floor,
+            "neurobooth_extras": snap.neurobooth_extras,
+        },
+        verdict=snap.verdict,
+        errors=snap.errors,
+    )
 
 
 def default_output_path(hostname: str) -> Path:

--- a/extras/time_clocks_variance.py
+++ b/extras/time_clocks_variance.py
@@ -1,93 +1,125 @@
 # -*- coding: utf-8 -*-
+"""Per-primitive timing-error microbenchmark (strategy doc "Test C").
+
+Measures the realized vs. requested wait of the five timing primitives the
+whole neurobooth timing stack is built on. This is the most
+OS-scheduler-sensitive layer and the cheapest signal for the Win10 -> Win11
+question (#759 concern #3, issue #761).
+
+Originally a 2022 print-only standalone script. Refactored so the
+measurement loop is importable: the JSON metrics emitter
+``extras/perf/timing_baseline.py`` calls :func:`measure_primitives`; running
+this file directly still prints the per-primitive mean +/- SD error exactly
+as the original did, so its standalone use is unchanged.
+
+Created on Wed Apr 27 15:46:36 2022 (@author: STM); refactored for #761.
 """
-Created on Wed Apr 27 15:46:36 2022
 
-@author: STM
-"""
+from __future__ import annotations
 
-from pylsl import local_clock
-
-# import pylink
 import time
-from psychopy.core import wait, CountdownTimer
+from typing import Dict, List
 
-time_period = 0.01
-n_reps = 100
-
-print(f"    sleep period: {time_period}, n_reps: {n_reps}")
-
-t_intervals = dict()
-t_intervals["pylsl"] = list()
-tstart = local_clock()
-for _ in range(n_reps):
-
-    t1 = local_clock()
-    t2 = local_clock()
-    while t2 - t1 < time_period:
-        t2 = local_clock()
-    t_intervals["pylsl"].append(t2 - t1)
-
-print("pypls local_clock ", local_clock() - tstart)
-
-time.sleep(1.0)
-
-t_intervals["time.time"] = list()
-tstart = local_clock()
-for _ in range(n_reps):
-
-    t1 = time.time()
-    t2 = time.time()
-    while t2 - t1 < time_period:
-        t2 = time.time()
-    t_intervals["time.time"].append(t2 - t1)
-
-print("time.time", local_clock() - tstart)
-
-time.sleep(1.0)
-
-t_intervals["time.sleep"] = list()
-tstart = local_clock()
-for _ in range(n_reps):
-    t1 = local_clock()
-    time.sleep(time_period)
-    t2 = local_clock()
-    t_intervals["time.sleep"].append(t2 - t1)
-
-print("time.sleep", local_clock() - tstart)
-
-time.sleep(1.0)
-
-t_intervals["wait"] = list()
-tstart = local_clock()
-for _ in range(n_reps):
-    t1 = local_clock()
-    # CountdownTimer().add( 0.0001)
-    wait(time_period, hogCPUperiod=0)
-    t2 = local_clock()
-    t_intervals["wait"].append(t2 - t1)
-
-print("core.wait ", local_clock() - tstart)
-
-time.sleep(1.0)  # make sure no interaction with previous timing measurements
-
-t_intervals["wait_hogcpuperiod"] = list()
-tstart = local_clock()
-for _ in range(n_reps):
-    t1 = local_clock()
-    # CountdownTimer().add( 0.0001)
-    wait(time_period, hogCPUperiod=time_period)
-    t2 = local_clock()
-    t_intervals["wait_hogcpuperiod"].append(t2 - t1)
-
-print("core.wait hogCPUperiod ", local_clock() - tstart)
-
-time.sleep(1.0)
-
-print("")
 import numpy as np
 
-for wait_type in t_intervals:
-    err = np.abs(np.array(t_intervals[wait_type]) - time_period)
-    avg_error = np.mean(err)
-    std_error = np.std(err)
-    print(f"error for {wait_type}: {avg_error:.8f} +/- {std_error:.8f}")
+DEFAULT_INTERVAL = 0.01
+DEFAULT_N_REPS = 100
+DEFAULT_SETTLE = 1.0
+
+# Stable primitive identifiers. Kept as module-level constants so the
+# emitter, the comparator, and the tests all agree on the names.
+PRIMITIVES = ("pylsl", "time.time", "time.sleep", "wait", "wait_hogcpuperiod")
+
+
+def measure_primitives(
+    time_period: float = DEFAULT_INTERVAL,
+    n_reps: int = DEFAULT_N_REPS,
+    settle: float = DEFAULT_SETTLE,
+) -> Dict[str, List[float]]:
+    """Measure the realized wait duration of each timing primitive.
+
+    For each primitive, request a ``time_period`` wait ``n_reps`` times and
+    record the realized interval each time. A short idle ``settle`` between
+    primitives keeps one primitive's scheduler/CPU state from biasing the
+    next (behaviour preserved from the original script).
+
+    ``psychopy`` and ``pylsl`` are imported lazily inside this function so
+    the module can be imported (and unit-tested) on a machine without the
+    booth scientific stack; only actually *running* the benchmark needs them.
+
+    Args:
+        time_period: Requested wait, in seconds.
+        n_reps: Repetitions per primitive.
+        settle: Idle seconds between primitives.
+
+    Returns:
+        Mapping of primitive name -> list of realized intervals (seconds).
+        The caller derives the error as ``realized - time_period``;
+        :mod:`timing_baseline` reports absolute-error statistics.
+    """
+    from psychopy.core import wait
+    from pylsl import local_clock
+
+    intervals: Dict[str, List[float]] = {}
+
+    intervals["pylsl"] = []
+    for _ in range(n_reps):
+        t1 = local_clock()
+        t2 = local_clock()
+        while t2 - t1 < time_period:
+            t2 = local_clock()
+        intervals["pylsl"].append(t2 - t1)
+
+    time.sleep(settle)
+
+    intervals["time.time"] = []
+    for _ in range(n_reps):
+        t1 = time.time()
+        t2 = time.time()
+        while t2 - t1 < time_period:
+            t2 = time.time()
+        intervals["time.time"].append(t2 - t1)
+
+    time.sleep(settle)
+
+    intervals["time.sleep"] = []
+    for _ in range(n_reps):
+        t1 = local_clock()
+        time.sleep(time_period)
+        t2 = local_clock()
+        intervals["time.sleep"].append(t2 - t1)
+
+    time.sleep(settle)
+
+    intervals["wait"] = []
+    for _ in range(n_reps):
+        t1 = local_clock()
+        wait(time_period, hogCPUperiod=0)
+        t2 = local_clock()
+        intervals["wait"].append(t2 - t1)
+
+    time.sleep(settle)
+
+    intervals["wait_hogcpuperiod"] = []
+    for _ in range(n_reps):
+        t1 = local_clock()
+        wait(time_period, hogCPUperiod=time_period)
+        t2 = local_clock()
+        intervals["wait_hogcpuperiod"].append(t2 - t1)
+
+    time.sleep(settle)
+    return intervals
+
+
+def main() -> None:
+    """Legacy CLI: print mean +/- SD of the per-iteration absolute error."""
+    print(f"    sleep period: {DEFAULT_INTERVAL}, n_reps: {DEFAULT_N_REPS}")
+    intervals = measure_primitives()
+    print("")
+    for wait_type, realized in intervals.items():
+        err = np.abs(np.array(realized) - DEFAULT_INTERVAL)
+        print(f"error for {wait_type}: {err.mean():.8f} +/- {err.std():.8f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,17 @@
+"""Make the loose ``extras/`` perf scripts importable in unit tests.
+
+``extras/perf/*.py`` use bare sibling imports (``from _baseline_common
+import ...``) exactly as they do when run as scripts from that directory, so
+the unit tests put ``extras/`` and ``extras/perf/`` on ``sys.path`` -- the
+import-time equivalent of running from there. This only prepends paths; it
+does not change behaviour for the existing ``neurobooth_os`` tests.
+"""
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT / "extras", _REPO_ROOT / "extras" / "perf"):
+    _s = str(_p)
+    if _s not in sys.path:
+        sys.path.insert(0, _s)

--- a/tests/pytest/test_baseline_common.py
+++ b/tests/pytest/test_baseline_common.py
@@ -1,0 +1,67 @@
+"""Unit tests for extras/perf/_baseline_common.py and the win11_readiness
+refactor that now depends on it.
+
+The win11_readiness test is the regression guard for the behaviour-preserving
+extraction: its committed baseline JSONs must keep diffing cleanly, so the
+envelope key set and order must not move.
+"""
+
+import _baseline_common as bc
+
+
+def test_collection_error_from_exception():
+    err = bc.CollectionError.from_exception("a.b", ValueError("boom"))
+    assert err.field == "a.b"
+    assert err.message == "ValueError: boom"
+
+
+def test_build_envelope_shape_and_key_order():
+    payload = bc.build_envelope(
+        schema_name="demo",
+        schema_version=3,
+        machine={"hostname": "h"},
+        blocks={"metrics": {"x": 1}, "extra": {"y": 2}},
+        verdict={"category": "CAPTURED", "reasons": [], "remediation_hints": []},
+        errors=[bc.CollectionError("f", "m")],
+    )
+    assert list(payload.keys()) == [
+        "schema_version",
+        "schema_name",
+        "captured_at",
+        "machine",
+        "metrics",
+        "extra",
+        "verdict",
+        "collection_errors",
+    ]
+    assert payload["schema_version"] == 3
+    assert payload["schema_name"] == "demo"
+    assert payload["collection_errors"] == [{"field": "f", "message": "m"}]
+    # captured_at is an ISO-8601 UTC string.
+    assert payload["captured_at"].endswith("+00:00")
+
+
+def test_win11_readiness_envelope_unchanged_after_refactor():
+    """Guard: the extraction must not change win11_readiness's JSON shape."""
+    import win11_readiness as w
+
+    payload = w.to_payload(w.Snapshot())
+    assert list(payload.keys()) == [
+        "schema_version",
+        "schema_name",
+        "captured_at",
+        "machine",
+        "win11_floor",
+        "neurobooth_extras",
+        "verdict",
+        "collection_errors",
+    ]
+    assert payload["schema_name"] == "win11_readiness"
+    assert payload["schema_version"] == 1
+
+
+def test_parse_ps_date_passthrough_and_convert():
+    assert bc.parse_ps_date("not-a-date") == "not-a-date"
+    assert bc.parse_ps_date(None) is None
+    out = bc.parse_ps_date("/Date(1600000000000)/")
+    assert out.startswith("2020-")  # 2020-09-13T...

--- a/tests/pytest/test_baseline_common.py
+++ b/tests/pytest/test_baseline_common.py
@@ -65,3 +65,30 @@ def test_parse_ps_date_passthrough_and_convert():
     assert bc.parse_ps_date(None) is None
     out = bc.parse_ps_date("/Date(1600000000000)/")
     assert out.startswith("2020-")  # 2020-09-13T...
+
+
+def test_resolved_log_dir_falls_back_to_nb_install(tmp_path, monkeypatch):
+    """With no neurobooth config loaded and NB_CONFIG unset, the resolver
+    must fall back to NB_INSTALL (the same fallback the crash logs use),
+    and never raise."""
+    import neurobooth_os.config as nb_config
+
+    monkeypatch.setattr(nb_config, "neurobooth_config", None, raising=False)
+    monkeypatch.delenv("NB_CONFIG", raising=False)
+    monkeypatch.setenv("NB_INSTALL", str(tmp_path))
+
+    assert bc.resolved_log_dir() == tmp_path
+    assert bc.resolved_log_dir("timing") == tmp_path / "timing"
+
+
+def test_resolved_log_dir_never_raises(monkeypatch):
+    """Even with NB_INSTALL unset and no config, it returns a usable Path."""
+    import neurobooth_os.config as nb_config
+
+    monkeypatch.setattr(nb_config, "neurobooth_config", None, raising=False)
+    monkeypatch.delenv("NB_CONFIG", raising=False)
+    monkeypatch.delenv("NB_INSTALL", raising=False)
+
+    result = bc.resolved_log_dir("timing")
+    assert result.name == "timing"
+    assert result.parent.is_absolute()

--- a/tests/pytest/test_compare_timing.py
+++ b/tests/pytest/test_compare_timing.py
@@ -138,7 +138,18 @@ def test_thresholds_block_records_proposal_note():
     assert "not measured facts" in cmp["thresholds"]["_note"]
 
 
-def test_main_strict_exit_code(tmp_path, capsys):
+@pytest.fixture
+def _isolated_log_dir(tmp_path, monkeypatch):
+    """Pin resolved_log_dir to tmp so default-path writes never touch $HOME."""
+    import neurobooth_os.config as nb_config
+
+    monkeypatch.setattr(nb_config, "neurobooth_config", None, raising=False)
+    monkeypatch.delenv("NB_CONFIG", raising=False)
+    monkeypatch.setenv("NB_INSTALL", str(tmp_path))
+    return tmp_path
+
+
+def test_main_strict_exit_code(tmp_path, _isolated_log_dir):
     base = _baseline()
     pilot = copy.deepcopy(base)
     pilot["metrics"]["microbench"]["pylsl"]["p99"] = 9e-6  # flagged
@@ -149,7 +160,7 @@ def test_main_strict_exit_code(tmp_path, capsys):
     bp.write_text(json.dumps(base), encoding="utf-8")
     pp.write_text(json.dumps(pilot), encoding="utf-8")
 
-    # Default: a flag is REVIEW, exit 0.
+    # Default: a flag is REVIEW, exit 0; explicit --json honored.
     rc = ct.main([str(bp), str(pp), "--json", str(outp)])
     assert rc == 0
     assert outp.exists()
@@ -157,10 +168,35 @@ def test_main_strict_exit_code(tmp_path, capsys):
     assert payload["schema_name"] == "timing_comparison"
     assert payload["verdict"]["category"] == "REVIEW"
 
-    # --strict: same flag now a hard gate.
-    rc_strict = ct.main([str(bp), str(pp), "--strict"])
-    assert rc_strict == 1
+    # --strict: same flag now a hard gate (--no-json: no file side effect).
+    assert ct.main([str(bp), str(pp), "--strict", "--no-json"]) == 1
 
     # Clean comparison is exit 0 even with --strict.
     pp.write_text(json.dumps(base), encoding="utf-8")
-    assert ct.main([str(bp), str(pp), "--strict"]) == 0
+    assert ct.main([str(bp), str(pp), "--strict", "--no-json"]) == 0
+
+
+def test_main_defaults_json_into_log_dir(tmp_path, _isolated_log_dir):
+    base = _baseline()  # machine.hostname == "stm"
+    bp = tmp_path / "win10.json"
+    pp = tmp_path / "win11.json"
+    bp.write_text(json.dumps(base), encoding="utf-8")
+    pp.write_text(json.dumps(copy.deepcopy(base)), encoding="utf-8")
+
+    rc = ct.main([str(bp), str(pp)])  # no --json, no --no-json
+    assert rc == 0
+    expected = _isolated_log_dir / "timing" / "compare_stm.json"
+    assert expected.exists()
+    payload = json.loads(expected.read_text(encoding="utf-8"))
+    assert payload["schema_name"] == "timing_comparison"
+
+
+def test_main_no_json_suppresses_file(tmp_path, _isolated_log_dir):
+    base = _baseline()
+    bp = tmp_path / "win10.json"
+    pp = tmp_path / "win11.json"
+    bp.write_text(json.dumps(base), encoding="utf-8")
+    pp.write_text(json.dumps(copy.deepcopy(base)), encoding="utf-8")
+
+    assert ct.main([str(bp), str(pp), "--no-json"]) == 0
+    assert not (_isolated_log_dir / "timing").exists()

--- a/tests/pytest/test_compare_timing.py
+++ b/tests/pytest/test_compare_timing.py
@@ -1,0 +1,166 @@
+"""Unit tests for extras/perf/compare_timing.py.
+
+The strategy doc's hard requirements are asserted explicitly: raw deltas are
+always present (even when nothing is flagged), thresholds are overridable,
+and a flag is REVIEW (never an auto-fail).
+"""
+
+import copy
+import json
+
+import pytest
+
+import compare_timing as ct
+
+
+def _baseline():
+    return {
+        "schema_name": "timing_baseline",
+        "schema_version": 1,
+        "machine": {
+            "os_caption": "Microsoft Windows 10 Home",
+            "os_build": "19045",
+            "hostname": "stm",
+        },
+        "metrics": {
+            "requested_interval_s": 0.01,
+            "microbench": {
+                "pylsl": {
+                    "mean": 1e-5,
+                    "sd": 2e-6,
+                    "p95": 3e-6,
+                    "p99": 4e-6,
+                    "max": 5e-6,
+                    "n": 100,
+                },
+            },
+            "flip_stats": {
+                "mean_ms": 16.67,
+                "sd_ms": 0.5,
+                "p95_ms": 17.0,
+                "p99_ms": 17.2,
+                "max_ms": 18.0,
+                "dropped_flips": 0,
+                "requested_hz": 60.0,
+                "n": 600,
+            },
+        },
+    }
+
+
+def test_identical_inputs_match_but_every_delta_present():
+    base = _baseline()
+    cmp = ct.build_comparison(base, copy.deepcopy(base))
+    assert cmp["flags"] == []
+    assert ct.to_verdict(cmp)["category"] == "MATCH"
+
+    # Every microbench stat keeps a full raw cell, nothing hidden.
+    for stat in ct._MICROBENCH_STATS:
+        cell = cmp["microbench"]["pylsl"][stat]
+        assert set(cell) >= {"baseline", "pilot", "delta", "ratio"}
+        assert cell["delta"] == 0.0
+        assert cell["ratio"] == pytest.approx(1.0)
+        assert "flagged" not in cell
+
+
+def test_p99_regression_is_flagged():
+    base = _baseline()
+    pilot = copy.deepcopy(base)
+    pilot["metrics"]["microbench"]["pylsl"]["p99"] = 9e-6  # ratio 2.25 > 2.0
+    cmp = ct.build_comparison(base, pilot)
+    assert cmp["microbench"]["pylsl"]["p99"]["flagged"] is True
+    assert any("p99" in f for f in cmp["flags"])
+    assert ct.to_verdict(cmp)["category"] == "REVIEW"
+
+
+def test_sd_regression_is_flagged_and_threshold_overridable():
+    base = _baseline()
+    pilot = copy.deepcopy(base)
+    pilot["metrics"]["microbench"]["pylsl"]["sd"] = 2.6e-6  # ratio 1.30
+
+    flagged = ct.build_comparison(base, pilot)  # default 1.25
+    assert flagged["microbench"]["pylsl"]["sd"]["flagged"] is True
+
+    loosened = ct.build_comparison(base, pilot, sd_ratio_limit=1.5)
+    assert "flagged" not in loosened["microbench"]["pylsl"]["sd"]
+    assert loosened["flags"] == []
+
+
+def test_sd_rising_from_zero_baseline_is_flagged():
+    base = _baseline()
+    base["metrics"]["microbench"]["pylsl"]["sd"] = 0.0
+    pilot = copy.deepcopy(base)
+    pilot["metrics"]["microbench"]["pylsl"]["sd"] = 1e-6
+    cmp = ct.build_comparison(base, pilot)
+    assert cmp["microbench"]["pylsl"]["sd"]["flagged"] is True
+    assert any("from ~0" in f for f in cmp["flags"])
+
+
+def test_new_dropped_flips_flagged():
+    base = _baseline()
+    pilot = copy.deepcopy(base)
+    pilot["metrics"]["flip_stats"]["dropped_flips"] = 5
+    cmp = ct.build_comparison(base, pilot)
+    assert cmp["flip_stats"]["dropped_flips"]["flagged"] is True
+    assert any("dropped flips" in f for f in cmp["flags"])
+
+
+def test_flip_stats_absent_is_not_comparable_not_crash():
+    base = _baseline()
+    pilot = copy.deepcopy(base)
+    pilot["metrics"]["flip_stats"] = None
+    cmp = ct.build_comparison(base, pilot)
+    assert cmp["flip_stats"]["status"] == "not_comparable"
+    assert "pilot" in cmp["flip_stats"]["reason"]
+    # microbench still compared fine.
+    assert "pylsl" in cmp["microbench"]
+
+
+def test_schema_mismatch_flagged_but_still_compares():
+    base = _baseline()
+    pilot = copy.deepcopy(base)
+    pilot["schema_version"] = 2
+    cmp = ct.build_comparison(base, pilot)
+    assert cmp["schema"]["compatible"] is False
+    assert any("schema mismatch" in f for f in cmp["flags"])
+    assert "pylsl" in cmp["microbench"]  # comparison still happened
+
+
+def test_verdict_first_reason_is_the_proposal_disclaimer():
+    cmp = ct.build_comparison(_baseline(), copy.deepcopy(_baseline()))
+    reasons = ct.to_verdict(cmp)["reasons"]
+    assert "proposals" in reasons[0].lower()
+    assert "not a failure" in reasons[0].lower()
+
+
+def test_thresholds_block_records_proposal_note():
+    cmp = ct.build_comparison(_baseline(), copy.deepcopy(_baseline()))
+    assert "not measured facts" in cmp["thresholds"]["_note"]
+
+
+def test_main_strict_exit_code(tmp_path, capsys):
+    base = _baseline()
+    pilot = copy.deepcopy(base)
+    pilot["metrics"]["microbench"]["pylsl"]["p99"] = 9e-6  # flagged
+
+    bp = tmp_path / "win10.json"
+    pp = tmp_path / "win11.json"
+    outp = tmp_path / "delta.json"
+    bp.write_text(json.dumps(base), encoding="utf-8")
+    pp.write_text(json.dumps(pilot), encoding="utf-8")
+
+    # Default: a flag is REVIEW, exit 0.
+    rc = ct.main([str(bp), str(pp), "--json", str(outp)])
+    assert rc == 0
+    assert outp.exists()
+    payload = json.loads(outp.read_text(encoding="utf-8"))
+    assert payload["schema_name"] == "timing_comparison"
+    assert payload["verdict"]["category"] == "REVIEW"
+
+    # --strict: same flag now a hard gate.
+    rc_strict = ct.main([str(bp), str(pp), "--strict"])
+    assert rc_strict == 1
+
+    # Clean comparison is exit 0 even with --strict.
+    pp.write_text(json.dumps(base), encoding="utf-8")
+    assert ct.main([str(bp), str(pp), "--strict"]) == 0

--- a/tests/pytest/test_timing_baseline.py
+++ b/tests/pytest/test_timing_baseline.py
@@ -1,0 +1,107 @@
+"""Unit tests for extras/perf/timing_baseline.py (the Test C emitter).
+
+Only the pure layer is exercised; the microbench measurement and the
+PsychoPy flip probe need the booth scientific stack and are intentionally
+not unit-tested (they degrade to recorded collection_errors off-booth).
+"""
+
+import numpy as np
+import pytest
+
+import timing_baseline as tb
+
+
+@pytest.mark.parametrize("pct", [0, 25, 50, 90, 95, 99, 100])
+def test_percentile_matches_numpy_linear(pct):
+    vals = [3.0, 1.0, 4.0, 1.5, 5.0, 9.0, 2.0, 6.0]
+    got = tb._percentile(sorted(vals), pct)
+    assert got == pytest.approx(float(np.percentile(vals, pct)))
+
+
+def test_percentile_single_value():
+    assert tb._percentile([7.0], 95.0) == 7.0
+
+
+def test_summarize_errors_against_numpy_reference():
+    intervals = {
+        "pylsl": [0.0100, 0.0100, 0.0100],
+        "wait": [0.0120, 0.0090, 0.0135, 0.0101, 0.0098],
+    }
+    requested = 0.01
+    out = tb.summarize_errors(intervals, requested)
+
+    for name, realized in intervals.items():
+        errs = np.abs(np.array(realized) - requested)
+        s = out[name]
+        assert s["n"] == len(realized)
+        assert s["mean"] == pytest.approx(float(errs.mean()))
+        assert s["sd"] == pytest.approx(float(errs.std()))  # population, ddof=0
+        assert s["p95"] == pytest.approx(float(np.percentile(errs, 95)))
+        assert s["p99"] == pytest.approx(float(np.percentile(errs, 99)))
+        assert s["max"] == pytest.approx(float(errs.max()))
+
+
+def test_summarize_errors_empty_primitive():
+    out = tb.summarize_errors({"pylsl": []}, 0.01)
+    assert out["pylsl"] == {
+        "mean": 0.0,
+        "sd": 0.0,
+        "p95": 0.0,
+        "p99": 0.0,
+        "max": 0.0,
+        "n": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "machine,expected",
+    [
+        ({"os_build": "19045"}, "win10"),
+        ({"os_build": "22631"}, "win11"),
+        ({"os_build": "22000"}, "win11"),  # first Win11 build
+        ({"os_build": "21999"}, "win10"),  # boundary below
+        ({"os_caption": "Microsoft Windows 11 Pro"}, "win11"),
+        ({"os_caption": "Microsoft Windows 10 Home"}, "win10"),
+        ({"os_build": None, "os_caption": "Acme OS"}, "unknown"),
+        ({}, "unknown"),
+    ],
+)
+def test_os_segment(machine, expected):
+    assert tb.os_segment(machine) == expected
+
+
+def test_default_output_path():
+    p = tb.default_output_path("win10", "stm").as_posix()
+    assert p.endswith("extras/perf/baselines/timing/win10/stm.json")
+
+
+def test_derive_verdict_clean_run_is_captured():
+    metrics = {
+        "microbench": {
+            "pylsl": {"mean": 2e-5, "max": 5e-5, "n": 100},
+        }
+    }
+    v = tb.derive_verdict(metrics, interval=0.01)
+    assert v["category"] == "CAPTURED"
+    # The standing reason must always state that a single run is not a verdict.
+    assert any("compare_timing.py" in r for r in v["reasons"])
+    assert v["remediation_hints"] == []
+
+
+def test_derive_verdict_flags_contaminated_run():
+    # mean error 0.1s is 10x a 0.01s requested interval -> contamination flag.
+    metrics = {
+        "microbench": {"wait": {"mean": 0.1, "max": 0.2, "n": 100}},
+        "_had_errors": True,
+    }
+    v = tb.derive_verdict(metrics, interval=0.01)
+    assert v["category"] == "CAPTURED_WITH_ERRORS"
+    assert any("contaminated" in r for r in v["reasons"])
+    assert v["remediation_hints"]  # a re-run hint is offered
+
+
+def test_derive_verdict_ignores_empty_primitive():
+    metrics = {"microbench": {"pylsl": {"mean": 0.0, "max": 0.0, "n": 0}}}
+    v = tb.derive_verdict(metrics, interval=0.01)
+    assert v["category"] == "CAPTURED"
+    assert len(v["reasons"]) == 1  # only the standing reason

--- a/tests/pytest/test_timing_baseline.py
+++ b/tests/pytest/test_timing_baseline.py
@@ -70,9 +70,11 @@ def test_os_segment(machine, expected):
     assert tb.os_segment(machine) == expected
 
 
-def test_default_output_path():
-    p = tb.default_output_path("win10", "stm").as_posix()
-    assert p.endswith("extras/perf/baselines/timing/win10/stm.json")
+def test_default_output_path_is_pure_under_given_base():
+    from pathlib import Path
+
+    p = tb.default_output_path(Path("/var/log/nb/timing"), "win10", "stm")
+    assert p.as_posix() == "/var/log/nb/timing/win10/stm.json"
 
 
 def test_derive_verdict_clean_run_is_captured():

--- a/tests/pytest/test_timing_session_metrics.py
+++ b/tests/pytest/test_timing_session_metrics.py
@@ -1,0 +1,168 @@
+"""Unit tests for extras/perf/timing_session_metrics.py.
+
+Only the pure transform layer is exercised (the live DB path needs the SSH
+tunnel + production Postgres). The Tier-2 scaffold must stay inert: it has to
+raise rather than silently return a fabricated number.
+"""
+
+import pandas as pd
+import pytest
+
+import timing_session_metrics as sm
+
+
+def _df():
+    rows = []
+
+    def add(sid, date, task, dev, t0, t1):
+        rows.append(
+            dict(
+                device_id=dev,
+                log_session_id=sid,
+                session_date=date,
+                task_id=task,
+                task_start=pd.Timestamp(t0),
+                task_end=pd.Timestamp(t1),
+            )
+        )
+
+    # baseline session 1, task A: marker@00.000, Intel +0.5s, FLIR +1.2s
+    add(
+        1, "2026-01-10", "A", "Marker", "2026-01-10 10:00:00.000", "2026-01-10 10:01:00"
+    )
+    add(1, "2026-01-10", "A", "Intel", "2026-01-10 10:00:00.500", "2026-01-10 10:01:00")
+    add(1, "2026-01-10", "A", "FLIR", "2026-01-10 10:00:01.200", "2026-01-10 10:01:00")
+    # baseline session 2, task A: skew 0.4s, marker latency 0.1s
+    add(
+        2, "2026-02-01", "A", "Marker", "2026-02-01 09:00:00.000", "2026-02-01 09:01:00"
+    )
+    add(2, "2026-02-01", "A", "Intel", "2026-02-01 09:00:00.100", "2026-02-01 09:01:00")
+    add(2, "2026-02-01", "A", "FLIR", "2026-02-01 09:00:00.400", "2026-02-01 09:01:00")
+    # pilot session 3, task A: skew 2.0s, marker latency 0.3s
+    add(
+        3, "2026-04-05", "A", "Marker", "2026-04-05 11:00:00.000", "2026-04-05 11:01:30"
+    )
+    add(3, "2026-04-05", "A", "Intel", "2026-04-05 11:00:00.300", "2026-04-05 11:01:30")
+    add(3, "2026-04-05", "A", "FLIR", "2026-04-05 11:00:02.000", "2026-04-05 11:01:30")
+    # session 4 in the gap -> must be excluded by assign_period
+    add(4, "2026-03-10", "A", "Marker", "2026-03-10 11:00:00", "2026-03-10 11:01:00")
+    add(4, "2026-03-10", "A", "Intel", "2026-03-10 11:00:05", "2026-03-10 11:01:00")
+    return pd.DataFrame(rows)
+
+
+BASELINE = ("2026-01-01", "2026-03-03")
+PILOT = ("2026-03-20", "2026-05-15")
+
+
+def test_assign_period_buckets_and_excludes_gap():
+    tagged = sm.assign_period(_df(), BASELINE, PILOT)
+    by_session = tagged.groupby("log_session_id")["period"].first().to_dict()
+    assert by_session[1] == "baseline"
+    assert by_session[2] == "baseline"
+    assert by_session[3] == "pilot"
+    assert by_session[4] is None  # in the deliberate gap
+
+
+def test_start_skew_values():
+    tagged = sm.assign_period(_df(), BASELINE, PILOT)
+    skew = sm.start_skew(tagged[tagged["period"].notna()])
+    by_session = skew.set_index("log_session_id")["skew_sec"].to_dict()
+    assert by_session[1] == pytest.approx(1.2)
+    assert by_session[2] == pytest.approx(0.4)
+    assert by_session[3] == pytest.approx(2.0)
+    assert set(skew["n_devices"]) == {3}
+
+
+def test_marker_first_sample_latency_values():
+    tagged = sm.assign_period(_df(), BASELINE, PILOT)
+    lat = sm.marker_first_sample_latency(tagged[tagged["period"].notna()])
+    by_session = lat.set_index("log_session_id")["marker_latency_sec"].to_dict()
+    assert by_session[1] == pytest.approx(0.5)
+    assert by_session[2] == pytest.approx(0.1)
+    assert by_session[3] == pytest.approx(0.3)
+
+
+def test_marker_latency_empty_without_marker_rows():
+    df = _df()
+    df = df[df["device_id"] != "Marker"]
+    lat = sm.marker_first_sample_latency(df)
+    assert lat.empty
+
+
+def test_device_span():
+    spans = sm.device_span(_df())
+    s1 = spans[(spans["log_session_id"] == 1) & (spans["device_id"] == "Marker")]
+    assert s1["span_sec"].iloc[0] == pytest.approx(60.0)
+
+
+def test_summarize_empty_and_nonempty():
+    empty = sm.summarize(pd.Series([], dtype=float))
+    assert empty["n"] == 0 and empty["mean"] is None and empty["p95"] is None
+
+    s = sm.summarize(pd.Series([1.0, 2.0, 3.0, 4.0]))
+    assert s["n"] == 4
+    assert s["mean"] == pytest.approx(2.5)
+    assert s["median"] == pytest.approx(2.5)
+    assert s["sd"] == pytest.approx(pd.Series([1.0, 2, 3, 4]).std(ddof=0))
+
+
+def test_ab_summary_delta_sign():
+    df = pd.DataFrame(
+        {
+            "period": ["baseline", "baseline", "pilot", "pilot"],
+            "v": [1.0, 3.0, 10.0, 12.0],
+        }
+    )
+    out = sm.ab_summary(df, "v")
+    assert out["baseline"]["mean"] == pytest.approx(2.0)
+    assert out["pilot"]["mean"] == pytest.approx(11.0)
+    assert out["delta"]["mean"] == pytest.approx(9.0)
+
+
+def test_ab_summary_delta_none_when_one_side_empty():
+    df = pd.DataFrame({"period": ["baseline", "baseline"], "v": [1.0, 2.0]})
+    out = sm.ab_summary(df, "v")
+    assert out["pilot"]["n"] == 0
+    assert out["delta"]["mean"] is None
+
+
+def test_compute_metrics_end_to_end():
+    metrics = sm.compute_metrics(_df(), BASELINE, PILOT)
+    assert metrics["session_counts"] == {"baseline": 2, "pilot": 1}
+
+    skew = metrics["cross_device_start_skew_sec"]
+    assert skew["baseline"]["mean"] == pytest.approx(0.8)  # mean(1.2, 0.4)
+    assert skew["pilot"]["mean"] == pytest.approx(2.0)
+    assert skew["delta"]["mean"] == pytest.approx(1.2)
+
+    lat = metrics["marker_to_first_sample_latency_sec"]
+    assert lat["baseline"]["mean"] == pytest.approx(0.3)  # mean(0.5, 0.1)
+
+    # Tier-2 must be an explicit deferred sentinel, never a number.
+    sl = metrics["sample_level"]
+    assert sl["status"] == "deferred"
+    assert "HDF5" in sl["data_source"]
+    assert sl["metrics_pending"]
+
+
+def test_compute_metrics_marker_note_when_no_marker():
+    df = _df()
+    df = df[df["device_id"] != "Marker"]
+    metrics = sm.compute_metrics(df, BASELINE, PILOT)
+    blk = metrics["marker_to_first_sample_latency_sec"]
+    assert blk["note"] == "no Marker device rows in range"
+    assert blk["delta"]["mean"] is None
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        sm.frame_interval_jitter_from_hdf5,
+        sm.native_vs_lsl_drift_ppm_from_hdf5,
+        sm.dropped_duplicated_frames_from_hdf5,
+    ],
+)
+def test_tier2_scaffolds_raise_not_implemented(fn):
+    with pytest.raises(NotImplementedError) as exc:
+        fn("anything")
+    assert "methodology review" in str(exc.value)


### PR DESCRIPTION
## What & why

Implements the four-piece timing-regression instrument from `docs/timing_test_strategy.md` so booth recording timing can be compared across the Windows 10 → Windows 11 upgrade (**#759 concern #3**) remotely, quantitatively, and reproducibly — replacing the lab-only saccades/clapping tests for the routine loop. Closes the code portion of **#761** (steps 3–5; sets up step 6).

## Pieces

| File | Role |
|---|---|
| `extras/perf/_baseline_common.py` | Shared JSON-envelope / OS-identity / PowerShell helpers (single source of truth) |
| `extras/perf/win11_readiness.py` | Refactored onto the shared module — **behaviour-preserving**, envelope shape byte-identical (guarded by a test) |
| `extras/time_clocks_variance.py` | Made importable so the microbench measurement lives in one place; standalone CLI preserved |
| `extras/perf/timing_baseline.py` | **Test C**: clock-microbench emitter + optional PsychoPy flip-jitter probe → `baselines/timing/<os>/<hostname>.json` |
| `extras/perf/timing_session_metrics.py` | **Test D**: passive-session Win10/Win11 A/B from the production DB |
| `extras/perf/compare_timing.py` | A/B comparator; always prints every raw delta, thresholds are review-not-fail |
| `docs/timing_summary.md` | JSON-authoritative roll-up + phased capture runbook |
| `docs/timing_test_strategy.md` | Design rationale (companion to the already-committed recording audit) |

## Deliberate scope decisions (please sanity-check)

- **Tier-1 vs Tier-2 in `timing_session_metrics.py`:** ships DB-derivable metrics only (cross-device start skew, marker→first-sample latency, per-device coarse span), following the proven `intertask_report.py` / `mbient_timing_before_after.py` precedent. Sample-level jitter / native-vs-LSL drift (ppm) / dropped-duplicated-frame detection are **scaffolded as `NotImplementedError` + a `deferred` JSON sentinel** — that data is in per-device HDF5, not Postgres, and the definitions need a methodology review before any number is trusted (strategy §6.1). Emitting nothing is intentional, not a stub left unfinished.
- **Out of scope by design:** the heavyweight bag-file post-processing rebuild (#761 step 2) and the non-code recording fixture (#761 step 5). The strategy demotes the saccades/clapping tests to one-off confirmatory runs; see `timing_summary.md` → "Deferred / out of scope".
- **`win11_readiness.py`** pre-existing (non-Black) formatting was intentionally left untouched to keep the refactor diff focused; only its added lines are Black-clean.

## Verification

- **235 / 235 pytest pass** (186 pre-existing + 49 new). No regressions.
- New pure layers checked numerically (percentiles/stats vs numpy; A/B bucketing incl. gap exclusion; comparator flag + always-raw-delta behaviour; the win11_readiness envelope-unchanged guard; deferred scaffolds raise rather than fabricate).
- `ruff` clean and `black` clean on all new files; all three CLIs `--help` import cleanly.
- Not runnable from a dev box (stated, not faked): the live SSH-tunnel DB path, the booth microbench, the PsychoPy flip probe — each degrades to a recorded `collection_error`, never a fabricated value.

## Follow-ups (not in this PR)

- Operator Phase-2: lock the Win10 baseline (≥3 runs/booth) per the runbook.
- Methodology review to un-gate the Tier-2 HDF5 sample-level metrics.

Refs #759
