### PR TITLE
Add active Mbient/BLE soak harness for Win10/Win11 (#762)

### DIFF
--- a/docs/mbient_soak_summary.md
+++ b/docs/mbient_soak_summary.md
@@ -1,0 +1,151 @@
+# Mbient Soak Summary
+
+One-page roll-up of the active Mbient/BLE soak harness called for by issue
+#762 (concern #4 of #759). It answers one question: **does the Mbient/BLE
+stack behave the same — or crash differently — between Windows 10 and
+Windows 11?**
+
+The source of truth is the per-run JSON under
+[`extras/perf/baselines/mbient_soak/`](../extras/perf/baselines/mbient_soak/),
+produced by the tools below. This document summarizes those JSONs for
+humans; **if the doc and a JSON disagree, the JSON wins** (same convention as
+[`timing_summary.md`](timing_summary.md) / `win11_readiness_summary.md`).
+
+## The instrument
+
+| Tool | Produces | Lab needed |
+|---|---|---|
+| [`extras/perf/mbient_soak.py`](../extras/perf/mbient_soak.py) | `<log_dir>/mbient_soak/<os>/<host>_<ts>.json` — per-cycle connect/reset timing, sample drop-rate, BLE disconnects, and the **native-crash exit code** over a multi-hour connect/stream/reset/reconnect soak | Yes (real BLE devices on one ACQ-class booth) |
+| [`extras/perf/mbient_soak_compare.py`](../extras/perf/mbient_soak_compare.py) | `<log_dir>/mbient_soak/compare_<host>.json` — every raw delta between a locked Win10 run and a Win11 run, plus a flagged-for-review verdict | No |
+
+It drives the **production** `neurobooth_os.iout.mbient.Mbient` surface
+(`connect`→`start`→`reset_and_reconnect`→`close`); LSL/DB are neutralized at
+the harness boundary, `mbient.py` is untouched. The retrospective
+`extras/perf/mbient_timing*.py` / `mbient_acq_bottleneck.py` scripts are kept
+as-is — this is additive.
+
+`<log_dir>` is the neurobooth config `local_log_dir` (`NB_INSTALL` → home
+fallback). Runtime artefacts stay **out of the repo working tree**; a locked
+baseline is a deliberate copy into `extras/perf/baselines/mbient_soak/`.
+
+## How to populate this doc
+
+Win10-baseline execution across all four Win11-evaluation harnesses
+(timing, **this Mbient soak**, hardware/SDK, WMI/DCOM) is coordinated under
+**#768**. The procedure below is the summary; #768 is the checklist.
+
+### Phase 2 — lock the Win10 baseline (before any Win11 work)
+
+1. On an ACQ-class booth with the real Mbients, current Win10, booth idle:
+
+   ```
+   uv run python extras/perf/mbient_soak.py --json %USERPROFILE%\mbients.json \
+       --duration-min 120 --wer-dumps
+   uv run python extras/perf/mbient_soak.py --json %USERPROFILE%\mbients.json \
+       --duration-min 120 --with-iphone --wer-dumps
+   ```
+
+   Run **≥3 times per arm** (with and **without** `--with-iphone` — both
+   arms are required; see "Known limits"). Writes to
+   `<log_dir>/mbient_soak/win10/...`.
+
+2. **Lock it.** Pick the representative runs, copy them into
+   `extras/perf/baselines/mbient_soak/win10/`, and commit. This copy-and-commit
+   is the only step that version-controls a run.
+
+3. Fill in the **Win10 baseline** table below from the committed JSONs.
+
+### Phase 3 — Win11 pilot diff
+
+1. On the Win11 pilot booth, re-run step 1 (auto-writes under
+   `<log_dir>/mbient_soak/win11/...`); lock into
+   `extras/perf/baselines/mbient_soak/win11/`.
+2. Diff **matching arms** (with-iphone vs with-iphone, etc.):
+
+   ```
+   uv run python extras/perf/mbient_soak_compare.py \
+       extras/perf/baselines/mbient_soak/win10/acq_withiphone.json \
+       extras/perf/baselines/mbient_soak/win11/acq_withiphone.json
+   ```
+3. Fill in the **comparison** table; a `REVIEW` verdict means a human
+   inspects the flagged numbers — it is **not** a failure.
+
+## Verdict categories
+
+| Tool | Category | Meaning |
+|---|---|---|
+| `mbient_soak` | `CAPTURED` | Clean soak, no Python errors, no native crash. |
+| `mbient_soak` | `CAPTURED_WITH_ERRORS` | Soak completed but some cycles failed at the Python level (read `metrics.errors`). |
+| `mbient_soak` | `CRASHED` | The worker process died on a native fault — the dominant Win10 failure mode. This is a **recorded data point, not a harness bug**; see `crash.dump_paths` / the faulthandler log. |
+| `mbient_soak_compare` | `MATCH` | No proposed threshold tripped. Raw deltas still printed in full. |
+| `mbient_soak_compare` | `REVIEW` | ≥1 proposed threshold tripped (or the #669 measurement trap detected) → a human reviews. Never auto-fail. |
+
+Comparator thresholds (connect/reset p95 ratio, drop-rate increase,
+ok-fraction drop) are **proposals to be ratified by whoever owns the BLE
+budget, not measured facts**, and every one is CLI-overridable. Raw deltas
+are printed regardless.
+
+## Win10 baseline
+
+_Not yet captured — Phase 2 is operator work on a real ACQ booth (≥3 runs
+per arm). No numbers here until the JSONs are committed; this is the shape._
+
+| Arm | Host | Verdict | connect p95 (ms) | reset p95 (ms) | drop-rate | crashed | JSON | Date |
+|---|---|---|---|---|---|---|---|---|
+| no-iphone | _acq_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+| with-iphone | _acq_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+
+## Win10 → Win11 comparison
+
+_Not yet run — Phase 3 follows the Win11 pilot (#769)._
+
+| Arm | OS transition | Verdict | Flags | Comparison JSON | Date |
+|---|---|---|---|---|---|
+| no-iphone | _Win10 → Win11_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+| with-iphone | _Win10 → Win11_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+
+## Known limits (read before relying on this)
+
+1. **The iPhone co-runner is synthetic.** #669 — the native access
+   violation that coincides with Mbient BLE-connect while the iPhone
+   *listening thread* runs — is a two-subsystem race. Driving the real
+   iPhone in a multi-hour soak would spew large video files into the
+   permanent-storage transfer workflow, so `--with-iphone` runs a synthetic
+   stand-in that reproduces the **contention shape** (a continuously
+   blocking-socket listener thread concurrent with Mbient BLE) without an
+   iPhone or any video. A clean Win11 `--with-iphone` result is therefore
+   **suggestive, not definitive**. The run JSON records
+   `run.iphone_corunner: "synthetic"`; the comparator refuses to call a
+   crash-improvement meaningful unless both sides' co-runner state matched.
+2. **Definitive #669 confirmation is a separate, manual booth check** — one
+   short run with the *real* iPhone and the transfer/dump workflow disabled
+   so it does not pollute permanent storage. Out of scope for the routine
+   harness; noted here so it is tracked, not assumed.
+3. **Negotiated BLE connection parameters are not recorded.** The production
+   public surface exposes only the *requested* `ConnectionParameters`
+   (7.5/7.5/0/6000). Capturing the negotiated interval/latency/timeout would
+   require new native calls in `mbient.py` (out of scope, #762). The JSON
+   records the requested values and flags this explicitly.
+4. **Both arms are mandatory for a valid OS comparison.** A Win11 soak run
+   only without the co-runner can look clean simply because it never
+   exercised the #669 path — that is the measurement trap #762 point 5
+   names. Always capture and diff matching arms.
+
+## Deferred / out of scope (per #762, intentionally not built)
+
+- **Fixing any crash the harness finds** — that becomes its own issue. This
+  is a measurement tool.
+- **Re-architecting `mbient.py`** to be driveable outside the GUI — the
+  harness calls the existing public surface; it does not fork it.
+- **Migrating off `mbientlab.warble` / `metawear`** — would invalidate any
+  baseline.
+- **Replacing the retrospective `extras/perf/mbient_timing*.py`** — kept
+  as-is; the soak is additive.
+
+## References
+
+- Sibling harness: [`timing_summary.md`](timing_summary.md) (#761)
+- Convention mirrored: `win11_readiness_summary.md`
+- Issues: #759 (umbrella, concern #4), #762 (this harness), #768 (Win10
+  baseline lockdown across all four harnesses), #669 (the iPhone↔Mbient
+  native race), #769 (Win11 pilot)

--- a/extras/perf/_baseline_common.py
+++ b/extras/perf/_baseline_common.py
@@ -236,3 +236,149 @@ def resolved_log_dir(subfolder: Optional[str] = None) -> Path:
 
     root = Path(base)
     return root / subfolder if subfolder else root
+
+
+def percentile(sorted_vals: "list[float]", pct: float) -> float:
+    """Linear-interpolated percentile (numpy 'linear' method), pure-Python.
+
+    Single source of truth for the perf tools' percentile (timing baseline,
+    Mbient soak, and the comparators) so the number is computed identically
+    everywhere and stays unit-test-stable without the scientific stack.
+
+    Args:
+        sorted_vals: Ascending-sorted samples (must be non-empty; callers
+            guard the empty case, matching the original timing-baseline use).
+        pct: Percentile in [0, 100].
+
+    Returns:
+        The interpolated percentile value.
+    """
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+    rank = (pct / 100.0) * (len(sorted_vals) - 1)
+    low = int(rank)
+    high = min(low + 1, len(sorted_vals) - 1)
+    frac = rank - low
+    return float(sorted_vals[low] * (1.0 - frac) + sorted_vals[high] * frac)
+
+
+# Win11's first build is 22000; anything below is Win10 for our booths.
+WIN11_MIN_BUILD = 22000
+
+
+def os_segment(machine: "dict") -> str:
+    """Derive the ``win10`` / ``win11`` / ``unknown`` path segment.
+
+    Prefers the OS build number (unambiguous: Win11 >= 22000); falls back to
+    the caption string; returns ``"unknown"`` if neither is conclusive so a
+    misfiled artefact is obvious rather than silently mislabeled. Shared by
+    the timing-baseline and Mbient-soak artefact paths.
+
+    Args:
+        machine: The ``machine`` identity block.
+
+    Returns:
+        One of ``"win10"``, ``"win11"``, ``"unknown"``.
+    """
+    build_raw = machine.get("os_build")
+    try:
+        build = int(str(build_raw).strip())
+    except (TypeError, ValueError):
+        build = None
+    if build is not None:
+        return "win11" if build >= WIN11_MIN_BUILD else "win10"
+
+    caption = (machine.get("os_caption") or "").lower()
+    if "windows 11" in caption:
+        return "win11"
+    if "windows 10" in caption:
+        return "win10"
+    return "unknown"
+
+
+_BT_RADIO_PS = (
+    "Get-PnpDevice -Class Bluetooth -Status OK -ErrorAction SilentlyContinue | "
+    "ForEach-Object { "
+    "  $id = $_.InstanceId; "
+    "  $drv = (Get-PnpDeviceProperty -InstanceId $id "
+    "    -KeyName 'DEVPKEY_Device_DriverVersion' -ErrorAction SilentlyContinue).Data; "
+    "  $date = (Get-PnpDeviceProperty -InstanceId $id "
+    "    -KeyName 'DEVPKEY_Device_DriverDate' -ErrorAction SilentlyContinue).Data; "
+    "  $mfg = (Get-PnpDeviceProperty -InstanceId $id "
+    "    -KeyName 'DEVPKEY_Device_Manufacturer' -ErrorAction SilentlyContinue).Data; "
+    "  [pscustomobject]@{ "
+    "    Name = $_.FriendlyName; InstanceId = $id; "
+    "    Manufacturer = $mfg; DriverVersion = $drv; DriverDate = $date "
+    "  } "
+    "} | ConvertTo-Json -Depth 3"
+)
+
+_BT_POWER_PS = (
+    "Get-CimInstance -Namespace root/WMI -ClassName MSPower_DeviceEnable "
+    "-ErrorAction SilentlyContinue | "
+    "Where-Object { $_.InstanceName -match 'BTH|Bluetooth' } | "
+    "Select-Object InstanceName, Enable | ConvertTo-Json -Depth 3"
+)
+
+
+def collect_bluetooth_radios(
+    include_power: bool = False,
+) -> "tuple[list, list[CollectionError]]":
+    """Enumerate Bluetooth radios (name / driver / date) and, optionally, the
+    radio power-management ("allow the computer to turn off this device")
+    state — which #759 concern #4 flags as a Win11 default change.
+
+    Single source of truth shared by ``win11_readiness.py`` (hardware floor)
+    and ``mbient_soak.py`` (BLE soak run context). PowerShell failures are
+    returned as :class:`CollectionError` rather than raised so the caller can
+    still emit a useful artefact.
+
+    Args:
+        include_power: Also query ``MSPower_DeviceEnable`` and attach a
+            best-effort ``power_mgmt`` list (each ``{instance_name, enable}``;
+            ``enable=False`` means power-saving will NOT turn the radio off).
+
+    Returns:
+        ``(radios, errors)``. ``radios`` is a list of dicts; when
+        ``include_power`` and the query succeeds, a final element
+        ``{"power_mgmt": [...]}`` is appended so the shape stays a plain list.
+    """
+    radios: list = []
+    errors: list = []
+    try:
+        info = ps_json(_BT_RADIO_PS)
+        if isinstance(info, dict):
+            info = [info]
+        for entry in info or []:
+            radios.append(
+                {
+                    "name": entry.get("Name"),
+                    "instance_id": entry.get("InstanceId"),
+                    "manufacturer": entry.get("Manufacturer"),
+                    "driver_version": entry.get("DriverVersion"),
+                    "driver_date": parse_ps_date(entry.get("DriverDate")),
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        errors.append(CollectionError.from_exception("bluetooth.radios", exc))
+
+    if include_power:
+        try:
+            pw = ps_json(_BT_POWER_PS)
+            if isinstance(pw, dict):
+                pw = [pw]
+            radios.append(
+                {
+                    "power_mgmt": [
+                        {
+                            "instance_name": e.get("InstanceName"),
+                            "enable": e.get("Enable"),
+                        }
+                        for e in (pw or [])
+                    ]
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(CollectionError.from_exception("bluetooth.power_mgmt", exc))
+
+    return radios, errors

--- a/extras/perf/baselines/mbient_soak/README.md
+++ b/extras/perf/baselines/mbient_soak/README.md
@@ -1,0 +1,34 @@
+# Locked Mbient soak baseline artefacts
+
+Version-controlled JSON artefacts for the Mbient/BLE soak harness
+(issue #762, concern #4 of #759; Win10-baseline execution coordinated under
+#768).
+
+**The tools do not write here by default.** `mbient_soak.py` and
+`mbient_soak_compare.py` write runs to the configured neurobooth log
+directory (`<local_log_dir>/mbient_soak/...`, with an `NB_INSTALL` → home
+fallback) so multi-hour soak output — including large crash minidumps — stays
+out of the repo working tree.
+
+This directory is the destination for a **deliberately locked** baseline: the
+operator reviews the runs in the log dir, picks the representative ones, and
+*copies* them here and commits. Layout once populated:
+
+```
+baselines/mbient_soak/
+  win10/<host>_<arm>.json    # locked Win10 soak (one per arm: with/without iphone)
+  win11/<host>_<arm>.json    # locked Win11 pilot soak
+  compare_<host>.json        # locked comparator delta (optional)
+```
+
+Capture **both arms** (`--with-iphone` and without) — a Win11 run only
+without the co-runner can look clean simply because it never exercised the
+#669 path. The `win10` / `win11` segment is chosen automatically from the OS
+build (Win11 = build ≥ 22000).
+
+These committed JSONs are the source of truth. The human roll-up is
+[`docs/mbient_soak_summary.md`](../../../../docs/mbient_soak_summary.md); if
+the two disagree, the JSON wins. The capture-and-lock procedure (and the
+synthetic-co-runner caveat) is in that doc. Nothing is committed here until
+Phase 2 (operator work on a real ACQ booth) is done — this README keeps the
+directory tracked until then.

--- a/extras/perf/mbient_soak.py
+++ b/extras/perf/mbient_soak.py
@@ -1,0 +1,803 @@
+"""Active Mbient/BLE soak harness for the Win10 -> Win11 decision (#762).
+
+#759 concern #4. The existing ``extras/perf/mbient_*.py`` scripts are
+*retrospective* (they read what production already logged). This is a *test*:
+it drives the real BLE stack on demand on one ACQ-class booth, hundreds of
+connect / stream / reset / reconnect cycles, and emits numbers two operating
+systems can be diffed on.
+
+It calls the **production** ``neurobooth_os.iout.mbient.Mbient`` surface
+(`connect` -> `start` -> `reset_and_reconnect` -> `close`) so it exercises the
+same code paths the GUI does -- it does not fork or re-implement the driver.
+LSL and DB messaging are neutralized at the harness boundary (the established
+test pattern: ``mbient.DISABLE_LSL = True`` + ``mbient.post_message`` no-op);
+``mbient.py`` itself is untouched.
+
+Same conventions as the timing harness (#761): the run JSON is authoritative,
+the ``verdict`` is derived *from* the numbers, and the OS comparison is a
+separate tool (``mbient_soak_compare.py``) -- a single run only *captures*.
+Output uses the shared ``_baseline_common`` envelope and lands in the
+configured log dir, not the repo tree.
+
+Honest limits (stated, not buried -- see ``docs/mbient_soak_summary.md``):
+
+* **The iPhone co-runner is synthetic.** #669 (the access violation that
+  coincides with Mbient BLE-connect while the iPhone listener runs) is a
+  two-subsystem race. Driving the real iPhone in a multi-hour soak would
+  spew large video files into the permanent-storage transfer workflow, so
+  ``--with-iphone`` runs a synthetic stand-in that reproduces the *contention
+  shape* (a continuously blocking-socket listener thread concurrent with
+  Mbient BLE) without an iPhone or any video. A clean Win11 ``--with-iphone``
+  result is therefore suggestive, not definitive.
+* **Negotiated BLE connection parameters are not recorded.** The production
+  public surface only exposes the *requested* ``ConnectionParameters``; the
+  negotiated interval/latency/timeout would require new native calls in
+  ``mbient.py`` (out of scope per #762). Only the requested values are
+  emitted, flagged as such.
+
+Usage::
+
+    uv run python extras/perf/mbient_soak.py \\
+        [--json ~/mbients.json | --mac AA:BB.. --mac CC:DD.. | --scan] \\
+        [--duration-min 120] [--stream-seconds 30] [--with-iphone] \\
+        [--mock] [--wer-dumps] [--out PATH] [--no-json] [--stdout] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import multiprocessing as mp
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from _baseline_common import (
+    CollectionError,
+    build_envelope,
+    collect_bluetooth_radios,
+    collect_os_identity,
+    os_segment,
+    percentile,
+    resolved_log_dir,
+)
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "mbient_soak"
+
+# App-log substrings that indicate a BLE disconnect of interest. Counted by a
+# logging handler so a soft (non-crash) link drop is still visible per cycle.
+_DISCONNECT_MARKERS = (
+    "Disconnected Prematurely",
+    "Disconnect with status",
+    "Disconnected during reset",
+    "Disconnect during attempt_reconnect",
+)
+
+# Single-run sanity bounds (NOT the OS pass/fail thresholds -- that is
+# mbient_soak_compare.py against a locked Win10 baseline). A flag means "a
+# human looks", never "fail".
+SANITY_MIN_OK_CYCLE_FRACTION = 0.5  # < half the cycles succeeded -> flag
+SANITY_DROP_RATE_FLAG = 0.10  # mean per-cycle sample drop-rate > 10% -> flag
+
+
+# ---------------------------------------------------------------------------
+# Pure layer (stdlib only; unit-tested without the neurobooth stack)
+# ---------------------------------------------------------------------------
+
+
+def _stats(values: List[float]) -> Dict[str, Optional[float]]:
+    """Mean / SD / p95 / max / n for a list of numbers (population SD).
+
+    Empty input yields ``n=0`` with the rest ``None`` so callers never crash
+    on a soak that produced no usable cycles.
+    """
+    if not values:
+        return {"n": 0, "mean": None, "sd": None, "p95": None, "max": None}
+    ordered = sorted(values)
+    n = len(ordered)
+    mean = sum(ordered) / n
+    var = sum((v - mean) ** 2 for v in ordered) / n
+    return {
+        "n": n,
+        "mean": mean,
+        "sd": var**0.5,
+        "p95": percentile(ordered, 95.0),
+        "max": ordered[-1],
+    }
+
+
+def summarize_cycles(cycles: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Reduce per-cycle soak records to the comparable metric block.
+
+    Pure: no I/O, no globals, no neurobooth imports -- the unit-test seam.
+
+    Args:
+        cycles: Per-cycle dicts written by the worker. Recognized keys:
+            ``ok`` (bool), ``connect_ms``, ``reset_ms``, ``cycle_wall_s``,
+            ``samples``, ``expected_samples``, ``ble_disconnects``,
+            ``error`` (str|None).
+
+    Returns:
+        ``{n_cycles, n_ok, n_failed, ok_fraction, connect_ms{}, reset_ms{},
+        cycle_wall_s{}, drop_rate{}, ble_disconnects_total,
+        cycles_with_disconnect, errors[]}``.
+    """
+    n = len(cycles)
+    ok = [c for c in cycles if c.get("ok")]
+    connect_ms = [
+        float(c["connect_ms"]) for c in cycles if c.get("connect_ms") is not None
+    ]
+    reset_ms = [float(c["reset_ms"]) for c in cycles if c.get("reset_ms") is not None]
+    wall = [
+        float(c["cycle_wall_s"]) for c in cycles if c.get("cycle_wall_s") is not None
+    ]
+    drop_rates: List[float] = []
+    for c in cycles:
+        exp = c.get("expected_samples")
+        got = c.get("samples")
+        if exp and got is not None and exp > 0:
+            drop_rates.append(max(0.0, 1.0 - (got / exp)))
+    disconnects = [int(c.get("ble_disconnects", 0) or 0) for c in cycles]
+    errors = sorted({c["error"] for c in cycles if c.get("error")})
+
+    return {
+        "n_cycles": n,
+        "n_ok": len(ok),
+        "n_failed": n - len(ok),
+        "ok_fraction": (len(ok) / n) if n else 0.0,
+        "connect_ms": _stats(connect_ms),
+        "reset_ms": _stats(reset_ms),
+        "cycle_wall_s": _stats(wall),
+        "drop_rate": _stats(drop_rates),
+        "ble_disconnects_total": sum(disconnects),
+        "cycles_with_disconnect": sum(1 for d in disconnects if d > 0),
+        "errors": errors,
+    }
+
+
+def derive_verdict(metrics: Dict[str, Any], crash: Dict[str, Any]) -> Dict[str, Any]:
+    """Honest single-run verdict. Never pass/fail for the OS question.
+
+    Category is ``CRASHED`` if the worker process died on a native fault
+    (the dominant Win10 failure mode -- recording it is the whole point),
+    else ``CAPTURED`` / ``CAPTURED_WITH_ERRORS``. ``reasons`` always states
+    that the regression assessment is a comparison, plus any obviously-bad
+    signal that means the run should probably be re-taken before being
+    locked as a baseline.
+    """
+    reasons: List[str] = [
+        "Single-run capture. Regression assessment is a comparison: run "
+        "extras/perf/mbient_soak_compare.py against the locked Win10 baseline."
+    ]
+    hints: List[str] = []
+
+    crashed = bool(crash.get("crashed"))
+    if crashed:
+        reasons.append(
+            f"Worker process exited abnormally (exit_code="
+            f"{crash.get('exit_code')}, {crash.get('exit_code_hex')}). "
+            f"A native fault is the dominant Win10 failure mode -- this is a "
+            f"recorded data point, not a harness bug. See crash.dump_paths / "
+            f"the faulthandler log."
+        )
+
+    n = metrics.get("n_cycles", 0)
+    if n == 0:
+        reasons.append("No cycles completed -- soak did not run; investigate.")
+    else:
+        if metrics["ok_fraction"] < SANITY_MIN_OK_CYCLE_FRACTION:
+            reasons.append(
+                f"Only {metrics['n_ok']}/{n} cycles succeeded "
+                f"(< {SANITY_MIN_OK_CYCLE_FRACTION:.0%}); run may be unusable "
+                f"as a baseline."
+            )
+            hints.append("Re-run on an idle ACQ booth with charged devices.")
+        drop_mean = metrics.get("drop_rate", {}).get("mean")
+        if drop_mean is not None and drop_mean > SANITY_DROP_RATE_FLAG:
+            reasons.append(
+                f"Mean per-cycle sample drop-rate {drop_mean:.1%} "
+                f"> {SANITY_DROP_RATE_FLAG:.0%} sanity bound."
+            )
+
+    if crashed:
+        category = "CRASHED"
+    elif metrics.get("errors") or metrics.get("n_failed"):
+        category = "CAPTURED_WITH_ERRORS"
+    else:
+        category = "CAPTURED"
+    return {
+        "category": category,
+        "reasons": reasons,
+        "remediation_hints": sorted(set(hints)),
+    }
+
+
+def classify_exit(exit_code: Optional[int]) -> Dict[str, Any]:
+    """Interpret a worker process exit code.
+
+    ``0`` = clean; ``None`` = never returned (joined-out / terminated);
+    anything else = abnormal (on Windows a native access violation surfaces
+    as ``3221225477`` / ``0xC0000005``).
+    """
+    if exit_code == 0:
+        return {"crashed": False, "exit_code": 0, "exit_code_hex": "0x0"}
+    if exit_code is None:
+        return {
+            "crashed": True,
+            "exit_code": None,
+            "exit_code_hex": None,
+            "note": "worker did not return (timed out or was terminated)",
+        }
+    return {
+        "crashed": True,
+        "exit_code": exit_code,
+        "exit_code_hex": hex(exit_code & 0xFFFFFFFF),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Synthetic iPhone co-runner (the #669 contention shape, no real iPhone)
+# ---------------------------------------------------------------------------
+
+
+class SyntheticIphoneCorunner:
+    """Reproduce the #669 contention *shape* without an iPhone or video.
+
+    #669 is a race between Mbient BLE-connect on the main thread and the
+    iPhone *listening thread* (a continuous blocking-socket ``recv`` + Python
+    packet processing). This stands that mechanism up with a localhost UDP
+    socket: a feeder thread emits small datagrams and a listener thread does
+    blocking ``recvfrom`` + a trivial parse in a tight loop, competing for
+    the GIL / scheduler exactly while the soak does its BLE work.
+
+    It is explicitly an approximation (no video, no real iPhone, no transfer
+    workflow); the run JSON records ``iphone_corunner: "synthetic"`` so a
+    Win11 result is read with that caveat.
+    """
+
+    def __init__(self, rate_hz: int = 200) -> None:
+        self._rate_hz = rate_hz
+        self._stop = threading.Event()
+        self._threads: List[threading.Thread] = []
+        self.packets_processed = 0
+
+    def start(self) -> None:
+        rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        rx.bind(("127.0.0.1", 0))
+        rx.settimeout(0.5)
+        addr = rx.getsockname()
+
+        def _listener() -> None:
+            while not self._stop.is_set():
+                try:
+                    data, _ = rx.recvfrom(2048)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+                # Trivial parse, mirroring iphone.listen() packet handling.
+                if data:
+                    self.packets_processed += 1
+                    _ = len(data).to_bytes(4, "little")
+            rx.close()
+
+        def _feeder() -> None:
+            tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            period = 1.0 / max(1, self._rate_hz)
+            payload = b"\x01" * 256
+            while not self._stop.is_set():
+                try:
+                    tx.sendto(payload, addr)
+                except OSError:
+                    break
+                time.sleep(period)
+            tx.close()
+
+        for fn in (_listener, _feeder):
+            t = threading.Thread(
+                target=fn, name=f"iphone-syn-{fn.__name__}", daemon=True
+            )
+            t.start()
+            self._threads.append(t)
+
+    def stop(self) -> None:
+        self._stop.set()
+        for t in self._threads:
+            t.join(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Disconnect tally (no production change; counts app-log markers per cycle)
+# ---------------------------------------------------------------------------
+
+
+class _DisconnectTally(logging.Handler):
+    """Count BLE-disconnect log lines and tee the app log to a run file."""
+
+    def __init__(self, log_file: Path) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.count = 0
+        self._fh = open(log_file, "a", encoding="utf-8")
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = record.getMessage()
+        except Exception:  # noqa: BLE001
+            return
+        if any(m in msg for m in _DISCONNECT_MARKERS):
+            self.count += 1
+        try:
+            self._fh.write(msg + "\n")
+            self._fh.flush()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def close(self) -> None:
+        try:
+            self._fh.close()
+        finally:
+            super().close()
+
+
+# ---------------------------------------------------------------------------
+# Device construction (model_construct: clean, non-forking, no validation)
+# ---------------------------------------------------------------------------
+
+
+def make_device(
+    name: str, mac: str, mock: bool, acc_hz: int, gyro_hz: int, data_range: int
+) -> Any:
+    """Build a production ``Mbient`` (or ``MockMbient``) for one device.
+
+    Uses the canonical ``model_construct`` builder (the pattern in
+    ``tests/pytest/test_mock_mbient.py``) so no pydantic validation or
+    ``ENV_devices`` config context is needed. neurobooth imports are lazy so
+    this module's pure layer imports without the stack.
+    """
+    from neurobooth_os.iout.stim_param_reader import (
+        MbientDeviceArgs,
+        MbientSensorArgs,
+        MockMbientDeviceArgs,
+    )
+
+    acc = MbientSensorArgs.model_construct(
+        sensor_id="acc1", sample_rate=acc_hz, data_range=data_range
+    )
+    gyro = MbientSensorArgs.model_construct(
+        sensor_id="gyro1", sample_rate=gyro_hz, data_range=2000
+    )
+    args_cls = MockMbientDeviceArgs if mock else MbientDeviceArgs
+    device_args = args_cls.model_construct(
+        ENV_devices={},
+        device_id=f"Mbient_{name}_1",
+        sensor_ids=["acc1", "gyro1"],
+        sensor_array=[acc, gyro],
+        mac=mac,
+        device_name=name,
+        arg_parser=f"iout.stim_param_reader.py::{args_cls.__name__}()",
+    )
+    if mock:
+        from neurobooth_os.iout.mock.mock_mbient import MockMbient
+
+        return MockMbient(device_args)
+    from neurobooth_os.iout.mbient import Mbient
+
+    return Mbient(device_args)
+
+
+def resolve_device_list(
+    macs: List[str], json_path: Optional[str], scan: bool, scan_n: int
+) -> List[Tuple[str, str]]:
+    """Return ``[(name, mac), ...]`` reusing reset_mbients' discovery (DRY).
+
+    ``--mac`` is handled inline (trivial); ``--json`` / ``--scan`` defer to
+    ``reset_mbients.discovery_json`` / ``discovery_scan`` so the device-list
+    convention stays single-sourced.
+    """
+    if json_path:
+        extras_dir = Path(__file__).resolve().parent.parent
+        if str(extras_dir) not in sys.path:
+            sys.path.insert(0, str(extras_dir))
+        from reset_mbients import discovery_json
+
+        return [(d.name, d.address) for d in discovery_json(json_path)]
+    if macs:
+        return [(f"CL-{i}", m) for i, m in enumerate(macs)]
+    if scan:
+        extras_dir = Path(__file__).resolve().parent.parent
+        if str(extras_dir) not in sys.path:
+            sys.path.insert(0, str(extras_dir))
+        from reset_mbients import discovery_scan
+
+        return [
+            (d.name, d.address)
+            for d in discovery_scan(timeout_sec=10, n_devices=scan_n)
+        ]
+    raise SystemExit("No devices: pass --json, --mac (repeatable), or --scan.")
+
+
+# ---------------------------------------------------------------------------
+# Worker (runs in a child process; native crash -> parent reads exit code)
+# ---------------------------------------------------------------------------
+
+
+def run_soak_worker(cfg: Dict[str, Any], jsonl_path: str) -> int:
+    """Drive the production Mbient loop, writing one JSONL line per cycle.
+
+    Crash-safe by construction: each cycle is flushed to ``jsonl_path`` as it
+    completes, so a native fault mid-soak loses only the in-flight cycle and
+    the parent still has every prior one. Python-level per-cycle failures are
+    caught and recorded (``ok=False``) so a soft error does not abort the
+    soak.
+
+    Returns 0 on clean completion. (A native fault never returns -- the
+    process dies and the parent classifies the exit code.)
+    """
+    # Neutralize LSL + DB at the harness boundary (production module
+    # untouched) -- the exact pattern tests/pytest/test_mock_mbient.py uses.
+    from neurobooth_os.iout import mbient as mbient_mod
+
+    mbient_mod.DISABLE_LSL = True
+    mbient_mod.post_message = lambda msg: None
+
+    try:
+        from neurobooth_os.log_manager import enable_crash_handler
+
+        enable_crash_handler("MBIENT_SOAK")
+    except Exception:  # noqa: BLE001
+        pass  # faulthandler is a bonus; the exit code is the primary signal
+
+    tally = _DisconnectTally(Path(cfg["log_file"]))
+    app_logger = logging.getLogger("app")
+    app_logger.addHandler(tally)
+    app_logger.setLevel(logging.DEBUG)
+
+    corunner = None
+    if cfg["with_iphone"]:
+        corunner = SyntheticIphoneCorunner()
+        corunner.start()
+
+    devices = [
+        make_device(
+            name,
+            mac,
+            cfg["mock"],
+            cfg["acc_hz"],
+            cfg["gyro_hz"],
+            cfg["data_range"],
+        )
+        for name, mac in cfg["devices"]
+    ]
+    stream_s = cfg["stream_seconds"]
+    expected = int(stream_s * cfg["acc_hz"])
+    deadline = time.time() + cfg["duration_s"]
+
+    out = open(jsonl_path, "a", encoding="utf-8")
+
+    def _write(rec: Dict[str, Any]) -> None:
+        out.write(json.dumps(rec, default=str) + "\n")
+        out.flush()
+
+    cycle_idx = 0
+    try:
+        while time.time() < deadline:
+            for name, dev in zip([d[0] for d in cfg["devices"]], devices):
+                cycle_idx += 1
+                disc0 = tally.count
+                rec: Dict[str, Any] = {
+                    "cycle": cycle_idx,
+                    "device": name,
+                    "ts": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
+                    "ok": False,
+                    "error": None,
+                    "connect_ms": None,
+                    "reset_ms": None,
+                    "samples": None,
+                    "expected_samples": expected,
+                    "ble_disconnects": 0,
+                    "cycle_wall_s": None,
+                }
+                t_cycle = time.perf_counter()
+                try:
+                    n0 = dev.n_samples_streamed
+                    t0 = time.perf_counter()
+                    connected = dev.connect()
+                    rec["connect_ms"] = (time.perf_counter() - t0) * 1000.0
+                    if not connected:
+                        rec["error"] = "connect() returned False"
+                        _write(rec)
+                        continue
+
+                    dev.start(buzz=False)
+                    time.sleep(stream_s)
+                    rec["samples"] = dev.n_samples_streamed - n0
+
+                    t0 = time.perf_counter()
+                    dev.reset_and_reconnect()
+                    rec["reset_ms"] = (time.perf_counter() - t0) * 1000.0
+                    rec["ok"] = True
+                except Exception as exc:  # noqa: BLE001
+                    rec["error"] = f"{type(exc).__name__}: {exc}"
+                finally:
+                    rec["ble_disconnects"] = tally.count - disc0
+                    rec["cycle_wall_s"] = time.perf_counter() - t_cycle
+                    _write(rec)
+                if time.time() >= deadline:
+                    break
+    finally:
+        for dev in devices:
+            try:
+                dev.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if corunner is not None:
+            corunner.stop()
+        out.close()
+        app_logger.removeHandler(tally)
+        tally.close()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Run context + optional WER minidumps (HKCU, no admin, reversible)
+# ---------------------------------------------------------------------------
+
+
+def _lib_version(name: str) -> Optional[str]:
+    """Best-effort installed-version lookup (None if absent)."""
+    try:
+        from importlib.metadata import version
+
+        return version(name)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def collect_run_context(
+    with_iphone: bool, mock: bool
+) -> Tuple[Dict[str, Any], List[CollectionError], Dict[str, Any]]:
+    """OS identity + BT radio/driver/power + lib versions + run flags.
+
+    Returns ``(machine, errors, context)``.
+    """
+    machine, errors = collect_os_identity(None)
+    radios, bt_errors = collect_bluetooth_radios(include_power=True)
+    errors.extend(bt_errors)
+    context = {
+        "bluetooth": radios,
+        "versions": {
+            "python": sys.version.split()[0],
+            "metawear": _lib_version("metawear"),
+            "warble": _lib_version("warble"),
+        },
+        "iphone_corunner": ("synthetic" if with_iphone else "none"),
+        "mock": mock,
+        "connection_params_requested": {
+            "min_conn_interval": 7.5,
+            "max_conn_interval": 7.5,
+            "latency": 0,
+            "timeout": 6000,
+        },
+        "connection_params_negotiated": None,
+        "connection_params_note": (
+            "negotiated BLE parameters are not exposed by the Mbient public "
+            "surface; capturing them would require extending mbient.py "
+            "(out of scope, #762). Only requested values are recorded."
+        ),
+    }
+    return machine, errors, context
+
+
+_WER_KEY = r"Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\python.exe"
+
+
+def enable_wer_localdumps(dump_dir: Path) -> Optional[str]:
+    """Opt-in HKCU WER LocalDumps for python.exe (full dumps). Reversible.
+
+    Returns the dump directory on success (so the caller can scan it), or
+    ``None`` if the registry write failed (recorded, never fatal). No admin
+    rights needed -- HKCU only.
+    """
+    try:
+        import winreg
+
+        dump_dir.mkdir(parents=True, exist_ok=True)
+        key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, _WER_KEY)
+        with key:
+            winreg.SetValueEx(key, "DumpFolder", 0, winreg.REG_EXPAND_SZ, str(dump_dir))
+            winreg.SetValueEx(key, "DumpType", 0, winreg.REG_DWORD, 2)  # full
+            winreg.SetValueEx(key, "DumpCount", 0, winreg.REG_DWORD, 10)
+        return str(dump_dir)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def disable_wer_localdumps() -> None:
+    """Remove the HKCU LocalDumps key we created (restore prior state)."""
+    try:
+        import winreg
+
+        winreg.DeleteKey(winreg.HKEY_CURRENT_USER, _WER_KEY)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--mac", action="append", default=[], help="Device MAC (repeatable)."
+    )
+    p.add_argument(
+        "--json",
+        dest="json_path",
+        help="JSON file of {device_name: MAC} (e.g. ~/mbients.json).",
+    )
+    p.add_argument(
+        "--scan",
+        action="store_true",
+        help="BLE-scan for devices instead of --mac/--json.",
+    )
+    p.add_argument(
+        "--scan-n",
+        type=int,
+        default=5,
+        help="Expected device count when --scan (default 5).",
+    )
+    p.add_argument(
+        "--duration-min",
+        type=float,
+        default=120.0,
+        help="Soak wall-clock duration in minutes (default 120).",
+    )
+    p.add_argument(
+        "--stream-seconds",
+        type=float,
+        default=30.0,
+        help="Stream seconds per cycle before reset (default 30).",
+    )
+    p.add_argument("--acc-hz", type=int, default=100)
+    p.add_argument("--gyro-hz", type=int, default=100)
+    p.add_argument("--data-range", type=int, default=8)
+    p.add_argument(
+        "--with-iphone",
+        action="store_true",
+        help="Run the synthetic #669 iPhone-contention co-runner.",
+    )
+    p.add_argument(
+        "--mock",
+        action="store_true",
+        help="Drive MockMbient (no hardware/DB) for dev/CI.",
+    )
+    p.add_argument(
+        "--wer-dumps",
+        action="store_true",
+        help="Opt-in HKCU WER full minidumps for python.exe.",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        help="Output JSON path (default: "
+        "<log_dir>/mbient_soak/<os>/<host>_<ts>.json).",
+    )
+    p.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Do not write the JSON file (stdout/console only).",
+    )
+    p.add_argument(
+        "--stdout", action="store_true", help="Also print the JSON envelope to stdout."
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if the worker crashed (CI gate).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    devices = resolve_device_list(args.mac, args.json_path, args.scan, args.scan_n)
+
+    machine, errors, run_context = collect_run_context(args.with_iphone, args.mock)
+    seg = os_segment(machine)
+    host = machine.get("hostname", "unknown")
+    stamp = dt.datetime.now(tz=dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    out_path = args.out or (
+        resolved_log_dir("mbient_soak") / seg / f"{host}_{stamp}.json"
+    )
+    run_dir = out_path.parent
+    run_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = run_dir / f"{host}_{stamp}.cycles.jsonl"
+    log_file = run_dir / f"{host}_{stamp}.app.log"
+
+    dump_dir: Optional[str] = None
+    if args.wer_dumps:
+        dump_dir = enable_wer_localdumps(run_dir / "dumps")
+        if dump_dir is None:
+            errors.append(
+                CollectionError("crash.wer_dumps", "HKCU LocalDumps set failed")
+            )
+
+    cfg: Dict[str, Any] = {
+        "devices": devices,
+        "duration_s": args.duration_min * 60.0,
+        "stream_seconds": args.stream_seconds,
+        "acc_hz": args.acc_hz,
+        "gyro_hz": args.gyro_hz,
+        "data_range": args.data_range,
+        "with_iphone": args.with_iphone,
+        "mock": args.mock,
+        "log_file": str(log_file),
+    }
+
+    print(
+        f"Mbient soak: {len(devices)} device(s), "
+        f"{args.duration_min} min, mock={args.mock}, "
+        f"with_iphone={args.with_iphone}",
+        file=sys.stderr,
+    )
+
+    proc = mp.Process(target=run_soak_worker, args=(cfg, str(jsonl_path)))
+    proc.start()
+    grace_s = max(60.0, args.stream_seconds * 4)
+    proc.join(timeout=args.duration_min * 60.0 + grace_s)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=30)
+    exit_code = proc.exitcode
+
+    if args.wer_dumps:
+        disable_wer_localdumps()
+
+    cycles: List[Dict[str, Any]] = []
+    if jsonl_path.exists():
+        for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    cycles.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass  # a torn final line after a native fault
+
+    crash = classify_exit(exit_code)
+    if dump_dir and Path(dump_dir).is_dir():
+        crash["dump_paths"] = [str(p) for p in Path(dump_dir).glob("*.dmp")]
+    crash["faulthandler_log"] = "neurobooth_crash.log (in the configured log dir)"
+    crash["cycles_jsonl"] = str(jsonl_path)
+    crash["app_log"] = str(log_file)
+
+    metrics = summarize_cycles(cycles)
+    verdict = derive_verdict(metrics, crash)
+    payload = build_envelope(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        machine=machine,
+        blocks={"metrics": metrics, "run": run_context, "crash": crash},
+        verdict=verdict,
+        errors=errors,
+    )
+
+    if not args.no_json:
+        out_path.write_text(
+            json.dumps(payload, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"Wrote: {out_path}", file=sys.stderr)
+    print(f"Verdict: {verdict['category']}", file=sys.stderr)
+    if args.stdout:
+        print(json.dumps(payload, indent=2, default=str))
+
+    if args.strict and crash.get("crashed"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/perf/mbient_soak_compare.py
+++ b/extras/perf/mbient_soak_compare.py
@@ -1,0 +1,442 @@
+"""Diff two Mbient soak runs (Win10 locked vs Win11 pilot) into a delta table.
+
+Sibling of ``compare_timing.py`` for #762 / #759 concern #4. Ingests two
+``mbient_soak.py`` artefacts and emits *every* raw delta, then derives a
+verdict from the numbers.
+
+Design rules, identical to the timing comparator (strategy doc §6):
+
+* **Raw deltas are always printed**, for every metric, flagged or not.
+* The thresholds are **proposals to be ratified by whoever owns the BLE
+  budget -- not measured facts.** Named constants, every one CLI-overridable.
+* A trip means **"a human looks, with the numbers in hand"** -- never an
+  automatic fail. Exit 0 even when flagged, unless ``--strict``.
+* The single most important signal is **the native-crash transition**: a
+  Win11 run that no longer crashes is only meaningful if the iPhone
+  co-runner state matches (the #669 measurement trap) -- this tool surfaces
+  that pairing rather than hiding it behind a green check.
+
+Pure stdlib (json/argparse/pathlib/socket): no DB, no neurobooth stack, so
+it runs anywhere and is fully unit-testable.
+
+Usage::
+
+    uv run python extras/perf/mbient_soak_compare.py \\
+        extras/perf/baselines/mbient_soak/win10/acq.json \\
+        extras/perf/baselines/mbient_soak/win11/acq.json \\
+        [--p95-ratio 1.25] [--drop-rate-increase 0.05] \\
+        [--json PATH] [--no-json] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from _baseline_common import build_envelope, resolved_log_dir
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "mbient_soak_comparison"
+# The schema_name the soak artefacts carry, distinct from this comparator's
+# own SCHEMA_NAME.
+SCHEMA_NAME_SRC = "mbient_soak"
+
+# --- Proposed thresholds (NOT measured facts). CLI-overridable. Flag != fail.
+DEFAULT_P95_RATIO = 1.25  # connect/reset p95 worse by > 25% vs baseline
+DEFAULT_DROP_RATE_INCREASE = 0.05  # mean drop-rate up > 5 percentage points
+DEFAULT_OK_FRACTION_DROP = 0.05  # ok-fraction down > 5 percentage points
+
+_EPS = 1e-9
+# (metric path, stat) pairs compared as scalars with a ratio.
+_RATIO_METRICS = (
+    ("connect_ms", "mean"),
+    ("connect_ms", "p95"),
+    ("reset_ms", "mean"),
+    ("reset_ms", "p95"),
+)
+
+
+def load_run(path: Path) -> Dict[str, Any]:
+    """Read and JSON-parse one soak artefact (surfaced errors, not swallowed)."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ratio(base: Optional[float], pilot: Optional[float]) -> Optional[float]:
+    if base is None or pilot is None or abs(base) <= _EPS:
+        return None
+    return pilot / base
+
+
+def _delta(base: Optional[float], pilot: Optional[float]) -> Optional[float]:
+    if base is None or pilot is None:
+        return None
+    return pilot - base
+
+
+def _cell(base: Optional[float], pilot: Optional[float]) -> Dict[str, Any]:
+    return {
+        "baseline": base,
+        "pilot": pilot,
+        "delta": _delta(base, pilot),
+        "ratio": _ratio(base, pilot),
+    }
+
+
+def _os_label(machine: Dict[str, Any]) -> str:
+    cap = machine.get("os_caption")
+    build = machine.get("os_build")
+    if cap and build:
+        return f"{cap} (build {build})"
+    return str(cap or build or "unknown")
+
+
+def build_comparison(
+    baseline: Dict[str, Any],
+    pilot: Dict[str, Any],
+    *,
+    p95_ratio_limit: float = DEFAULT_P95_RATIO,
+    drop_rate_increase: float = DEFAULT_DROP_RATE_INCREASE,
+    ok_fraction_drop: float = DEFAULT_OK_FRACTION_DROP,
+) -> Dict[str, Any]:
+    """Assemble the full structured comparison. Pure; the unit-test seam."""
+    b_machine = baseline.get("machine", {})
+    p_machine = pilot.get("machine", {})
+    bm = baseline.get("metrics", {})
+    pm = pilot.get("metrics", {})
+    b_run = baseline.get("run", {})
+    p_run = pilot.get("run", {})
+    b_crash = baseline.get("crash", {})
+    p_crash = pilot.get("crash", {})
+
+    flags: List[str] = []
+
+    schema_ok = baseline.get("schema_name") == pilot.get(
+        "schema_name"
+    ) == SCHEMA_NAME_SRC and baseline.get("schema_version") == pilot.get(
+        "schema_version"
+    )
+    if not schema_ok:
+        flags.append(
+            "schema mismatch: "
+            f"{baseline.get('schema_name')}/v{baseline.get('schema_version')} "
+            f"vs {pilot.get('schema_name')}/v{pilot.get('schema_version')} "
+            "-- comparing overlapping fields only."
+        )
+
+    # Scalar latency metrics (connect/reset mean+p95) with ratio flagging.
+    latency: Dict[str, Any] = {}
+    for metric, stat in _RATIO_METRICS:
+        b = (bm.get(metric) or {}).get(stat)
+        p = (pm.get(metric) or {}).get(stat)
+        cell = _cell(b, p)
+        r = cell["ratio"]
+        if r is not None and r > p95_ratio_limit:
+            cell["flagged"] = True
+            flags.append(
+                f"{metric}.{stat} x{r:.2f} ({b:.1f}ms -> {p:.1f}ms) "
+                f"> x{p95_ratio_limit} proposed."
+            )
+        elif (
+            r is None
+            and (b is not None and abs(b) <= _EPS)
+            and (p is not None and p > _EPS)
+        ):
+            cell["flagged"] = True
+            flags.append(f"{metric}.{stat} rose from ~0 to {p:.1f}ms.")
+        latency[f"{metric}.{stat}"] = cell
+
+    # Drop-rate (mean): an increase beyond the proposed band is flagged.
+    b_drop = (bm.get("drop_rate") or {}).get("mean")
+    p_drop = (pm.get("drop_rate") or {}).get("mean")
+    drop_cell = _cell(b_drop, p_drop)
+    if drop_cell["delta"] is not None and drop_cell["delta"] > drop_rate_increase:
+        drop_cell["flagged"] = True
+        flags.append(
+            f"mean sample drop-rate +{drop_cell['delta']:.1%} "
+            f"({b_drop:.1%} -> {p_drop:.1%}) > "
+            f"{drop_rate_increase:.0%} proposed."
+        )
+
+    # ok-fraction: a drop beyond the proposed band is flagged.
+    b_ok = bm.get("ok_fraction")
+    p_ok = pm.get("ok_fraction")
+    ok_cell = _cell(b_ok, p_ok)
+    if ok_cell["delta"] is not None and ok_cell["delta"] < -ok_fraction_drop:
+        ok_cell["flagged"] = True
+        flags.append(
+            f"ok-fraction {b_ok:.1%} -> {p_ok:.1%} "
+            f"(down > {ok_fraction_drop:.0%} proposed)."
+        )
+
+    # BLE disconnects: any new ones where the baseline had none is flagged.
+    b_disc = bm.get("ble_disconnects_total")
+    p_disc = pm.get("ble_disconnects_total")
+    disc_cell = _cell(b_disc, p_disc)
+    if (b_disc == 0 or b_disc is None) and (p_disc or 0) > 0:
+        disc_cell["flagged"] = True
+        flags.append(f"BLE disconnects rose 0 -> {p_disc} (baseline had none).")
+
+    # The crash transition -- the headline signal, paired with co-runner state.
+    b_crashed = bool(b_crash.get("crashed"))
+    p_crashed = bool(p_crash.get("crashed"))
+    b_iphone = b_run.get("iphone_corunner")
+    p_iphone = p_run.get("iphone_corunner")
+    crash_block = {
+        "baseline": {
+            "crashed": b_crashed,
+            "exit_code_hex": b_crash.get("exit_code_hex"),
+            "iphone_corunner": b_iphone,
+        },
+        "pilot": {
+            "crashed": p_crashed,
+            "exit_code_hex": p_crash.get("exit_code_hex"),
+            "iphone_corunner": p_iphone,
+        },
+        "iphone_corunner_match": b_iphone == p_iphone,
+    }
+    if b_crashed and not p_crashed:
+        if b_iphone == p_iphone:
+            crash_block["interpretation"] = (
+                "Win11 did not crash where Win10 did, iPhone co-runner state "
+                "matched -- promising, but the co-runner is synthetic so this "
+                "is suggestive, not definitive (#669)."
+            )
+        else:
+            crash_block["flagged"] = True
+            flags.append(
+                f"crash improved (Win10 crashed, Win11 did not) BUT iPhone "
+                f"co-runner differed ({b_iphone} vs {p_iphone}) -- the #669 "
+                f"measurement trap; result is not comparable."
+            )
+    elif p_crashed and not b_crashed:
+        crash_block["flagged"] = True
+        flags.append(
+            f"REGRESSION: Win11 crashed where Win10 did not "
+            f"(exit {p_crash.get('exit_code_hex')})."
+        )
+    elif b_crashed and p_crashed:
+        crash_block["interpretation"] = (
+            "Both crashed -- compare crash.dump_paths / faulthandler stacks "
+            "to see if it is the same native signature."
+        )
+
+    return {
+        "baseline_machine": b_machine,
+        "pilot_machine": p_machine,
+        "os_transition": {
+            "from": _os_label(b_machine),
+            "to": _os_label(p_machine),
+        },
+        "schema": {
+            "baseline": (
+                f"{baseline.get('schema_name')}" f"/v{baseline.get('schema_version')}"
+            ),
+            "pilot": (f"{pilot.get('schema_name')}/v{pilot.get('schema_version')}"),
+            "compatible": bool(schema_ok),
+        },
+        "thresholds": {
+            "p95_ratio": p95_ratio_limit,
+            "drop_rate_increase": drop_rate_increase,
+            "ok_fraction_drop": ok_fraction_drop,
+            "_note": (
+                "proposals to be ratified by the BLE-budget owner, not "
+                "measured facts"
+            ),
+        },
+        "latency": latency,
+        "drop_rate_mean": drop_cell,
+        "ok_fraction": ok_cell,
+        "ble_disconnects_total": disc_cell,
+        "crash": crash_block,
+        "flags": flags,
+    }
+
+
+def to_verdict(comparison: Dict[str, Any]) -> Dict[str, Any]:
+    """Convenience verdict. ``REVIEW`` if anything flagged; never ``FAIL``."""
+    flags = comparison.get("flags", [])
+    reasons = [
+        "Thresholds are proposals (not measured facts). A flag means a human "
+        "reviews with the numbers in hand -- not a failure. The iPhone "
+        "co-runner is synthetic, so crash-improvement is suggestive (#669).",
+    ]
+    reasons += flags
+    return {
+        "category": "REVIEW" if flags else "MATCH",
+        "reasons": reasons,
+        "remediation_hints": (
+            [
+                "Inspect the flagged metrics; for a crash delta confirm the "
+                "iPhone co-runner state matched and compare native stacks."
+            ]
+            if flags
+            else []
+        ),
+    }
+
+
+def _fmt(v: Optional[float]) -> str:
+    if v is None:
+        return "    n/a"
+    if v == 0:
+        return "  0.000"
+    if abs(v) < 1e-3 or abs(v) >= 1e5:
+        return f"{v:.3e}"
+    return f"{v:.3f}"
+
+
+def render(comparison: Dict[str, Any]) -> str:
+    """Render the comparison as the familiar perf-script text table."""
+    out: List[str] = []
+    ot = comparison["os_transition"]
+    out.append("=" * 78)
+    out.append("MBIENT SOAK COMPARISON  --  Win10 baseline -> Win11 pilot")
+    out.append(f"  {ot['from']}  ->  {ot['to']}")
+    if not comparison["schema"]["compatible"]:
+        out.append(
+            f"  SCHEMA: {comparison['schema']['baseline']} vs "
+            f"{comparison['schema']['pilot']}  (overlap only)"
+        )
+    out.append("=" * 78)
+
+    out.append("\nLatency (ms)")
+    hdr = (
+        f"  {'metric':<18s}{'baseline':>12s}{'pilot':>12s}"
+        f"{'delta':>12s}{'ratio':>9s}"
+    )
+    out.append(hdr)
+    out.append("  " + "-" * (len(hdr) - 2))
+    for name, c in comparison["latency"].items():
+        r = c.get("ratio")
+        rs = f"{r:>8.2f}x" if r is not None else "     n/a"
+        flag = "  <== FLAG" if c.get("flagged") else ""
+        out.append(
+            f"  {name:<18s}{_fmt(c['baseline']):>12s}{_fmt(c['pilot']):>12s}"
+            f"{_fmt(c['delta']):>12s}{rs:>9s}{flag}"
+        )
+
+    for label, key in (
+        ("drop_rate (mean)", "drop_rate_mean"),
+        ("ok_fraction", "ok_fraction"),
+        ("ble_disconnects", "ble_disconnects_total"),
+    ):
+        c = comparison[key]
+        flag = "  <== FLAG" if c.get("flagged") else ""
+        out.append(
+            f"\n  {label:<18s}{_fmt(c['baseline']):>12s} -> "
+            f"{_fmt(c['pilot']):>12s}  (delta {_fmt(c['delta'])}){flag}"
+        )
+
+    cb = comparison["crash"]
+    out.append("\nCrash transition")
+    out.append(
+        f"  baseline: crashed={cb['baseline']['crashed']} "
+        f"({cb['baseline']['exit_code_hex']}) "
+        f"iphone={cb['baseline']['iphone_corunner']}"
+    )
+    out.append(
+        f"  pilot:    crashed={cb['pilot']['crashed']} "
+        f"({cb['pilot']['exit_code_hex']}) "
+        f"iphone={cb['pilot']['iphone_corunner']}"
+    )
+    if cb.get("interpretation"):
+        out.append(f"  -> {cb['interpretation']}")
+
+    verdict = to_verdict(comparison)
+    out.append(f"\nVERDICT: {verdict['category']}")
+    for r in verdict["reasons"]:
+        out.append(f"  - {r}")
+    out.append("")
+    return "\n".join(out)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("baseline", type=Path, help="Win10 mbient_soak JSON")
+    p.add_argument("pilot", type=Path, help="Win11 mbient_soak JSON")
+    p.add_argument(
+        "--p95-ratio",
+        type=float,
+        default=DEFAULT_P95_RATIO,
+        help=f"Proposed connect/reset p95 regression ratio "
+        f"(default {DEFAULT_P95_RATIO}).",
+    )
+    p.add_argument(
+        "--drop-rate-increase",
+        type=float,
+        default=DEFAULT_DROP_RATE_INCREASE,
+        help=f"Proposed tolerated mean drop-rate increase "
+        f"(default {DEFAULT_DROP_RATE_INCREASE}).",
+    )
+    p.add_argument(
+        "--ok-fraction-drop",
+        type=float,
+        default=DEFAULT_OK_FRACTION_DROP,
+        help=f"Proposed tolerated ok-fraction drop "
+        f"(default {DEFAULT_OK_FRACTION_DROP}).",
+    )
+    p.add_argument(
+        "--json",
+        type=Path,
+        help="Comparison-JSON output path. Default: "
+        "<log_dir>/mbient_soak/compare_<hostname>.json.",
+    )
+    p.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Do not write the JSON file (print the delta table only).",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if anything was flagged (CI gate). Off by "
+        "default: a flag means review, not fail.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    baseline = load_run(args.baseline)
+    pilot = load_run(args.pilot)
+
+    comparison = build_comparison(
+        baseline,
+        pilot,
+        p95_ratio_limit=args.p95_ratio,
+        drop_rate_increase=args.drop_rate_increase,
+        ok_fraction_drop=args.ok_fraction_drop,
+    )
+    print(render(comparison))
+
+    if not args.no_json:
+        verdict = to_verdict(comparison)
+        payload = build_envelope(
+            schema_name=SCHEMA_NAME,
+            schema_version=SCHEMA_VERSION,
+            machine={"hostname": socket.gethostname(), "role": "comparator"},
+            blocks={"comparison": comparison},
+            verdict=verdict,
+            errors=[],
+        )
+        host = comparison.get("pilot_machine", {}).get("hostname", "unknown")
+        out_path = args.json or (
+            resolved_log_dir("mbient_soak") / f"compare_{host}.json"
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(payload, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"Wrote: {out_path}", file=sys.stderr)
+
+    if args.strict and comparison["flags"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/perf/timing_baseline.py
+++ b/extras/perf/timing_baseline.py
@@ -43,14 +43,13 @@ from _baseline_common import (
     CollectionError,
     build_envelope,
     collect_os_identity,
+    os_segment,
+    percentile,
     resolved_log_dir,
 )
 
 SCHEMA_VERSION = 1
 SCHEMA_NAME = "timing_baseline"
-
-# Win11's first build is 22000; anything below is Win10 for our booths.
-WIN11_MIN_BUILD = 22000
 
 # Sanity bounds for the single-run verdict. These are NOT pass/fail
 # thresholds for the OS question -- that is compare_timing.py's job against a
@@ -60,56 +59,14 @@ WIN11_MIN_BUILD = 22000
 SANITY_MEAN_ERROR_FACTOR = 5.0  # mean abs error > 5x requested interval
 SANITY_MAX_ERROR_FACTOR = 50.0  # worst single wait > 50x requested interval
 
-
-def os_segment(machine: Dict[str, Any]) -> str:
-    """Derive the ``win10`` / ``win11`` / ``unknown`` path segment.
-
-    Prefers the OS build number (unambiguous: Win11 >= 22000); falls back to
-    the caption string; returns ``"unknown"`` if neither is conclusive so a
-    misfiled artefact is obvious rather than silently mislabeled.
-
-    Args:
-        machine: The ``machine`` identity block.
-
-    Returns:
-        One of ``"win10"``, ``"win11"``, ``"unknown"``.
-    """
-    build_raw = machine.get("os_build")
-    try:
-        build = int(str(build_raw).strip())
-    except (TypeError, ValueError):
-        build = None
-    if build is not None:
-        return "win11" if build >= WIN11_MIN_BUILD else "win10"
-
-    caption = (machine.get("os_caption") or "").lower()
-    if "windows 11" in caption:
-        return "win11"
-    if "windows 10" in caption:
-        return "win10"
-    return "unknown"
+# os_segment / WIN11_MIN_BUILD now live in _baseline_common (shared with
+# mbient_soak); imported above so timing_baseline.os_segment still resolves.
 
 
-def _percentile(sorted_vals: List[float], pct: float) -> float:
-    """Linear-interpolated percentile (numpy 'linear' method), pure-Python.
-
-    Kept dependency-free so the summary layer is unit-testable without the
-    scientific stack and gives bit-stable expected values in tests.
-
-    Args:
-        sorted_vals: Ascending-sorted samples (non-empty).
-        pct: Percentile in [0, 100].
-
-    Returns:
-        The interpolated percentile value.
-    """
-    if len(sorted_vals) == 1:
-        return float(sorted_vals[0])
-    rank = (pct / 100.0) * (len(sorted_vals) - 1)
-    low = int(rank)
-    high = min(low + 1, len(sorted_vals) - 1)
-    frac = rank - low
-    return float(sorted_vals[low] * (1.0 - frac) + sorted_vals[high] * frac)
+# Percentile lives in _baseline_common now (shared with mbient_soak and the
+# comparators — single source of truth). Thin module alias so the existing
+# call sites and tests that reference ``_percentile`` are unaffected.
+_percentile = percentile
 
 
 def summarize_errors(

--- a/extras/perf/win11_readiness.py
+++ b/extras/perf/win11_readiness.py
@@ -30,6 +30,7 @@ from typing import Any, Optional
 from _baseline_common import (
     CollectionError,
     build_envelope,
+    collect_bluetooth_radios,
     collect_os_identity,
     parse_ps_date,
     ps_json,
@@ -253,40 +254,15 @@ def collect_gpu(snap: Snapshot) -> None:
 
 
 def collect_bluetooth(snap: Snapshot) -> None:
-    """Populate ``neurobooth_extras.bluetooth`` with radio and driver versions."""
-    try:
-        info = ps_json(
-            "Get-PnpDevice -Class Bluetooth -Status OK -ErrorAction SilentlyContinue | "
-            "ForEach-Object { "
-            "  $id = $_.InstanceId; "
-            "  $drv = (Get-PnpDeviceProperty -InstanceId $id "
-            "    -KeyName 'DEVPKEY_Device_DriverVersion' -ErrorAction SilentlyContinue).Data; "
-            "  $date = (Get-PnpDeviceProperty -InstanceId $id "
-            "    -KeyName 'DEVPKEY_Device_DriverDate' -ErrorAction SilentlyContinue).Data; "
-            "  $mfg = (Get-PnpDeviceProperty -InstanceId $id "
-            "    -KeyName 'DEVPKEY_Device_Manufacturer' -ErrorAction SilentlyContinue).Data; "
-            "  [pscustomobject]@{ "
-            "    Name = $_.FriendlyName; InstanceId = $id; "
-            "    Manufacturer = $mfg; DriverVersion = $drv; DriverDate = $date "
-            "  } "
-            "} | ConvertTo-Json -Depth 3"
-        )
-        if isinstance(info, dict):
-            info = [info]
-        radios = []
-        for entry in info or []:
-            radios.append(
-                {
-                    "name": entry.get("Name"),
-                    "instance_id": entry.get("InstanceId"),
-                    "manufacturer": entry.get("Manufacturer"),
-                    "driver_version": entry.get("DriverVersion"),
-                    "driver_date": parse_ps_date(entry.get("DriverDate")),
-                }
-            )
-        snap.neurobooth_extras["bluetooth"] = radios
-    except Exception as exc:  # noqa: BLE001
-        snap.record_error("neurobooth_extras.bluetooth", exc)
+    """Populate ``neurobooth_extras.bluetooth`` with radio and driver versions.
+
+    Delegates to the shared :func:`collect_bluetooth_radios` (single source of
+    truth, also used by ``mbient_soak.py``); the hardware-floor inventory does
+    not need the power-management add-on.
+    """
+    radios, errors = collect_bluetooth_radios()
+    snap.neurobooth_extras["bluetooth"] = radios
+    snap.errors.extend(errors)
 
 
 def collect_vendor_software(snap: Snapshot) -> None:

--- a/tests/pytest/test_mbient_soak.py
+++ b/tests/pytest/test_mbient_soak.py
@@ -1,0 +1,202 @@
+"""Unit tests for extras/perf/mbient_soak.py.
+
+Covers the pure aggregation/verdict layer, the synthetic #669 co-runner, the
+``model_construct`` device builder, and an end-to-end **mock** soak worker
+(no hardware, no DB, no LSL) so the production-surface drive loop is exercised
+without a real BLE device.
+"""
+
+import json
+import time
+
+import pytest
+
+import mbient_soak as s
+
+
+# --- pure layer -----------------------------------------------------------
+
+
+def test_stats_empty_and_nonempty():
+    empty = s._stats([])
+    assert empty["n"] == 0 and empty["mean"] is None and empty["p95"] is None
+
+    st = s._stats([10.0, 20.0, 30.0, 40.0])
+    assert st["n"] == 4
+    assert st["mean"] == pytest.approx(25.0)
+    assert st["max"] == pytest.approx(40.0)
+
+
+def test_summarize_cycles_core_math():
+    cycles = [
+        {
+            "ok": True,
+            "connect_ms": 100.0,
+            "reset_ms": 300.0,
+            "cycle_wall_s": 5.0,
+            "samples": 95,
+            "expected_samples": 100,
+            "ble_disconnects": 0,
+        },
+        {
+            "ok": False,
+            "connect_ms": 5000.0,
+            "reset_ms": None,
+            "cycle_wall_s": 6.0,
+            "samples": 0,
+            "expected_samples": 100,
+            "ble_disconnects": 1,
+            "error": "connect() returned False",
+        },
+    ]
+    m = s.summarize_cycles(cycles)
+    assert m["n_cycles"] == 2
+    assert m["n_ok"] == 1
+    assert m["n_failed"] == 1
+    assert m["ok_fraction"] == pytest.approx(0.5)
+    assert m["connect_ms"]["mean"] == pytest.approx(2550.0)
+    assert m["drop_rate"]["mean"] == pytest.approx((0.05 + 1.0) / 2)
+    assert m["ble_disconnects_total"] == 1
+    assert m["cycles_with_disconnect"] == 1
+    assert m["errors"] == ["connect() returned False"]
+
+
+def test_summarize_cycles_empty():
+    m = s.summarize_cycles([])
+    assert m["n_cycles"] == 0
+    assert m["ok_fraction"] == 0.0
+    assert m["connect_ms"]["mean"] is None
+
+
+@pytest.mark.parametrize(
+    "code,crashed,hexcode",
+    [
+        (0, False, "0x0"),
+        (None, True, None),
+        (3221225477, True, "0xc0000005"),
+    ],
+)
+def test_classify_exit(code, crashed, hexcode):
+    c = s.classify_exit(code)
+    assert c["crashed"] is crashed
+    assert c["exit_code_hex"] == hexcode
+
+
+def test_derive_verdict_clean_captured():
+    m = s.summarize_cycles(
+        [
+            {
+                "ok": True,
+                "connect_ms": 100.0,
+                "reset_ms": 200.0,
+                "samples": 100,
+                "expected_samples": 100,
+                "cycle_wall_s": 1.0,
+            }
+        ]
+    )
+    v = s.derive_verdict(m, {"crashed": False, "exit_code": 0})
+    assert v["category"] == "CAPTURED"
+    assert any("comparison" in r for r in v["reasons"])
+
+
+def test_derive_verdict_crashed_is_recorded_not_a_bug():
+    m = s.summarize_cycles([{"ok": True, "samples": 1, "expected_samples": 1}])
+    v = s.derive_verdict(
+        m, {"crashed": True, "exit_code": 3221225477, "exit_code_hex": "0xc0000005"}
+    )
+    assert v["category"] == "CRASHED"
+    assert any("not a harness bug" in r for r in v["reasons"])
+
+
+def test_derive_verdict_flags_low_ok_fraction():
+    cycles = [
+        {"ok": False, "error": "x", "samples": 0, "expected_samples": 100}
+        for _ in range(10)
+    ]
+    cycles[0]["ok"] = True
+    m = s.summarize_cycles(cycles)
+    v = s.derive_verdict(m, {"crashed": False, "exit_code": 0})
+    assert v["category"] == "CAPTURED_WITH_ERRORS"
+    assert any("cycles succeeded" in r for r in v["reasons"])
+    assert v["remediation_hints"]
+
+
+# --- synthetic #669 co-runner ---------------------------------------------
+
+
+def test_synthetic_iphone_corunner_processes_packets():
+    co = s.SyntheticIphoneCorunner(rate_hz=400)
+    co.start()
+    try:
+        time.sleep(0.4)
+    finally:
+        co.stop()
+    assert co.packets_processed > 0
+
+
+# --- device builder + device list -----------------------------------------
+
+
+def test_make_device_mock_builds_without_validation_or_db():
+    dev = s.make_device(
+        "UnitDev",
+        "AA:BB:CC:DD:EE:FF",
+        mock=True,
+        acc_hz=100,
+        gyro_hz=100,
+        data_range=8,
+    )
+    from neurobooth_os.iout.mock.mock_mbient import MockMbient
+
+    assert isinstance(dev, MockMbient)
+    assert dev.mac == "AA:BB:CC:DD:EE:FF"
+
+
+def test_resolve_device_list_mac_inline():
+    out = s.resolve_device_list(["AA:BB", "CC:DD"], None, False, 5)
+    assert out == [("CL-0", "AA:BB"), ("CL-1", "CC:DD")]
+
+
+def test_resolve_device_list_requires_a_source():
+    with pytest.raises(SystemExit):
+        s.resolve_device_list([], None, False, 5)
+
+
+# --- end-to-end mock soak worker ------------------------------------------
+
+
+def test_run_soak_worker_end_to_end_mock(tmp_path):
+    """Drive the production Mbient public surface through the worker against
+    MockMbient: JSONL is written crash-safe and summarizes cleanly."""
+    import neurobooth_os.iout.mbient as mb
+
+    saved = (mb.DISABLE_LSL, mb.post_message)  # worker mutates these globally
+    jsonl = tmp_path / "c.jsonl"
+    cfg = {
+        "devices": [("SoakA", "AA:BB:CC:DD:EE:01")],
+        "duration_s": 0.05,
+        "stream_seconds": 0.15,
+        "acc_hz": 100,
+        "gyro_hz": 100,
+        "data_range": 8,
+        "with_iphone": True,  # exercises the synthetic co-runner too
+        "mock": True,
+        "log_file": str(tmp_path / "a.log"),
+    }
+    try:
+        rc = s.run_soak_worker(cfg, str(jsonl))
+    finally:
+        mb.DISABLE_LSL, mb.post_message = saved
+
+    assert rc == 0
+    assert jsonl.exists()
+    recs = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert len(recs) >= 1
+    assert recs[0]["ok"] is True
+    assert recs[0]["connect_ms"] is not None
+    assert recs[0]["samples"] is not None
+
+    m = s.summarize_cycles(recs)
+    assert m["n_cycles"] == len(recs)
+    assert m["ok_fraction"] == pytest.approx(1.0)

--- a/tests/pytest/test_mbient_soak_compare.py
+++ b/tests/pytest/test_mbient_soak_compare.py
@@ -1,0 +1,148 @@
+"""Unit tests for extras/perf/mbient_soak_compare.py.
+
+Asserts the same hard guarantees as the timing comparator (raw deltas always
+present, thresholds overridable, flag != fail) plus the #669-specific rule:
+a crash-improvement is only credited when the iPhone co-runner state matched.
+"""
+
+import copy
+import json
+
+import pytest
+
+import mbient_soak_compare as mc
+
+
+def _run(
+    crashed=False, iphone="synthetic", connect_p95=400.0, drop=0.02, okf=0.98, disc=0
+):
+    return {
+        "schema_name": "mbient_soak",
+        "schema_version": 1,
+        "machine": {
+            "os_caption": "Microsoft Windows 10 Home",
+            "os_build": "19045",
+            "hostname": "acq",
+        },
+        "metrics": {
+            "connect_ms": {"mean": 200.0, "p95": connect_p95, "n": 50},
+            "reset_ms": {"mean": 300.0, "p95": 500.0, "n": 50},
+            "drop_rate": {"mean": drop, "max": 0.1},
+            "ok_fraction": okf,
+            "ble_disconnects_total": disc,
+        },
+        "run": {"iphone_corunner": iphone},
+        "crash": {
+            "crashed": crashed,
+            "exit_code_hex": "0xc0000005" if crashed else "0x0",
+        },
+    }
+
+
+def test_identical_inputs_match_but_every_delta_present():
+    b = _run()
+    c = mc.build_comparison(b, copy.deepcopy(b))
+    assert c["flags"] == []
+    assert mc.to_verdict(c)["category"] == "MATCH"
+    cell = c["latency"]["connect_ms.mean"]
+    assert set(cell) >= {"baseline", "pilot", "delta", "ratio"}
+    assert cell["delta"] == 0.0
+    assert "flagged" not in cell
+
+
+def test_p95_regression_flagged_and_overridable():
+    b = _run()
+    p = _run(connect_p95=900.0)  # ratio 2.25
+    flagged = mc.build_comparison(b, p)
+    assert flagged["latency"]["connect_ms.p95"]["flagged"] is True
+    assert mc.to_verdict(flagged)["category"] == "REVIEW"
+
+    loose = mc.build_comparison(b, p, p95_ratio_limit=3.0)
+    assert "flagged" not in loose["latency"]["connect_ms.p95"]
+    assert loose["flags"] == []
+
+
+def test_drop_rate_and_ok_fraction_flags():
+    c = mc.build_comparison(_run(), _run(drop=0.20))
+    assert c["drop_rate_mean"]["flagged"] is True
+
+    c = mc.build_comparison(_run(), _run(okf=0.80))
+    assert c["ok_fraction"]["flagged"] is True
+
+
+def test_new_ble_disconnects_flagged():
+    c = mc.build_comparison(_run(disc=0), _run(disc=7))
+    assert c["ble_disconnects_total"]["flagged"] is True
+    assert any("disconnects rose" in f for f in c["flags"])
+
+
+def test_crash_regression_is_flagged():
+    c = mc.build_comparison(_run(crashed=False), _run(crashed=True))
+    assert c["crash"]["flagged"] is True
+    assert any("REGRESSION" in f for f in c["flags"])
+    assert mc.to_verdict(c)["category"] == "REVIEW"
+
+
+def test_669_trap_crash_improved_but_iphone_differs_is_flagged():
+    b = _run(crashed=True, iphone="synthetic")
+    p = _run(crashed=False, iphone="none")
+    c = mc.build_comparison(b, p)
+    assert c["crash"]["iphone_corunner_match"] is False
+    assert c["crash"]["flagged"] is True
+    assert any("measurement trap" in f for f in c["flags"])
+
+
+def test_crash_improved_with_matching_corunner_is_suggestive_not_flagged():
+    c = mc.build_comparison(_run(crashed=True), _run(crashed=False))
+    assert c["crash"].get("flagged") is None
+    assert "suggestive" in c["crash"]["interpretation"]
+    assert c["flags"] == []
+
+
+def test_schema_mismatch_flagged_but_still_compares():
+    b = _run()
+    bad = copy.deepcopy(b)
+    bad["schema_version"] = 2
+    c = mc.build_comparison(b, bad)
+    assert c["schema"]["compatible"] is False
+    assert any("schema mismatch" in f for f in c["flags"])
+    assert "connect_ms.mean" in c["latency"]
+
+
+def test_verdict_first_reason_is_the_disclaimer():
+    c = mc.build_comparison(_run(), copy.deepcopy(_run()))
+    reasons = mc.to_verdict(c)["reasons"]
+    assert "not a failure" in reasons[0].lower()
+    assert "synthetic" in reasons[0].lower()
+    assert "not measured facts" in c["thresholds"]["_note"]
+
+
+@pytest.fixture
+def _isolated_log_dir(tmp_path, monkeypatch):
+    import neurobooth_os.config as nb_config
+
+    monkeypatch.setattr(nb_config, "neurobooth_config", None, raising=False)
+    monkeypatch.delenv("NB_CONFIG", raising=False)
+    monkeypatch.setenv("NB_INSTALL", str(tmp_path))
+    return tmp_path
+
+
+def test_main_strict_and_default_path(tmp_path, _isolated_log_dir):
+    b = _run()
+    pilot = _run(connect_p95=900.0)  # flagged
+    bp = tmp_path / "win10.json"
+    pp = tmp_path / "win11.json"
+    bp.write_text(json.dumps(b), encoding="utf-8")
+    pp.write_text(json.dumps(pilot), encoding="utf-8")
+
+    # Default: flag is REVIEW, exit 0; JSON lands in the isolated log dir.
+    rc = mc.main([str(bp), str(pp)])
+    assert rc == 0
+    out = _isolated_log_dir / "mbient_soak" / "compare_acq.json"
+    assert out.exists()
+    assert json.loads(out.read_text())["schema_name"] == "mbient_soak_comparison"
+
+    # --strict turns the same flag into a hard gate; --no-json writes nothing.
+    assert mc.main([str(bp), str(pp), "--strict", "--no-json"]) == 1
+    pp.write_text(json.dumps(b), encoding="utf-8")
+    assert mc.main([str(bp), str(pp), "--strict", "--no-json"]) == 0


### PR DESCRIPTION
## What & why

#759 **concern #4**. The existing `extras/perf/mbient_*.py` scripts are *retrospective* (they read what production already logged). This adds an **active** Mbient/BLE soak that drives the stack on demand so Win10 and Win11 can be compared. Same playbook as the #761 timing harness (PR #800): shared `_baseline_common` envelope, JSON-authoritative, verdict-from-numbers, thresholds-are-proposals, flag≠fail, comparator, summary doc, locked-baseline dir, mock-driven tests.

## Pieces

| File | Role |
|---|---|
| `extras/perf/mbient_soak.py` | Parent runner + child worker; drives the **production** `Mbient` surface (`connect`→`start`→`reset_and_reconnect`→`close`) in a connect/stream/reset loop; crash-safe JSONL; native-crash exit-code capture (child process) + faulthandler + opt-in HKCU WER minidumps; OS/BT-radio/driver/power/version context |
| `extras/perf/mbient_soak_compare.py` | Two run JSONs → raw deltas (connect/reset p95, drop-rate, ok-fraction, BLE disconnects) + the crash transition; named CLI-overridable thresholds; flag≠fail |
| `docs/mbient_soak_summary.md`, `extras/perf/baselines/mbient_soak/` | Runbook + locked-baseline convention; Win10 execution tracked under **#768** |
| `_baseline_common.py` | Gains shared `percentile` / `os_segment` / `collect_bluetooth_radios`; `win11_readiness.py` + `timing_baseline.py` refactored onto them (behaviour-preserving) |

## Deliberate scope decisions (resolved with the issue owner)

- **Crash capture:** faulthandler + child-process native exit-code + opt-in HKCU WER full minidumps (no admin, reversible) — honors #762's "compare native call stacks" intent without provisioning procdump.
- **iPhone #669 co-runner is synthetic, by constraint.** Driving the real iPhone in a multi-hour soak would spew large video files into the permanent-storage transfer workflow. `--with-iphone` reproduces the *contention shape* (a continuously blocking-socket listener thread concurrent with Mbient BLE) — no iPhone, no video. Recorded as `run.iphone_corunner="synthetic"`; the comparator **refuses to credit a crash-improvement unless both sides' co-runner state matched** (the #669 measurement trap); docs state a clean Win11 result is **suggestive, not definitive**, and that the definitive confirmation is a separate manual booth check with the transfer workflow disabled.
- **Negotiated BLE params not recorded** — not exposed by the public surface; extending `mbient.py` is out of scope per #762. Only requested params, flagged as such.
- **`mbient.py` untouched** — LSL/DB neutralized at the harness boundary (the established `test_mock_mbient.py` pattern).
- **Out of scope per #762:** fixing any crash found; re-architecting `mbient.py`; swapping BLE libs; replacing the retrospective scripts.

## Verification

- **263 / 263 pytest pass** (24 new, no regressions; the #761 envelope-unchanged guard still passes after the shared refactors).
- Pure layers + an **end-to-end mock soak** (`MockMbient`, no hardware/DB/LSL) unit-tested: aggregation, drop-rate, crash classification, the synthetic co-runner, the comparator's flagging incl. the #669 trap.
- `ruff` + `black` clean on all new files; both CLIs `--help` import cleanly.
- Not runnable from a dev box (stated, not faked): the real BLE soak (needs Mbients on an ACQ booth) and native-minidump capture — the worker degrades to recorded errors/exit codes, never fabricated numbers.

## Follow-ups (not in this PR)

- Operator: capture the Win10 baseline (both arms, ≥3 runs) per the runbook — tracked under **#768**.
- Definitive #669 confirmation: one manual booth run with the real iPhone and the transfer/dump workflow disabled.

Refs #759, #762, #669, #768
