### PR TITLE
Add inter-machine validation harness + booth security snapshot (#764)

### DIFF
--- a/docs/inter_machine_setup.md
+++ b/docs/inter_machine_setup.md
@@ -178,7 +178,7 @@ Section 2 covers this. Re-walk Section 2 after any Win10→Win11 in-place upgrad
 
 ## 8. Expected state (harness checklist)
 
-The harness portion of #764 (deferred to Phase 1) will validate the state below from CTR. Capture this as the booth-side acceptance criterion:
+The harness portion of #764 (`extras/perf/booth_security_snapshot.py`, run on the booth) captures and validates the state below; Section 10 documents how to run it. Capture this as the booth-side acceptance criterion:
 
 | Property | Expected value | How to check on booth |
 |---|---|---|
@@ -221,10 +221,41 @@ net use \\<booth>\admin$ /DELETE
 
 If all four return without an `Access denied` / RPC / SMB error, the booth is ready. If any one fails, work back through Sections 2–7; the failing primitive's transport identifies which.
 
+## 10. Automated validation harness
+
+The harness portion of #764 wraps Section 9's manual round-trips and Section 8's expected-state checklist into two scripts. Run both to capture a Win10 baseline before the Win11 pilot; the JSON artefacts both emit are diff-friendly for #768.
+
+### From CTR — `extras/perf/intermachine_check.py`
+
+Exercises each of the four remote primitives plus `admin$` SMB against every configured booth (`presentation` and each `acquisition_*` in `cfg.neurobooth_config`). Reads credentials from `secrets.yaml` so no passwords appear on the command line. Includes a SCHTASKS `/Create /XML /F` + `/Delete` round-trip with a disabled no-op task — exercises the SMB-via-`admin$` dependency the other primitives mask, and cleans up in a `finally` so nothing remains registered.
+
+```powershell
+uv run python extras/perf/intermachine_check.py
+# or restrict to a single booth:
+uv run python extras/perf/intermachine_check.py --targets presentation
+```
+
+Per-target verdict: `PASS` (all probes ok), `DEGRADED` (read primitives ok, write primitive failed — usually SMB), or `FAIL` (a read primitive failed — usually firewall or NTLM). Output: `<log_dir>/intermachine_check/<os>/<hostname>.json`.
+
+### On each booth — `extras/perf/booth_security_snapshot.py`
+
+Captures the Section 8 expected-state items into JSON for drift detection between Win10 baseline and Win11 candidate. The DCOM Launch/Activation and WMI CIMV2 ACL bytes are not decoded — captured as length + SHA-256 so any change is visible without the snapshot inspecting policy bytes. SDDL decoding is a follow-up; the contract here is "detect drift," not "interpret."
+
+```powershell
+uv run python extras/perf/booth_security_snapshot.py --role STM
+```
+
+Verdict: `PASS` if every Section 8 item matches; `WARN` with per-field reasons if any drift. The snapshot does not decide whether a drift is intentional — record any exception in the operator log alongside the JSON.
+
+Output: `<log_dir>/booth_security_snapshot/<os>/<hostname>.json`. Re-run after any Windows servicing update so a silent default change does not regress the booth without anyone noticing.
+
 ## References
 
 - `neurobooth_os/netcomm/client.py` — the four remote primitives and the SCHTASKS XML schema
+- `extras/perf/intermachine_check.py` — CTR-side harness (Section 10)
+- `extras/perf/booth_security_snapshot.py` — per-booth posture snapshot (Section 10)
 - `docs/single_machine_testing.md` — how to skip this entire runbook for local dev
 - #759 — Win11 upgrade evaluation umbrella (concern #2)
-- #764 — parent issue; harness portion still ahead
+- #764 — parent issue
 - #760 / PR #770 — the WMIC → `Get-CimInstance` code change this runbook backs
+- #768 — Win10 baseline lockdown; this runbook's harness produces two of the per-booth artefacts it indexes

--- a/extras/perf/booth_security_snapshot.py
+++ b/extras/perf/booth_security_snapshot.py
@@ -1,0 +1,495 @@
+"""Snapshot a booth's security posture relevant to inter-machine plumbing.
+
+Issue #764 / concern #2 of #759. Runs *on the booth* (not from CTR) and
+captures the state items the runbook ``docs/inter_machine_setup.md``
+Section 8 lists as expected, so a Win10 baseline can be diffed against a
+Win11 pilot without anyone eyeballing each registry/firewall value.
+
+Captured items:
+
+* Per-NIC network profile (Section 2).
+* Whether the three firewall rule groups (Section 3) have enabled rules.
+* ``LocalAccountTokenFilterPolicy`` and ``LmCompatibilityLevel`` registry
+  values (Sections 6 and 7).
+* Credential Guard / VBS state (Section 7).
+* ``RunAsPPL`` LSASS protection state (Section 7).
+* SMB server protocol + signing config (Section 7).
+* DCOM Launch/Activation permission *presence* (Section 5): the binary
+  security descriptors are captured as base64 lengths and SHA-256 hashes
+  so a change is detectable without the snapshot inspecting policy bytes.
+* WMI CIMV2 ``__SystemSecurity.GetSD`` return code + descriptor hash
+  (Section 4): same diff-friendly capture.
+
+Emits the shared ``_baseline_common`` envelope under
+``<log_dir>/booth_security_snapshot/<os>/<hostname>.json``. The
+hash-only DCOM/WMI capture matches the runbook's "GUI verification"
+acceptance criterion (Sections 4 and 5) -- the snapshot's job is to
+detect drift, not interpret policy.
+
+Usage::
+
+    uv run python extras/perf/booth_security_snapshot.py
+        [--role CTR|STM|ACQ|spare] [--out PATH] [--stdout]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Optional
+
+from _baseline_common import (
+    CollectionError,
+    build_envelope,
+    collect_os_identity,
+    os_segment,
+    ps_json,
+    resolved_log_dir,
+    run_powershell,
+)
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "booth_security_snapshot"
+
+# Mirror the three groups from docs/inter_machine_setup.md Section 3.
+FIREWALL_RULE_GROUPS = (
+    "Windows Management Instrumentation (WMI)",
+    "Remote Scheduled Tasks Management",
+    "File and Printer Sharing",
+)
+
+# Expected state per Section 8. Drift from these flips the verdict to WARN.
+EXPECTED_LATFP = 1
+EXPECTED_LMCOMPAT_OK = (3, 5)
+EXPECTED_RUNASPPL = (None, 0)
+
+
+@dataclass
+class Snapshot:
+    network: dict = field(default_factory=dict)
+    firewall: dict = field(default_factory=dict)
+    registry: dict = field(default_factory=dict)
+    credential_guard: dict = field(default_factory=dict)
+    smb: dict = field(default_factory=dict)
+    dcom: dict = field(default_factory=dict)
+    wmi: dict = field(default_factory=dict)
+    errors: List[CollectionError] = field(default_factory=list)
+
+    def record(self, where: str, exc: BaseException) -> None:
+        self.errors.append(CollectionError.from_exception(where, exc))
+
+
+def _coerce_list(value: Any) -> list:
+    """ConvertTo-Json emits a single object as a dict, not a 1-item list.
+
+    Normalize to a list so downstream code does not branch on shape.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def collect_network_profiles(snap: Snapshot) -> None:
+    """Per-NIC ``NetworkCategory`` (Private/Public/Domain).
+
+    Section 8 expects ``Private`` on the booth's neurobooth-LAN NIC.
+    PowerShell renders the ``[NetworkCategory]`` and
+    ``[NetConnectivityLevel]`` enums as integers when piped through
+    ``ConvertTo-Json``; we project them to their ``.ToString()`` form so
+    the JSON carries the human-readable label.
+    """
+    try:
+        info = ps_json(
+            "Get-NetConnectionProfile | ForEach-Object { "
+            "  [pscustomobject]@{ "
+            "    Name = $_.Name; "
+            "    InterfaceAlias = $_.InterfaceAlias; "
+            "    InterfaceIndex = $_.InterfaceIndex; "
+            "    NetworkCategory = $_.NetworkCategory.ToString(); "
+            "    IPv4Connectivity = $_.IPv4Connectivity.ToString() "
+            "  } "
+            "} | ConvertTo-Json -Depth 3"
+        )
+        profiles = []
+        for entry in _coerce_list(info):
+            profiles.append(
+                {
+                    "name": entry.get("Name"),
+                    "interface_alias": entry.get("InterfaceAlias"),
+                    "interface_index": entry.get("InterfaceIndex"),
+                    "network_category": entry.get("NetworkCategory"),
+                    "ipv4_connectivity": entry.get("IPv4Connectivity"),
+                }
+            )
+        snap.network["profiles"] = profiles
+    except Exception as exc:  # noqa: BLE001
+        snap.record("network.profiles", exc)
+
+
+def collect_firewall_groups(snap: Snapshot) -> None:
+    """For each of the three runbook rule groups, count enabled rules.
+
+    Section 8 expects each group to have at least one ``Enabled = True``
+    rule. The per-group count is enough for drift detection; we do not
+    enumerate every rule by name (~hundreds; noisy diffs).
+    """
+    snap.firewall["groups"] = {}
+    for group in FIREWALL_RULE_GROUPS:
+        try:
+            # Escape single quotes in the group name for the PS string literal.
+            ps_group = group.replace("'", "''")
+            info = ps_json(
+                f"Get-NetFirewallRule -DisplayGroup '{ps_group}' "
+                "-ErrorAction SilentlyContinue | "
+                "Group-Object Enabled | "
+                "Select-Object @{n='enabled';e={$_.Name}}, Count | "
+                "ConvertTo-Json -Depth 3"
+            )
+            counts = {"True": 0, "False": 0}
+            for entry in _coerce_list(info):
+                # PowerShell may render Enabled as bool literal True/False
+                # (newer) or the string 'True'/'False' (older); both land
+                # as Python bool or str. Normalize.
+                key = str(entry.get("enabled"))
+                counts[key] = counts.get(key, 0) + int(entry.get("Count") or 0)
+            snap.firewall["groups"][group] = {
+                "enabled_count": counts.get("True", 0),
+                "disabled_count": counts.get("False", 0),
+            }
+        except Exception as exc:  # noqa: BLE001
+            snap.record(f"firewall.groups.{group}", exc)
+            snap.firewall["groups"][group] = {"enabled_count": None, "disabled_count": None}
+
+
+def _read_dword(path: str, name: str) -> Optional[int]:
+    """Return the DWord value at ``path\\name``, or ``None`` if missing.
+
+    Uses ``Get-ItemProperty -ErrorAction SilentlyContinue`` so a missing
+    key returns ``None`` rather than raising.
+    """
+    raw = run_powershell(
+        f"$v = (Get-ItemProperty '{path}' -Name '{name}' -ErrorAction SilentlyContinue)"
+        f".'{name}'; if ($null -eq $v) {{ 'NULL' }} else {{ [string]$v }}"
+    )
+    if raw == "NULL" or raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def collect_registry_state(snap: Snapshot) -> None:
+    """Capture the three registry DWords the runbook Sections 6-7 set."""
+    try:
+        latfp = _read_dword(
+            r"HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System",
+            "LocalAccountTokenFilterPolicy",
+        )
+        snap.registry["local_account_token_filter_policy"] = latfp
+    except Exception as exc:  # noqa: BLE001
+        snap.record("registry.local_account_token_filter_policy", exc)
+
+    try:
+        lmc = _read_dword(r"HKLM:\SYSTEM\CurrentControlSet\Control\Lsa", "LmCompatibilityLevel")
+        snap.registry["lm_compatibility_level"] = lmc
+    except Exception as exc:  # noqa: BLE001
+        snap.record("registry.lm_compatibility_level", exc)
+
+    try:
+        rap = _read_dword(r"HKLM:\SYSTEM\CurrentControlSet\Control\Lsa", "RunAsPPL")
+        snap.registry["run_as_ppl"] = rap
+    except Exception as exc:  # noqa: BLE001
+        snap.record("registry.run_as_ppl", exc)
+
+
+def collect_credential_guard(snap: Snapshot) -> None:
+    """Capture VBS / Credential Guard configuration and running state."""
+    try:
+        info = ps_json(
+            "Get-ComputerInfo -Property "
+            "DeviceGuardSmartStatus, "
+            "DeviceGuardSecurityServicesConfigured, "
+            "DeviceGuardSecurityServicesRunning, "
+            "DeviceGuardCodeIntegrityPolicyEnforcementStatus, "
+            "DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | "
+            "ConvertTo-Json -Depth 3"
+        )
+        if isinstance(info, dict):
+            snap.credential_guard = {
+                "smart_status": info.get("DeviceGuardSmartStatus"),
+                "services_configured": info.get("DeviceGuardSecurityServicesConfigured"),
+                "services_running": info.get("DeviceGuardSecurityServicesRunning"),
+                "code_integrity_enforcement": info.get(
+                    "DeviceGuardCodeIntegrityPolicyEnforcementStatus"
+                ),
+                "user_mode_ci_enforcement": info.get(
+                    "DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus"
+                ),
+            }
+    except Exception as exc:  # noqa: BLE001
+        snap.record("credential_guard", exc)
+
+
+def collect_smb(snap: Snapshot) -> None:
+    """Capture SMB server config relevant to ``admin$`` access."""
+    try:
+        info = ps_json(
+            "Get-SmbServerConfiguration | Select-Object "
+            "EnableSMB1Protocol, EnableSMB2Protocol, "
+            "EnableSecuritySignature, RequireSecuritySignature, "
+            "EnableInsecureGuestLogons, AutoShareServer, "
+            "RestrictNamedPipeAccessViaQuic | "
+            "ConvertTo-Json -Depth 3"
+        )
+        if isinstance(info, dict):
+            snap.smb = {
+                "enable_smb1": info.get("EnableSMB1Protocol"),
+                "enable_smb2": info.get("EnableSMB2Protocol"),
+                "enable_security_signature": info.get("EnableSecuritySignature"),
+                "require_security_signature": info.get("RequireSecuritySignature"),
+                "enable_insecure_guest_logons": info.get("EnableInsecureGuestLogons"),
+                "auto_share_server": info.get("AutoShareServer"),
+                "restrict_named_pipe_access_via_quic": info.get(
+                    "RestrictNamedPipeAccessViaQuic"
+                ),
+            }
+    except Exception as exc:  # noqa: BLE001
+        snap.record("smb", exc)
+
+
+def collect_dcom_perms(snap: Snapshot) -> None:
+    """Hash-fingerprint the four DCOM-permission registry values.
+
+    Section 5 of the runbook configures DCOM Launch/Activation via the
+    ``dcomcnfg`` GUI; the resulting ACLs live in HKLM\\SOFTWARE\\Microsoft\\Ole
+    as REG_BINARY security descriptors. We capture each value's byte
+    length and SHA-256 so a change to the policy surfaces as a hash
+    diff between the Win10 baseline and the Win11 pilot artefact. The
+    snapshot does not decode the descriptors -- diff-detection is the
+    contract; full SDDL decoding is a follow-up.
+    """
+    properties = (
+        "MachineLaunchRestriction",
+        "MachineAccessRestriction",
+        "DefaultLaunchPermission",
+        "DefaultAccessPermission",
+    )
+    payload: dict[str, Any] = {}
+    for prop in properties:
+        try:
+            raw = run_powershell(
+                f"$v = (Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Ole' "
+                f"-Name '{prop}' -ErrorAction SilentlyContinue).'{prop}'; "
+                "if ($null -eq $v) { 'NULL' } else { "
+                "  $sha = (New-Object System.Security.Cryptography.SHA256Managed)"
+                ".ComputeHash($v); "
+                "  ($v.Length).ToString() + ':' + "
+                "  (($sha | ForEach-Object { $_.ToString('x2') }) -join '') }"
+            )
+            if raw == "NULL" or not raw:
+                payload[prop] = {"present": False}
+            else:
+                length_str, _, sha_hex = raw.partition(":")
+                payload[prop] = {
+                    "present": True,
+                    "length_bytes": int(length_str),
+                    "sha256": sha_hex,
+                }
+        except Exception as exc:  # noqa: BLE001
+            snap.record(f"dcom.{prop}", exc)
+            payload[prop] = {"present": None, "error": str(exc)}
+    snap.dcom["permissions"] = payload
+
+
+def collect_wmi_acl(snap: Snapshot) -> None:
+    """Capture the WMI CIMV2 namespace ACL via ``__SystemSecurity.GetSD``.
+
+    Section 4 of the runbook adds a ``Remote Enable`` grant via
+    ``compmgmt.msc``; the resulting ACL is reachable only through the
+    legacy WMI `__SystemSecurity` interface. Pure CIM cmdlets cannot
+    invoke ``GetSD``, so we drop to ``Get-WmiObject`` for this one
+    query. Same diff-detection treatment as the DCOM block: length
+    + SHA-256 of the returned bytes, no decoding.
+    """
+    try:
+        raw = run_powershell(
+            "$ns = Get-WmiObject -Namespace 'root\\cimv2' -List | "
+            "Where-Object { $_.Name -eq '__SystemSecurity' }; "
+            "$res = $ns.GetSD(); "
+            "if ($res.ReturnValue -ne 0) { 'RC:' + $res.ReturnValue } "
+            "else { "
+            "  $sha = (New-Object System.Security.Cryptography.SHA256Managed)"
+            ".ComputeHash($res.SD); "
+            "  'OK:' + $res.SD.Length + ':' + "
+            "  (($sha | ForEach-Object { $_.ToString('x2') }) -join '') }"
+        )
+        if raw.startswith("RC:"):
+            snap.wmi["cimv2_acl"] = {
+                "captured": False,
+                "return_value": int(raw.split(":", 1)[1]),
+            }
+        elif raw.startswith("OK:"):
+            _, length_str, sha_hex = raw.split(":", 2)
+            snap.wmi["cimv2_acl"] = {
+                "captured": True,
+                "return_value": 0,
+                "length_bytes": int(length_str),
+                "sha256": sha_hex,
+            }
+        else:
+            snap.wmi["cimv2_acl"] = {"captured": False, "raw": raw}
+    except Exception as exc:  # noqa: BLE001
+        snap.record("wmi.cimv2_acl", exc)
+
+
+def derive_verdict(snap: Snapshot) -> dict:
+    """PASS if every expected-state item from Section 8 matches; WARN if any
+    drift; FAIL never -- the snapshot just captures, it does not decide
+    whether a drift is intentional. WARN reasons name the field so the
+    operator can record an exception in the runbook log."""
+    reasons: List[str] = []
+    hints: List[str] = []
+
+    profiles = snap.network.get("profiles") or []
+    non_private = [
+        p for p in profiles
+        if (p.get("network_category") or "").lower() not in ("private", "domainauthenticated")
+    ]
+    if non_private:
+        aliases = ", ".join(p.get("interface_alias") or "?" for p in non_private)
+        reasons.append(f"NIC profile not Private/Domain: {aliases}")
+        hints.append("Re-pin NIC profile per Section 2 of the runbook")
+
+    for group, counts in (snap.firewall.get("groups") or {}).items():
+        enabled = counts.get("enabled_count")
+        if enabled is None:
+            reasons.append(f"firewall group not queryable: {group}")
+        elif enabled == 0:
+            reasons.append(f"firewall group has zero enabled rules: {group}")
+            hints.append("Run Section 3 of the runbook")
+
+    latfp = snap.registry.get("local_account_token_filter_policy")
+    if latfp != EXPECTED_LATFP:
+        reasons.append(f"LocalAccountTokenFilterPolicy={latfp} (expected {EXPECTED_LATFP})")
+        hints.append("Run Section 6 of the runbook")
+
+    lmc = snap.registry.get("lm_compatibility_level")
+    if lmc not in EXPECTED_LMCOMPAT_OK and lmc is not None:
+        reasons.append(
+            f"LmCompatibilityLevel={lmc} (expected one of {EXPECTED_LMCOMPAT_OK})"
+        )
+        hints.append("Section 7 NTLM hardening")
+
+    rap = snap.registry.get("run_as_ppl")
+    if rap not in EXPECTED_RUNASPPL:
+        reasons.append(f"RunAsPPL={rap} (expected 0 or unset)")
+        hints.append("Section 7 LSASS protection -- document if intentional")
+
+    services_running = snap.credential_guard.get("services_running") or []
+    if any("CredentialGuard" in str(s) or s == 1 for s in _coerce_list(services_running)):
+        reasons.append("Credential Guard running -- NTLM workgroup auth may be restricted")
+        hints.append("Section 7 Credential Guard -- document if intentional")
+
+    if snap.smb.get("enable_smb2") is False:
+        reasons.append("EnableSMB2Protocol=False")
+        hints.append("SCHTASKS /XML round-trip needs SMB2; re-enable")
+    if snap.smb.get("enable_smb1") is True:
+        reasons.append("EnableSMB1Protocol=True (security hazard, not needed)")
+        hints.append("Disable SMB1 per Section 7")
+
+    if not reasons:
+        return {"category": "PASS", "reasons": [], "remediation_hints": []}
+    return {"category": "WARN", "reasons": reasons, "remediation_hints": hints}
+
+
+def to_payload(machine: dict, snap: Snapshot) -> dict:
+    return build_envelope(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        machine=machine,
+        blocks={
+            "network": snap.network,
+            "firewall": snap.firewall,
+            "registry": snap.registry,
+            "credential_guard": snap.credential_guard,
+            "smb": snap.smb,
+            "dcom": snap.dcom,
+            "wmi": snap.wmi,
+        },
+        verdict=derive_verdict(snap),
+        errors=snap.errors,
+    )
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--role",
+        choices=["CTR", "STM", "ACQ", "spare"],
+        help="Booth role for this machine; recorded in the JSON for triage.",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        help="Output JSON path. Defaults to "
+        "<log_dir>/booth_security_snapshot/<os>/<hostname>.json.",
+    )
+    p.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print the JSON envelope to stdout in addition to writing the file.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    snap = Snapshot()
+
+    print("Collecting booth security posture snapshot...", file=sys.stderr)
+    machine, machine_errors = collect_os_identity(args.role)
+    snap.errors.extend(machine_errors)
+
+    collect_network_profiles(snap)
+    collect_firewall_groups(snap)
+    collect_registry_state(snap)
+    collect_credential_guard(snap)
+    collect_smb(snap)
+    collect_dcom_perms(snap)
+    collect_wmi_acl(snap)
+
+    payload = to_payload(machine, snap)
+    out_path = args.out or (
+        resolved_log_dir("booth_security_snapshot")
+        / os_segment(machine)
+        / f"{machine.get('hostname', 'unknown')}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+    verdict = payload["verdict"]["category"]
+    print(f"Verdict: {verdict}", file=sys.stderr)
+    if payload["verdict"]["reasons"]:
+        for reason in payload["verdict"]["reasons"]:
+            print(f"  - {reason}", file=sys.stderr)
+    print(f"Wrote: {out_path}", file=sys.stderr)
+    if snap.errors:
+        print(
+            f"Collection errors: {len(snap.errors)} (see JSON 'collection_errors')",
+            file=sys.stderr,
+        )
+
+    if args.stdout:
+        print(json.dumps(payload, indent=2, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/perf/intermachine_check.py
+++ b/extras/perf/intermachine_check.py
@@ -1,0 +1,750 @@
+"""CTR-side harness: exercise the inter-machine plumbing each booth depends on.
+
+Issue #764 / concern #2 of #759. Validates that the four remote primitives
+in ``neurobooth_os/netcomm/client.py`` plus the ``admin$`` SMB share work
+end-to-end against every configured booth, before a Windows 11 upgrade has
+a chance to silently regress one of them. The runbook the harness checks
+against is ``docs/inter_machine_setup.md`` (Section 8 "Expected state").
+
+Primitives exercised per booth:
+
+* ``tasklist /S /U /P`` -- RPC over named pipes, NTLM auth
+* ``Get-CimInstance -CimSession (Dcom)`` -- DCOM (the post-PR-#770 path)
+* ``SCHTASKS /S /U /P /Query`` -- RPC + DCOM (Task Scheduler Remote)
+* ``SCHTASKS /S /U /P /Create /XML`` + ``/Delete`` round-trip -- same
+  transport plus the ``admin$`` SMB read SCHTASKS depends on when
+  transferring the task XML. The task is created Enabled=false and is
+  deleted immediately; no scheduled work ever runs.
+* ``taskkill /S /U /P /PID 0 /F`` -- expected to fail with
+  ``ERROR_NOT_FOUND``; a structured "no such process" reply confirms the
+  RPC/DCOM round-trip without killing anything.
+* ``net use \\<host>\admin$ /USER:<u> <p>`` -- direct SMB connect test
+  (separate signal from the SCHTASKS-implied SMB dependency above).
+
+Emits the shared ``_baseline_common`` envelope under
+``<log_dir>/intermachine_check/<os>/<hostname>.json`` so the artefact
+diffs cleanly against the four sibling baselines coordinated in #768.
+
+Reads booth credentials from ``cfg.neurobooth_config.server_by_name``;
+no flags pass them on the command line. Targets default to every
+configured remote service (presentation + acquisition_*); the current
+machine's own ``control`` entry is skipped because there is no
+cross-machine plumbing to exercise against localhost.
+
+Usage::
+
+    uv run python extras/perf/intermachine_check.py [--out PATH]
+        [--targets presentation,acquisition_0] [--stdout] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+import xml.sax.saxutils as _saxutils
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+from _baseline_common import (
+    CollectionError,
+    build_envelope,
+    collect_os_identity,
+    os_segment,
+    resolved_log_dir,
+)
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "intermachine_check"
+
+# Treat a probe that finishes in under this many milliseconds as "fast" in
+# the summary line; longer than this on a same-LAN booth often points at
+# auth retry / fallback under the hood (NTLMv2 hardening, profile flip).
+SLOW_PROBE_MS = 3000.0
+
+# taskkill on a non-existent PID returns 128 with stderr like
+# "ERROR: The process \"0\" not found." Treat that exit code as the
+# "expected fail" signal -- it proves the transport completed without
+# touching any real process.
+TASKKILL_NOTFOUND_RC = 128
+
+
+@dataclass
+class ProbeResult:
+    primitive: str
+    transport: str
+    status: str  # "ok" | "expected_fail" | "fail" | "skip"
+    duration_ms: float
+    exit_code: Optional[int] = None
+    stderr_excerpt: Optional[str] = None
+    note: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in self.__dict__.items() if v is not None or k in ("status",)}
+
+
+@dataclass
+class TargetResult:
+    name: str
+    host: str
+    user: str
+    probes: List[ProbeResult] = field(default_factory=list)
+    verdict: str = "PASS"  # PASS | DEGRADED | FAIL
+    skip_reason: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        out: dict = {
+            "name": self.name,
+            "host": self.host,
+            "user": self.user,
+            "verdict": self.verdict,
+        }
+        if self.skip_reason:
+            out["skip_reason"] = self.skip_reason
+        out["probes"] = [p.to_dict() for p in self.probes]
+        return out
+
+
+def _clip(text: Optional[str], limit: int = 500) -> Optional[str]:
+    if not text:
+        return None
+    text = text.strip()
+    return text[:limit] if len(text) > limit else (text or None)
+
+
+def _run(cmd: List[str], timeout: float, env: Optional[dict] = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+    )
+
+
+def _measure(fn) -> Tuple[Any, float]:
+    t0 = time.monotonic()
+    result = fn()
+    return result, (time.monotonic() - t0) * 1000.0
+
+
+def probe_tasklist(host: str, user: str, password: str, timeout: float = 20.0) -> ProbeResult:
+    """Exercise the named-pipe RPC + NTLM path used by ``get_python_pids``."""
+    def _go():
+        return _run(
+            ["tasklist.exe", "/S", host, "/U", user, "/P", password, "/FO", "CSV", "/NH"],
+            timeout=timeout,
+        )
+    try:
+        result, ms = _measure(_go)
+    except subprocess.TimeoutExpired as exc:
+        return ProbeResult(
+            primitive="tasklist",
+            transport="RPC over named pipes (NTLM)",
+            status="fail",
+            duration_ms=timeout * 1000.0,
+            stderr_excerpt=_clip(str(exc)),
+            note="timeout",
+        )
+
+    ok = result.returncode == 0
+    return ProbeResult(
+        primitive="tasklist",
+        transport="RPC over named pipes (NTLM)",
+        status="ok" if ok else "fail",
+        duration_ms=ms,
+        exit_code=result.returncode,
+        stderr_excerpt=_clip(result.stderr),
+    )
+
+
+_PS_DCOM_PYTHON_PROCS = r"""
+$ErrorActionPreference = 'Stop'
+$securepw = ConvertTo-SecureString $env:NB_REMOTE_PASSWORD -AsPlainText -Force
+$cred = New-Object System.Management.Automation.PSCredential($env:NB_REMOTE_USER, $securepw)
+$opt = New-CimSessionOption -Protocol Dcom
+$sess = New-CimSession -ComputerName $env:NB_REMOTE_HOST -Credential $cred -SessionOption $opt
+try {
+    Get-CimInstance -CimSession $sess -ClassName Win32_Process -Filter "Name='python.exe'" |
+        Measure-Object | Select-Object -ExpandProperty Count
+} finally {
+    Remove-CimSession $sess
+}
+"""
+
+
+def probe_dcom_ciminstance(host: str, user: str, password: str, timeout: float = 30.0) -> ProbeResult:
+    """Exercise the DCOM CimSession path that replaced WMIC in PR #770.
+
+    Credentials are passed via env vars to keep the password off the
+    command line (same convention as ``client.py``'s production code).
+    """
+    qualified_user = user if "\\" in user else f"{host}\\{user}"
+    env = {
+        **os.environ,
+        "NB_REMOTE_HOST": host,
+        "NB_REMOTE_USER": qualified_user,
+        "NB_REMOTE_PASSWORD": password or "",
+    }
+
+    def _go():
+        return _run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", _PS_DCOM_PYTHON_PROCS],
+            timeout=timeout,
+            env=env,
+        )
+    try:
+        result, ms = _measure(_go)
+    except subprocess.TimeoutExpired as exc:
+        return ProbeResult(
+            primitive="get_ciminstance_dcom",
+            transport="DCOM",
+            status="fail",
+            duration_ms=timeout * 1000.0,
+            stderr_excerpt=_clip(str(exc)),
+            note="timeout",
+        )
+
+    ok = result.returncode == 0
+    return ProbeResult(
+        primitive="get_ciminstance_dcom",
+        transport="DCOM",
+        status="ok" if ok else "fail",
+        duration_ms=ms,
+        exit_code=result.returncode,
+        stderr_excerpt=_clip(result.stderr),
+    )
+
+
+def probe_schtasks_query(host: str, user: str, password: str, timeout: float = 20.0) -> ProbeResult:
+    """Read-only Task Scheduler Remote round-trip."""
+    def _go():
+        return _run(
+            ["SCHTASKS", "/Query", "/S", host, "/U", user, "/P", password, "/FO", "CSV", "/NH"],
+            timeout=timeout,
+        )
+    try:
+        result, ms = _measure(_go)
+    except subprocess.TimeoutExpired as exc:
+        return ProbeResult(
+            primitive="schtasks_query",
+            transport="RPC + DCOM (Task Scheduler Remote)",
+            status="fail",
+            duration_ms=timeout * 1000.0,
+            stderr_excerpt=_clip(str(exc)),
+            note="timeout",
+        )
+
+    ok = result.returncode == 0
+    return ProbeResult(
+        primitive="schtasks_query",
+        transport="RPC + DCOM (Task Scheduler Remote)",
+        status="ok" if ok else "fail",
+        duration_ms=ms,
+        exit_code=result.returncode,
+        stderr_excerpt=_clip(result.stderr),
+    )
+
+
+def _noop_task_xml(machine: str, user: str) -> str:
+    """Minimal Task Scheduler XML that cannot run.
+
+    Strict-mode Win11 schema validation accepts the EventTrigger pattern
+    we use in production (``_build_task_xml`` in ``netcomm/client.py``);
+    we mirror it here for the same reason, with the trigger pointing at
+    an event ID nothing emits and the task itself Enabled=false /
+    AllowStartOnDemand=false. The Action is ``cmd.exe /c exit 0`` purely
+    so the schema validator accepts an Exec block; it never runs.
+    """
+    qualified_user = user if "\\" in user else f"{machine}\\{user}"
+    user_xml = _saxutils.escape(qualified_user)
+    return (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        '<Task version="1.3" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+        '  <Triggers>\n'
+        '    <EventTrigger>\n'
+        '      <Enabled>false</Enabled>\n'
+        "      <Subscription>&lt;QueryList&gt;&lt;Query&gt;&lt;Select Path='Application'&gt;"
+        "*[System/EventID=778]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;</Subscription>\n"
+        '    </EventTrigger>\n'
+        '  </Triggers>\n'
+        '  <Principals>\n'
+        '    <Principal id="Author">\n'
+        f'      <UserId>{user_xml}</UserId>\n'
+        '      <LogonType>InteractiveToken</LogonType>\n'
+        '      <RunLevel>LeastPrivilege</RunLevel>\n'
+        '    </Principal>\n'
+        '  </Principals>\n'
+        '  <Settings>\n'
+        '    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n'
+        '    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n'
+        '    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n'
+        '    <AllowStartOnDemand>false</AllowStartOnDemand>\n'
+        '    <Enabled>false</Enabled>\n'
+        '    <ExecutionTimeLimit>PT1M</ExecutionTimeLimit>\n'
+        '  </Settings>\n'
+        '  <Actions Context="Author">\n'
+        '    <Exec>\n'
+        '      <Command>cmd.exe</Command>\n'
+        '      <Arguments>/c exit 0</Arguments>\n'
+        '    </Exec>\n'
+        '  </Actions>\n'
+        '</Task>\n'
+    )
+
+
+def probe_schtasks_xml_roundtrip(host: str, user: str, password: str,
+                                 timeout: float = 30.0) -> ProbeResult:
+    """Create + Delete a disabled no-op task. Exercises SMB ``admin$`` too.
+
+    SCHTASKS ``/Create /XML`` pulls the XML file via SMB to ``\\<host>\\admin$``
+    before registering it, so this probe is the only one that surfaces an
+    SMB regression along the SCHTASKS path. The task is created
+    Enabled=false / AllowStartOnDemand=false; it cannot run even if a
+    cleanup failure leaves it registered.
+
+    Always deletes in a finally; the task name is uniquified so concurrent
+    runs against the same booth do not collide.
+    """
+    task_name = f"_nb_intermachine_probe_{uuid.uuid4().hex[:12]}"
+    xml_content = _noop_task_xml(machine=host, user=user)
+
+    fd, xml_path = tempfile.mkstemp(suffix=".xml")
+    create_rc: Optional[int] = None
+    create_stderr: Optional[str] = None
+    delete_rc: Optional[int] = None
+    delete_stderr: Optional[str] = None
+
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"\xff\xfe")  # SCHTASKS /XML expects UTF-16 LE with BOM
+            fh.write(xml_content.encode("utf-16-le"))
+
+        def _create():
+            return _run(
+                ["SCHTASKS", "/Create", "/S", host, "/U", user, "/P", password,
+                 "/TN", task_name, "/XML", xml_path, "/F"],
+                timeout=timeout,
+            )
+        try:
+            create_result, ms = _measure(_create)
+            create_rc = create_result.returncode
+            create_stderr = _clip(create_result.stderr)
+        except subprocess.TimeoutExpired as exc:
+            return ProbeResult(
+                primitive="schtasks_xml_roundtrip",
+                transport="RPC + DCOM + SMB (admin$ XML transfer)",
+                status="fail",
+                duration_ms=timeout * 1000.0,
+                stderr_excerpt=_clip(str(exc)),
+                note="create timeout",
+            )
+
+        if create_rc != 0:
+            return ProbeResult(
+                primitive="schtasks_xml_roundtrip",
+                transport="RPC + DCOM + SMB (admin$ XML transfer)",
+                status="fail",
+                duration_ms=ms,
+                exit_code=create_rc,
+                stderr_excerpt=create_stderr,
+                note="create failed",
+            )
+
+        def _delete():
+            return _run(
+                ["SCHTASKS", "/Delete", "/S", host, "/U", user, "/P", password,
+                 "/TN", task_name, "/F"],
+                timeout=timeout,
+            )
+        try:
+            delete_result, delete_ms = _measure(_delete)
+            delete_rc = delete_result.returncode
+            delete_stderr = _clip(delete_result.stderr)
+        except subprocess.TimeoutExpired as exc:
+            return ProbeResult(
+                primitive="schtasks_xml_roundtrip",
+                transport="RPC + DCOM + SMB (admin$ XML transfer)",
+                status="fail",
+                duration_ms=ms + timeout * 1000.0,
+                stderr_excerpt=_clip(str(exc)),
+                note="delete timeout (task left registered, but Enabled=false)",
+            )
+
+        if delete_rc != 0:
+            return ProbeResult(
+                primitive="schtasks_xml_roundtrip",
+                transport="RPC + DCOM + SMB (admin$ XML transfer)",
+                status="fail",
+                duration_ms=ms + delete_ms,
+                exit_code=delete_rc,
+                stderr_excerpt=delete_stderr,
+                note=f"delete failed; task '{task_name}' may remain (Enabled=false)",
+            )
+
+        return ProbeResult(
+            primitive="schtasks_xml_roundtrip",
+            transport="RPC + DCOM + SMB (admin$ XML transfer)",
+            status="ok",
+            duration_ms=ms + delete_ms,
+            exit_code=0,
+        )
+    finally:
+        try:
+            os.remove(xml_path)
+        except OSError:
+            pass
+
+
+def probe_taskkill_notfound(host: str, user: str, password: str,
+                            timeout: float = 15.0) -> ProbeResult:
+    """``taskkill /PID 0`` -- expected to fail with NOT_FOUND.
+
+    A structured "no such process" reply proves the RPC/DCOM transport
+    completed without touching any real process. Any other failure mode
+    (network, auth, firewall) shows up as a different exit code.
+    """
+    def _go():
+        return _run(
+            ["taskkill", "/S", host, "/U", user, "/P", password, "/PID", "0", "/F"],
+            timeout=timeout,
+        )
+    try:
+        result, ms = _measure(_go)
+    except subprocess.TimeoutExpired as exc:
+        return ProbeResult(
+            primitive="taskkill_notfound",
+            transport="RPC/DCOM",
+            status="fail",
+            duration_ms=timeout * 1000.0,
+            stderr_excerpt=_clip(str(exc)),
+            note="timeout",
+        )
+
+    if result.returncode == TASKKILL_NOTFOUND_RC:
+        return ProbeResult(
+            primitive="taskkill_notfound",
+            transport="RPC/DCOM",
+            status="expected_fail",
+            duration_ms=ms,
+            exit_code=result.returncode,
+            note='exit 128 "process not found" = transport ok',
+        )
+    if result.returncode == 0:
+        return ProbeResult(
+            primitive="taskkill_notfound",
+            transport="RPC/DCOM",
+            status="fail",
+            duration_ms=ms,
+            exit_code=0,
+            note="taskkill PID 0 unexpectedly returned 0; check remote state",
+        )
+    return ProbeResult(
+        primitive="taskkill_notfound",
+        transport="RPC/DCOM",
+        status="fail",
+        duration_ms=ms,
+        exit_code=result.returncode,
+        stderr_excerpt=_clip(result.stderr),
+    )
+
+
+def probe_admin_share_smb(host: str, user: str, password: str,
+                          timeout: float = 20.0) -> ProbeResult:
+    """``net use \\<host>\admin$`` round-trip.
+
+    Surfaces a regression in SMB signing / SMB1-off / NTLM-against-SMB
+    that would not show up in the SCHTASKS round-trip's exit code (the
+    SCHTASKS layer can sometimes mask the underlying SMB error).
+    """
+    share = f"\\\\{host}\\admin$"
+    def _connect():
+        return _run(
+            ["net", "use", share, password, f"/USER:{user}"],
+            timeout=timeout,
+        )
+    def _disconnect():
+        return _run(
+            ["net", "use", share, "/DELETE", "/Y"],
+            timeout=timeout,
+        )
+
+    try:
+        result, ms = _measure(_connect)
+    except subprocess.TimeoutExpired as exc:
+        return ProbeResult(
+            primitive="admin_share_smb",
+            transport="SMB",
+            status="fail",
+            duration_ms=timeout * 1000.0,
+            stderr_excerpt=_clip(str(exc)),
+            note="connect timeout",
+        )
+
+    if result.returncode != 0:
+        return ProbeResult(
+            primitive="admin_share_smb",
+            transport="SMB",
+            status="fail",
+            duration_ms=ms,
+            exit_code=result.returncode,
+            stderr_excerpt=_clip(result.stderr or result.stdout),
+        )
+
+    try:
+        _disconnect()  # best-effort cleanup; never fails the probe
+    except Exception:  # noqa: BLE001
+        pass
+
+    return ProbeResult(
+        primitive="admin_share_smb",
+        transport="SMB",
+        status="ok",
+        duration_ms=ms,
+        exit_code=0,
+    )
+
+
+PROBES = (
+    probe_tasklist,
+    probe_dcom_ciminstance,
+    probe_schtasks_query,
+    probe_schtasks_xml_roundtrip,
+    probe_taskkill_notfound,
+    probe_admin_share_smb,
+)
+
+
+def run_target(name: str, host: str, user: str, password: str) -> TargetResult:
+    """Run every probe against one booth and roll up a per-target verdict."""
+    target = TargetResult(name=name, host=host, user=user)
+    for probe_fn in PROBES:
+        try:
+            target.probes.append(probe_fn(host, user, password))
+        except Exception as exc:  # noqa: BLE001
+            target.probes.append(
+                ProbeResult(
+                    primitive=probe_fn.__name__,
+                    transport="unknown",
+                    status="fail",
+                    duration_ms=0.0,
+                    note=f"harness crash: {type(exc).__name__}: {exc}",
+                )
+            )
+
+    # Verdict: PASS if every probe is ok/expected_fail. DEGRADED if the read
+    # primitives pass but a write primitive (SCHTASKS XML roundtrip) fails.
+    # FAIL if a read primitive fails.
+    statuses = {p.primitive: p.status for p in target.probes}
+    read_primitives = ("tasklist", "get_ciminstance_dcom", "schtasks_query")
+    write_primitives = ("schtasks_xml_roundtrip", "admin_share_smb")
+
+    read_ok = all(statuses.get(p) in ("ok", "expected_fail") for p in read_primitives)
+    write_ok = all(statuses.get(p) in ("ok", "expected_fail") for p in write_primitives)
+
+    if not read_ok:
+        target.verdict = "FAIL"
+    elif not write_ok:
+        target.verdict = "DEGRADED"
+    else:
+        target.verdict = "PASS"
+    return target
+
+
+def _resolve_targets(requested: Optional[List[str]]) -> Tuple[List[Tuple[str, str, str, str]], List[CollectionError]]:
+    """Return ``[(service_name, host, user, password), ...]`` for the targets to probe.
+
+    Skips the current machine's ``control`` entry by default -- the cross-
+    machine plumbing has nothing to validate against localhost. If a
+    requested target has no password configured, it is dropped and an
+    error is appended (mirroring ``client.py``'s `ConfigException` path,
+    but the harness keeps running for the remaining booths).
+    """
+    errors: List[CollectionError] = []
+    try:
+        import neurobooth_os.config as _cfg
+    except ImportError as exc:  # neurobooth_os not installed
+        errors.append(CollectionError("config", f"neurobooth_os not importable: {exc}"))
+        return [], errors
+
+    if _cfg.neurobooth_config is None:
+        try:
+            _cfg.load_config(validate_paths=False)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(CollectionError("config.load", f"{type(exc).__name__}: {exc}"))
+            return [], errors
+
+    nbc = _cfg.neurobooth_config
+    if requested is None:
+        names = ["presentation"] + [f"acquisition_{i}" for i in range(len(nbc.acquisition))]
+    else:
+        names = requested
+
+    out: List[Tuple[str, str, str, str]] = []
+    local_host = socket.gethostname().upper()
+    for name in names:
+        try:
+            svc = nbc.server_by_name(name)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(CollectionError(f"config.target.{name}", f"{type(exc).__name__}: {exc}"))
+            continue
+        if not svc.user or svc.password is None:
+            errors.append(
+                CollectionError(
+                    f"config.target.{name}",
+                    "no user/password configured (single-machine dev?) -- skipping",
+                )
+            )
+            continue
+        if svc.name.upper() == local_host:
+            errors.append(
+                CollectionError(
+                    f"config.target.{name}",
+                    f"resolves to the current machine ({local_host}); no cross-machine plumbing to probe",
+                )
+            )
+            continue
+        out.append((name, svc.name, svc.user, svc.password.get_secret_value()))
+    return out, errors
+
+
+def derive_overall_verdict(targets: List[TargetResult]) -> dict:
+    if not targets:
+        return {
+            "category": "FAIL",
+            "reasons": ["no targets resolved"],
+            "remediation_hints": [
+                "Ensure NB_CONFIG points at the booth's config and secrets.yaml has passwords"
+            ],
+        }
+    per_verdict = {t.verdict for t in targets}
+    if per_verdict == {"PASS"}:
+        return {"category": "PASS", "reasons": [], "remediation_hints": []}
+    failed = [t.name for t in targets if t.verdict == "FAIL"]
+    degraded = [t.name for t in targets if t.verdict == "DEGRADED"]
+    reasons: List[str] = []
+    hints: List[str] = []
+    if failed:
+        reasons.append(f"read-primitive failure on: {', '.join(failed)}")
+        hints.append(
+            "Walk docs/inter_machine_setup.md sections 2-6 on the failing booth; "
+            "the failing probe's 'transport' field identifies which section"
+        )
+        category = "FAIL"
+    elif degraded:
+        reasons.append(f"write-primitive failure on: {', '.join(degraded)}")
+        hints.append(
+            "Check SMB server config on the failing booth (Section 7 of the runbook); "
+            "EnableSMB2Protocol=True and a non-Public NIC profile are the usual culprits"
+        )
+        category = "DEGRADED"
+    else:
+        category = "PASS"
+    return {"category": category, "reasons": reasons, "remediation_hints": hints}
+
+
+def to_payload(machine: dict, targets: List[TargetResult],
+               errors: List[CollectionError]) -> dict:
+    return build_envelope(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        machine=machine,
+        blocks={"targets": [t.to_dict() for t in targets]},
+        verdict=derive_overall_verdict(targets),
+        errors=errors,
+    )
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--out",
+        type=Path,
+        help="Output JSON path. Defaults to "
+        "<log_dir>/intermachine_check/<os>/<hostname>.json.",
+    )
+    p.add_argument(
+        "--targets",
+        help="Comma-separated service names (e.g. 'presentation,acquisition_0'). "
+        "Defaults to every configured remote service.",
+    )
+    p.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print the JSON envelope to stdout in addition to writing the file.",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if the overall verdict is not PASS (CI gate).",
+    )
+    return p.parse_args(argv)
+
+
+def _format_summary(target: TargetResult) -> str:
+    line = f"  [{target.verdict}] {target.name} ({target.host})"
+    for probe in target.probes:
+        marker = {"ok": "ok", "expected_fail": "ok*", "fail": "FAIL", "skip": "skip"}.get(
+            probe.status, probe.status
+        )
+        slow = " (slow)" if probe.duration_ms > SLOW_PROBE_MS else ""
+        line += f"\n      {probe.primitive:<24s} {marker:<5s} {probe.duration_ms:6.0f}ms{slow}"
+        if probe.status == "fail" and probe.stderr_excerpt:
+            line += f" -- {probe.stderr_excerpt.splitlines()[0][:80]}"
+    return line
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+
+    print("Resolving targets from neurobooth config...", file=sys.stderr)
+    requested = [s.strip() for s in args.targets.split(",")] if args.targets else None
+    targets_spec, cfg_errors = _resolve_targets(requested)
+
+    if cfg_errors:
+        for err in cfg_errors:
+            print(f"  config: {err.field}: {err.message}", file=sys.stderr)
+
+    machine, machine_errors = collect_os_identity()
+    machine["role"] = "control"
+
+    target_results: List[TargetResult] = []
+    for name, host, user, password in targets_spec:
+        print(f"Probing {name} ({host}) ...", file=sys.stderr)
+        target_results.append(run_target(name, host, user, password))
+
+    errors = cfg_errors + machine_errors
+    payload = to_payload(machine, target_results, errors)
+
+    out_path = args.out or (
+        resolved_log_dir("intermachine_check")
+        / os_segment(machine)
+        / f"{machine.get('hostname', 'unknown')}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+    verdict = payload["verdict"]["category"]
+    print(f"\nOverall verdict: {verdict}", file=sys.stderr)
+    for tr in target_results:
+        print(_format_summary(tr), file=sys.stderr)
+    print(f"\nWrote: {out_path}", file=sys.stderr)
+
+    if args.stdout:
+        print(json.dumps(payload, indent=2, default=str))
+
+    if args.strict and verdict != "PASS":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the harness portion of #764 (concern #2 of #759). The runbook portion shipped in #798.

- **`extras/perf/intermachine_check.py`** — CTR-side harness. Iterates `presentation` + each `acquisition_*` from `cfg.neurobooth_config`; runs six probes per booth: `tasklist`, `Get-CimInstance` over DCOM, `SCHTASKS /Query`, `SCHTASKS /Create /XML /F` + `/Delete` round-trip with a disabled no-op task, `taskkill /PID 0` expected-fail, and an `admin$` SMB connect. Reads credentials from `secrets.yaml`; nothing passes on the command line. Per-target verdict PASS / DEGRADED / FAIL with a remediation hint pointing at the right runbook section.

- **`extras/perf/booth_security_snapshot.py`** — runs *on* each booth. Captures the Section 8 expected-state items: NIC profile, the three firewall rule-group enabled counts, ``LocalAccountTokenFilterPolicy`` / ``LmCompatibilityLevel`` / ``RunAsPPL``, Credential Guard, SMB server config. DCOM Launch/Activation permissions and the WMI CIMV2 ACL are captured as length + SHA-256 of the binary descriptors so drift is detectable without the snapshot inspecting policy bytes (SDDL decoding is a follow-up). Verdict PASS / WARN against the Section 8 checklist.

- **`docs/inter_machine_setup.md`** — Section 8 updated to point at the snapshot for validation; new Section 10 documents how to run both tools; References updated.

Both new tools emit the shared `_baseline_common.build_envelope` shape so the artefacts join cleanly with the four sibling harnesses indexed in #768.

## Why split into harness + snapshot

The harness exercises the *transport* (CTR-to-booth round-trips); the snapshot captures the *configuration* (per-booth registry / firewall / ACL state). A regression in either layer surfaces in a different artefact, so the diff against the Win10 baseline tells you which layer changed.

## Test plan

Both tools verified locally on a Win11 dev box (`DESKTOP-GTJHOUH`, build 26200):

- [x] **Snapshot** ran end-to-end, produced a valid envelope with verdict `WARN`. Reasons were the expected dev-box-not-a-booth set: Wi-Fi NIC=Public, WMI + Scheduled Tasks rule groups have zero enabled rules, `RunAsPPL=2`. DCOM permission descriptors captured (4 of 4) with sensible byte lengths and SHA-256 hashes. WMI CIMV2 ACL captured (180 bytes, ReturnValue=0).
- [x] **Harness** compiled cleanly and ran end-to-end against the dev config: no remote creds → both targets skipped with a clear `collection_errors` entry → overall verdict `FAIL` with `no targets resolved` and a remediation hint pointing at `NB_CONFIG` / `secrets.yaml`. This is the expected dev-box behaviour; on a real booth pair the probes execute.
- [x] All 12 perf-tools that emit envelopes (including the two new ones) use `_baseline_common.build_envelope` + `collect_os_identity` — header consistent for the #768 baseline-lockdown rollup.

To execute on the booths:
- [ ] **Run the snapshot on CTR, STM, ACQ.** Commit the resulting JSONs as the Win10 baseline (per #768 layout).
- [ ] **Run `intermachine_check.py` from CTR** against the real STM + ACQ. Commit the resulting JSON as the Win10 baseline.
- [ ] **Re-run both after any Windows servicing update** so a silent default change does not regress the booth without anyone noticing. (Section 10 of the updated runbook calls this out.)

## Out of scope (follow-ups)

- SDDL decoding for the DCOM / WMI ACL captures. Hash-fingerprint detects drift; full decode is the natural follow-up if a drift fires and someone wants human-readable diffs.
- Win10 → Win11 comparator. Each harness emits structured JSON; the diff layer is shared #768 work.