### PR TITLE
Register zero-sample streams instead of skipping them (#819)

### DIFF
--- a/neurobooth_os/iout/split_xdf.py
+++ b/neurobooth_os/iout/split_xdf.py
@@ -305,20 +305,19 @@ def log_to_database(
         time_offset = compute_clocks_diff()
         timestamps = dev.device_data["time_stamps"]
         if len(timestamps) == 0:
-            # #819: a stream with zero samples is legitimate data — Mouse only
-            # emits samples on movement, and during tasks where the subject
-            # doesn't touch the mouse the stream is empty. Skipping here keeps
-            # the open transaction intact so the other devices' rows commit;
-            # before this guard, the next line raised IndexError and rolled
-            # back the entire task's log_sensor_file rows.
+            # #819: a zero-sample stream is legitimate (e.g. idle Mouse). The
+            # HDF5 is still written by write_device_hdf5, so register it with
+            # NULL timing — skipping it (the original guard) orphans the file
+            # and trips the copy script's "log_sensor_file_id not found" warning.
             logger.warning(
-                f"skipping {dev.device_id}: 0 samples in stream "
-                f"(hdf5: {dev.hdf5_path})"
+                f"{dev.device_id}: 0 samples in stream; registering "
+                f"{dev.hdf5_path} with NULL timing"
             )
-            continue
-        start_time = datetime.fromtimestamp(timestamps[0] + time_offset).strftime("%Y-%m-%d %H:%M:%S")
-        end_time = datetime.fromtimestamp(timestamps[-1] + time_offset).strftime("%Y-%m-%d %H:%M:%S")
-        temporal_resolution = 1 / np.median(np.diff(timestamps))
+            start_time = end_time = temporal_resolution = None
+        else:
+            start_time = datetime.fromtimestamp(timestamps[0] + time_offset).strftime("%Y-%m-%d %H:%M:%S")
+            end_time = datetime.fromtimestamp(timestamps[-1] + time_offset).strftime("%Y-%m-%d %H:%M:%S")
+            temporal_resolution = 1 / np.median(np.diff(timestamps))
 
         # Build the session-relative HDF5 path (to prepend or INSERT with)
         hdf5_folder, hdf5_file = os.path.split(dev.hdf5_path)

--- a/tests/pytest/test_split_xdf_log_to_database.py
+++ b/tests/pytest/test_split_xdf_log_to_database.py
@@ -7,6 +7,11 @@ IndexError on the empty case. The exception propagated out of
 ``log_to_database`` before ``conn.commit()`` was reached, rolling back every
 device's pending UPDATE/INSERT and leaving the entire task's
 ``log_sensor_file`` rows empty.
+
+The empty-stream device's HDF5 file is still written by ``write_device_hdf5``,
+so ``log_to_database`` must still register it -- with NULL timing -- otherwise
+the file is orphaned on disk and the copy script reports
+``log_sensor_file_id not found`` for it on every run.
 """
 from __future__ import annotations
 
@@ -28,10 +33,11 @@ def _mock_conn(rowcount: int = 1) -> MagicMock:
     return conn
 
 
-def test_log_to_database_skips_empty_stream(monkeypatch):
-    """#819 regression: an empty stream must skip with a warning instead of
-    raising IndexError. The non-empty device in the same call must still get
-    its row written and conn.commit() must be reached."""
+def test_log_to_database_registers_empty_stream_with_null_timing(monkeypatch):
+    """#819: an empty stream must NOT raise IndexError, and its HDF5 file must
+    still be registered -- with NULL timing fields -- so it is not orphaned.
+    The non-empty device in the same call must also register, with real
+    timing, and conn.commit() must be reached."""
     monkeypatch.setattr("neurobooth_terra.Table", lambda *a, **kw: MagicMock())
 
     conn = _mock_conn(rowcount=1)
@@ -54,15 +60,30 @@ def test_log_to_database_skips_empty_stream(monkeypatch):
 
     log_to_database([empty_mouse, populated], conn, "log_task_42")
 
-    # Only the populated device should have triggered an UPDATE.
-    assert cursor.execute.call_count == 1
-    # And the transaction must have been committed (we made it past the loop).
+    # Both devices register: one UPDATE each (rowcount=1 short-circuits).
+    assert cursor.execute.call_count == 2
+
+    # The empty Mouse (processed first) registers with NULL timing but a real
+    # HDF5 path. UPDATE bound params are
+    # (temporal_resolution, file_start_time, file_end_time, hdf5_rel, ...).
+    empty_params = cursor.execute.call_args_list[0][0][1]
+    assert empty_params[0] is None  # true_temporal_resolution
+    assert empty_params[1] is None  # file_start_time
+    assert empty_params[2] is None  # file_end_time
+    assert empty_params[3] is not None  # the HDF5 path IS registered
+
+    # The populated device registers with real (non-NULL) timing.
+    pop_params = cursor.execute.call_args_list[1][0][1]
+    assert pop_params[0] is not None
+    assert pop_params[1] is not None
+    assert pop_params[2] is not None
+
     assert conn.commit.called
 
 
 def test_log_to_database_empty_stream_first_does_not_block_subsequent(monkeypatch):
     """Order independence: an empty stream as the FIRST item in device_data
-    must not prevent later items from being processed."""
+    must register itself AND not prevent later items from being processed."""
     monkeypatch.setattr("neurobooth_terra.Table", lambda *a, **kw: MagicMock())
 
     conn = _mock_conn(rowcount=1)
@@ -92,15 +113,15 @@ def test_log_to_database_empty_stream_first_does_not_block_subsequent(monkeypatc
 
     log_to_database([empty_first, populated_a, populated_b], conn, "log_task_42")
 
-    # Two populated devices, one UPDATE each (rowcount=1 short-circuit).
-    assert cursor.execute.call_count == 2
+    # All three devices register, one UPDATE each (rowcount=1 short-circuit).
+    assert cursor.execute.call_count == 3
     assert conn.commit.called
 
 
-def test_log_to_database_all_empty_streams_still_commits(monkeypatch):
-    """If every stream happens to be empty (degenerate but legal), the
-    function must still reach conn.commit() rather than leaving the
-    transaction open."""
+def test_log_to_database_all_empty_streams_register_and_commit(monkeypatch):
+    """If every stream happens to be empty (degenerate but legal), each file is
+    still registered (with NULL timing) and the function reaches conn.commit()
+    rather than leaving the transaction open."""
     monkeypatch.setattr("neurobooth_terra.Table", lambda *a, **kw: MagicMock())
 
     conn = _mock_conn(rowcount=1)
@@ -119,5 +140,12 @@ def test_log_to_database_all_empty_streams_still_commits(monkeypatch):
 
     log_to_database(devs, conn, "log_task_42")
 
-    assert cursor.execute.call_count == 0
+    # Each empty device registers its file with NULL timing.
+    assert cursor.execute.call_count == 3
+    for call in cursor.execute.call_args_list:
+        params = call[0][1]
+        assert params[0] is None  # true_temporal_resolution
+        assert params[1] is None  # file_start_time
+        assert params[2] is None  # file_end_time
+        assert params[3] is not None  # HDF5 path registered
     assert conn.commit.called


### PR DESCRIPTION
## What
`split_xdf.log_to_database` skipped any device whose stream had zero samples. That stopped the #819 IndexError crash, but it left the device's HDF5 unregistered: `write_device_hdf5` still writes the file, so it sits on disk with no `log_sensor_file` row and trips the copy script's `log_sensor_file_id not found` warning on every run.

## Change
Register the empty file with NULL timing instead of skipping it. The empty-stream branch now sets `file_start_time` / `file_end_time` / `true_temporal_resolution` to `None` and falls through to the same UPDATE/INSERT, so the HDF5 is tracked. Populated devices in the task are unchanged.

## Verification
- DB queries against the 2026-06-09 production sessions (100001, 100835) confirmed the symptom is a per-device registration gap for files that exist (populated siblings were all registered with real timing), not a crash or whole-task rollback.
- Updated the #819 regression tests: the empty stream now asserts a NULL-timing row with the real HDF5 path is written. 3 passed.

## Not in scope
- Surfacing genuinely-dropped streams as a data-quality signal (the NULL-timing row would otherwise mask a real dropout): tracked in #820.
- Why streams go empty (root cause): separate investigation.

Follow-up to #819 (addresses the registration gap left by the v0.93.1 skip-guard).