### PR TITLE
Logging-blackout fix (#822) + message_queue clear-time logging (#706)

### DIFF
--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -198,14 +198,15 @@ def snapshot_message_queue(conn: connection) -> List[MessageQueueRow]:
     """Capture the current contents of ``message_queue`` without consuming anything.
 
     Unlike :func:`read_next_message`, this is a read-only SELECT: it never sets
-    ``time_read``, so it is safe to call from a background monitor while servers poll
-    the queue. Intended for forensic dumps when the system hangs or on session
-    teardown (issue #706).
+    ``time_read``. Used to capture the prior session's leftover messages before
+    :func:`clear_msg_queue` wipes them at session start, so a session that halted with
+    messages still pending leaves evidence behind (issue #706).
 
     Args:
-        conn: A database connection. Use an autocommit connection on a dedicated
-            thread -- like the application log table, the queue should be touched in
-            autocommit mode only, where SELECTs do not block concurrent INSERT/UPDATE.
+        conn: A database connection. When reading concurrently with live servers, use
+            an autocommit connection -- like the application log table, the queue is
+            safe to read under autocommit, where SELECTs do not block concurrent
+            INSERT/UPDATE.
 
     Returns:
         One :class:`MessageQueueRow` per row in the table, unread rows first within
@@ -294,20 +295,32 @@ def clear_msg_queue(conn):
 
     app_log = log_man.APP_LOGGER if log_man.APP_LOGGER is not None else logger
 
-    rows = snapshot_message_queue(conn)
-    if rows:
-        unread = sum(1 for r in rows if r.unread)
-        app_log.warning(
-            "Clearing message_queue at session start with %d row(s) still present "
-            "(%d unread); prior session may have halted with messages pending.",
-            len(rows),
-            unread,
-        )
-        app_log.warning(
-            "message_queue contents before clear:\n%s", format_message_queue_rows(rows)
-        )
-    else:
-        app_log.debug("message_queue empty at session start; nothing to clear.")
+    # Forensic capture is best-effort: clearing the queue is the essential operation at
+    # session start, so a failure to snapshot/log must never prevent it. A failed SELECT
+    # can also leave a (non-autocommit) connection in an aborted transaction, so roll
+    # back before the delete.
+    try:
+        rows = snapshot_message_queue(conn)
+        if rows:
+            unread = sum(1 for r in rows if r.unread)
+            app_log.warning(
+                "Clearing message_queue at session start with %d row(s) still present "
+                "(%d unread); prior session may have halted with messages pending.",
+                len(rows),
+                unread,
+            )
+            app_log.warning(
+                "message_queue contents before clear:\n%s",
+                format_message_queue_rows(rows),
+            )
+        else:
+            app_log.debug("message_queue empty at session start; nothing to clear.")
+    except Exception:
+        app_log.exception("Failed to capture message_queue before clearing; clearing anyway.")
+        try:
+            conn.rollback()
+        except Exception:
+            pass
 
     table = Table("message_queue", conn=conn)
     table.delete_row()

--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Callable, Dict, Any, Optional, List
 from neurobooth_os.util.nb_types import Subject
@@ -100,12 +101,18 @@ def str_fileid_to_eval(
     return task_func
 
 
-def get_database_connection(database: Optional[str] = None) -> ManagedConnection:
+def get_database_connection(
+    database: Optional[str] = None,
+    connect_timeout: Optional[int] = None,
+) -> ManagedConnection:
     """Open a database connection, optionally through an SSH tunnel.
 
     Returns a :class:`ManagedConnection` that behaves like a plain
     ``psycopg2.extensions.connection`` but also stops the SSH tunnel
     (if any) when :meth:`close` is called or the context manager exits.
+
+    :param connect_timeout: If set, bound the (non-tunnel) TCP connect to this
+        many seconds so an unreachable DB can't block the caller indefinitely.
     """
     database_info = cfg.neurobooth_config.database
     tunnel = None
@@ -128,14 +135,20 @@ def get_database_connection(database: Optional[str] = None) -> ManagedConnection
 
     db = database_info.dbname if database is None else database
 
+    connect_kwargs = dict(
+        database=db,
+        user=database_info.user,
+        password=database_info.password.get_secret_value(),
+        host=host,
+        port=port,
+    )
+    if connect_timeout is not None:
+        # Bound the TCP connect so an unreachable DB can't block the caller for
+        # the OS default (the app logger's reconnect runs inside logging.emit).
+        connect_kwargs["connect_timeout"] = connect_timeout
+
     try:
-        conn = psycopg2.connect(
-            database=db,
-            user=database_info.user,
-            password=database_info.password.get_secret_value(),
-            host=host,
-            port=port,
-        )
+        conn = psycopg2.connect(**connect_kwargs)
     except Exception:
         if tunnel is not None:
             tunnel.stop()
@@ -143,19 +156,159 @@ def get_database_connection(database: Optional[str] = None) -> ManagedConnection
     return ManagedConnection(conn, tunnel)
 
 
-def clear_msg_queue(conn):
-    """
-    Clears message_queue table. Intended for use at the start of a session so errors in prior session don't leave
-    unhandled messages.
-    TODO: Copy messages to log before clearing
-    Parameters
-    ----------
-    conn: connection    A database connection
+@dataclass(frozen=True)
+class MessageQueueRow:
+    """A single ``message_queue`` row captured by a read-only forensic snapshot.
 
-    Returns
-    -------
-    None
+    Attributes:
+        age_seconds: Seconds between ``time_created`` and the moment the snapshot was
+            taken, measured against the database clock.
+        unread: True when the message has never been consumed (``time_read IS NULL``)
+            -- a candidate for a stuck / never-picked-up condition.
+        body: The JSON message body, serialized to a string for logging.
     """
+
+    id: int
+    uuid: str
+    msg_type: str
+    priority: int
+    source: str
+    destination: str
+    time_created: datetime
+    time_read: Optional[datetime]
+    age_seconds: float
+    unread: bool
+    body: str
+
+
+# now() is evaluated by Postgres so age is measured against the DB clock rather than a
+# (possibly skewed) client clock. Unread rows are ordered first within each destination.
+_QUEUE_SNAPSHOT_SQL = """
+    SELECT id, uuid, msg_type, priority, source, destination,
+           time_created, time_read,
+           EXTRACT(EPOCH FROM (now() - time_created)) AS age_seconds,
+           (time_read IS NULL) AS unread,
+           body
+    FROM message_queue
+    ORDER BY destination, (time_read IS NULL) DESC, priority DESC, id ASC
+"""
+
+
+def snapshot_message_queue(conn: connection) -> List[MessageQueueRow]:
+    """Capture the current contents of ``message_queue`` without consuming anything.
+
+    Unlike :func:`read_next_message`, this is a read-only SELECT: it never sets
+    ``time_read``, so it is safe to call from a background monitor while servers poll
+    the queue. Intended for forensic dumps when the system hangs or on session
+    teardown (issue #706).
+
+    Args:
+        conn: A database connection. Use an autocommit connection on a dedicated
+            thread -- like the application log table, the queue should be touched in
+            autocommit mode only, where SELECTs do not block concurrent INSERT/UPDATE.
+
+    Returns:
+        One :class:`MessageQueueRow` per row in the table, unread rows first within
+        each destination, oldest-first.
+    """
+    curs = conn.cursor()
+    try:
+        curs.execute(_QUEUE_SNAPSHOT_SQL)
+        field_names = [d[0] for d in curs.description]
+        raw_rows = [dict(zip(field_names, r)) for r in curs.fetchall()]
+    finally:
+        curs.close()
+
+    rows: List[MessageQueueRow] = []
+    for r in raw_rows:
+        body = r["body"]
+        if not isinstance(body, str):  # JSONB comes back from psycopg2 as a dict
+            body = json.dumps(body)
+        rows.append(
+            MessageQueueRow(
+                id=r["id"],
+                uuid=str(r["uuid"]),
+                msg_type=r["msg_type"],
+                priority=r["priority"],
+                source=r["source"],
+                destination=r["destination"],
+                time_created=r["time_created"],
+                time_read=r["time_read"],
+                age_seconds=float(r["age_seconds"]),
+                unread=bool(r["unread"]),
+                body=body,
+            )
+        )
+    return rows
+
+
+def format_message_queue_rows(
+    rows: List[MessageQueueRow], body_max_len: int = 500
+) -> str:
+    """Render a queue snapshot as human-readable text for a log or forensic file.
+
+    Args:
+        rows: Rows from :func:`snapshot_message_queue`.
+        body_max_len: Truncate each message body to this many characters. Bodies can
+            contain subject identifiers, so dumps stay in the same trust boundary as
+            the other booth logs.
+
+    Returns:
+        A multi-line string: a one-line summary followed by one line per row. An empty
+        queue returns a single ``"<message_queue empty>"`` line.
+    """
+    if not rows:
+        return "<message_queue empty>"
+
+    unread = sum(1 for r in rows if r.unread)
+    lines = [f"message_queue snapshot: {len(rows)} row(s), {unread} unread"]
+    for r in rows:
+        state = "UNREAD" if r.unread else "read"
+        body = r.body if len(r.body) <= body_max_len else f"{r.body[:body_max_len]}...(truncated)"
+        lines.append(
+            f"  [{state}] id={r.id} dest={r.destination} src={r.source} "
+            f"type={r.msg_type} prio={r.priority} age={r.age_seconds:.1f}s "
+            f"created={r.time_created.isoformat()} uuid={r.uuid} body={body}"
+        )
+    return "\n".join(lines)
+
+
+def clear_msg_queue(conn):
+    """Clear ``message_queue``, capturing its contents to the log first.
+
+    Intended for use at the start of a session so unhandled messages from a prior
+    session don't leak into the new one. Before deleting, the current contents are
+    snapshotted and logged: a session that starts with a non-empty queue is a signal
+    that the previous session halted with messages still pending, and we want that
+    evidence preserved rather than silently dropped. Implements the on-startup half of
+    issue #706 (and closes the long-standing "copy messages to log before clearing"
+    TODO).
+
+    Args:
+        conn: A database connection.
+    """
+    # Use the application logger when one has been initialised so the capture lands in
+    # log_application; fall back to the module logger otherwise. Imported lazily to
+    # avoid a circular import (log_manager imports this module).
+    import neurobooth_os.log_manager as log_man
+
+    app_log = log_man.APP_LOGGER if log_man.APP_LOGGER is not None else logger
+
+    rows = snapshot_message_queue(conn)
+    if rows:
+        unread = sum(1 for r in rows if r.unread)
+        app_log.warning(
+            "Clearing message_queue at session start with %d row(s) still present "
+            "(%d unread); prior session may have halted with messages pending.",
+            len(rows),
+            unread,
+        )
+        app_log.warning(
+            "message_queue contents before clear:\n%s", format_message_queue_rows(rows)
+        )
+    else:
+        app_log.debug("message_queue empty at session start; nothing to clear.")
+
     table = Table("message_queue", conn=conn)
     table.delete_row()
 

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -341,6 +341,7 @@ class PostgreSQLHandler(logging.Handler):
         self._fallback_file: Optional[IO] = None
         self._last_reconnect_attempt = 0.0
         self._reconnect_interval_sec = 30.0
+        self._connect_timeout_sec = 3
 
         try:
             self._get_logger_connection()
@@ -452,6 +453,10 @@ class PostgreSQLHandler(logging.Handler):
             print(f"Failed to log to DB and to the fallback file: {e}")
 
     def _get_logger_connection(self):
-        self.connection = metadator.get_database_connection()
+        # Short connect_timeout so a reconnect to a dead DB can't block the
+        # logging call -- and, via the handler lock, every other thread that
+        # logs -- for the OS default TCP timeout.
+        self.connection = metadator.get_database_connection(
+            connect_timeout=self._connect_timeout_sec)
         self.connection.autocommit = True
         self.cursor = self.connection.cursor()

--- a/neurobooth_os/log_manager.py
+++ b/neurobooth_os/log_manager.py
@@ -336,6 +336,11 @@ class PostgreSQLHandler(logging.Handler):
         super(PostgreSQLHandler, self).__init__()
         self.setLevel(log_level)
         self.name = "db_handler"
+        self.connection = None
+        self.cursor = None
+        self._fallback_file: Optional[IO] = None
+        self._last_reconnect_attempt = 0.0
+        self._reconnect_interval_sec = 30.0
 
         try:
             self._get_logger_connection()
@@ -353,36 +358,98 @@ class PostgreSQLHandler(logging.Handler):
         APP_LOGGER = None
 
     def emit(self, record):
+        # Logging contract: never raise out of emit. Try the DB; on failure,
+        # attempt a rate-limited reconnect + retry; if the DB is still
+        # unreachable, fall back to a local file so the record is never
+        # silently lost. (The old behaviour print()'d to stdout, which is the
+        # hidden console on the booth machines.)
         try:
-            level = record.levelname.lower()
-            if level not in self._levels:
-                level = "debug"
-
-            if record.exc_info:
-                lines = traceback.format_exception(*record.exc_info)
-                traceback_text = ''.join(lines)
-            else:
-                traceback_text = None
-
-            args = {
-                "log_level": level,
-                "message": record.getMessage(),
-                "function": record.funcName,
-                "filename": record.filename,
-                "line_no": record.lineno,
-                "traceback": traceback_text,
-                "server_type": config.get_server_name_from_env(),
-                "server_id": platform.uname().node,
-                "subject_id": SUBJECT_ID,
-                "session_id": SESSION_ID,
-                "server_time": datetime.fromtimestamp(record.created),
-                "device": getattr(record, "device", None),
-            }
-
-            self.cursor.execute(self._query, args)
-
+            args = self._build_args(record)
         except Exception as e:
-            print(f"An exception occurred attempting to log to DB: {e}")
+            self._fallback_to_file(record, f"log-record build failed: {e}")
+            return
+
+        try:
+            self.cursor.execute(self._query, args)
+            return
+        except Exception as e:
+            db_error = e
+
+        # The held connection is most likely stale/broken. Rebuild it (at most
+        # once per interval, so a hard-down DB doesn't block every log call)
+        # and retry once.
+        if self._try_reconnect():
+            try:
+                self.cursor.execute(self._query, args)
+                return
+            except Exception as e:
+                db_error = e
+
+        self._fallback_to_file(record, f"DB log write failed: {db_error}")
+
+    def _build_args(self, record) -> Dict[str, Any]:
+        level = record.levelname.lower()
+        if level not in self._levels:
+            level = "debug"
+
+        if record.exc_info:
+            traceback_text = ''.join(traceback.format_exception(*record.exc_info))
+        else:
+            traceback_text = None
+
+        return {
+            "log_level": level,
+            "message": record.getMessage(),
+            "function": record.funcName,
+            "filename": record.filename,
+            "line_no": record.lineno,
+            "traceback": traceback_text,
+            "server_type": config.get_server_name_from_env(),
+            "server_id": platform.uname().node,
+            "subject_id": SUBJECT_ID,
+            "session_id": SESSION_ID,
+            "server_time": datetime.fromtimestamp(record.created),
+            "device": getattr(record, "device", None),
+        }
+
+    def _try_reconnect(self) -> bool:
+        """Rebuild the DB connection, at most once per
+        ``_reconnect_interval_sec``. Returns True if a live cursor is ready."""
+        now = datetime.now().timestamp()
+        if now - self._last_reconnect_attempt < self._reconnect_interval_sec:
+            return False
+        self._last_reconnect_attempt = now
+        try:
+            if self.connection is not None:
+                self.connection.close()
+        except Exception:
+            pass
+        try:
+            self._get_logger_connection()
+            return True
+        except Exception as e:
+            print(f"PostgreSQLHandler reconnect failed: {e}")
+            return False
+
+    def _fallback_to_file(self, record, reason: str) -> None:
+        """Append a record to a local file when the DB is unreachable, so it is
+        never silently lost. Best-effort; never raises."""
+        try:
+            if self._fallback_file is None:
+                path = os.path.join(_get_log_dir(), "neurobooth_db_log_fallback.log")
+                self._fallback_file = open(path, "a")
+            self._fallback_file.write(
+                f"[{datetime.fromtimestamp(record.created).isoformat()}] "
+                f"{record.levelname} {record.filename}:{record.lineno} "
+                f"{record.funcName}> {record.getMessage()}  ({reason})\n"
+            )
+            if record.exc_info:
+                self._fallback_file.write(
+                    ''.join(traceback.format_exception(*record.exc_info))
+                )
+            self._fallback_file.flush()
+        except Exception as e:
+            print(f"Failed to log to DB and to the fallback file: {e}")
 
     def _get_logger_connection(self):
         self.connection = metadator.get_database_connection()

--- a/tests/pytest/test_clear_msg_queue_logging.py
+++ b/tests/pytest/test_clear_msg_queue_logging.py
@@ -1,0 +1,137 @@
+"""Tests for capturing message_queue contents before the GUI clears it (issue #706).
+
+``clear_msg_queue`` wipes the table at the start of each session. A session that starts
+with rows still present means the *prior* session halted with messages pending -- the
+forensic signal we want preserved. These tests confirm the contents are snapshotted and
+logged *before* the delete, with no database (the connection, ``Table``, and the
+snapshot SELECT are stubbed).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+import neurobooth_os.iout.metadator as meta
+import neurobooth_os.log_manager as lm
+
+
+def _row(uuid: str, age: float, unread: bool = True, dest: str = "STM",
+         msg_type: str = "CreateTasksRequest") -> meta.MessageQueueRow:
+    return meta.MessageQueueRow(
+        id=1, uuid=uuid, msg_type=msg_type, priority=0, source="CTR",
+        destination=dest, time_created=datetime(2026, 1, 1),
+        time_read=None if unread else datetime(2026, 1, 1),
+        age_seconds=age, unread=unread, body='{"task_id": "DSC"}',
+    )
+
+
+@pytest.fixture
+def fake_table(monkeypatch):
+    """Replace neurobooth_terra.Table so delete_row() never touches a database."""
+    table = MagicMock(name="message_queue_table")
+    monkeypatch.setattr(meta, "Table", lambda *a, **k: table)
+    return table
+
+
+def test_snapshot_maps_rows_and_serializes_jsonb_body():
+    cursor = MagicMock()
+    cursor.description = [
+        (c,) for c in (
+            "id", "uuid", "msg_type", "priority", "source", "destination",
+            "time_created", "time_read", "age_seconds", "unread", "body",
+        )
+    ]
+    cursor.fetchall.return_value = [
+        (1, "u1", "CreateTasksRequest", 0, "CTR", "STM",
+         datetime(2026, 1, 1), None, 120.0, True, {"task_id": "DSC"}),
+    ]
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+
+    rows = meta.snapshot_message_queue(conn)
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert (r.destination, r.msg_type, r.unread, r.age_seconds) == ("STM", "CreateTasksRequest", True, 120.0)
+    assert r.body == '{"task_id": "DSC"}'  # JSONB dict serialized back to a string
+    cursor.close.assert_called_once()
+
+
+def test_format_rows_empty_and_populated():
+    assert meta.format_message_queue_rows([]) == "<message_queue empty>"
+
+    text = meta.format_message_queue_rows([_row("u1", age=90.0)])
+    assert "1 row(s), 1 unread" in text
+    assert "UNREAD" in text
+    assert "CreateTasksRequest" in text
+
+
+def test_format_rows_truncates_long_body():
+    big = _row("u1", age=5.0)
+    object.__setattr__(big, "body", "x" * 1000)  # frozen dataclass
+    text = meta.format_message_queue_rows([big], body_max_len=50)
+    assert "...(truncated)" in text
+    assert "x" * 1000 not in text
+
+
+def test_clear_logs_contents_before_deleting(monkeypatch, fake_table):
+    events = []
+    monkeypatch.setattr(
+        meta, "snapshot_message_queue",
+        lambda conn: (events.append("snapshot"), [_row("u1", age=120.0)])[1],
+    )
+    app_log = MagicMock()
+    app_log.warning.side_effect = lambda *a, **k: events.append("log")
+    monkeypatch.setattr(lm, "APP_LOGGER", app_log)
+    fake_table.delete_row.side_effect = lambda *a, **k: events.append("delete")
+
+    meta.clear_msg_queue(MagicMock())
+
+    # Snapshot first, log next, delete last -- "copy messages to log before clearing".
+    assert events[0] == "snapshot"
+    assert events[-1] == "delete"
+    assert "log" in events
+    logged = " ".join(str(c) for c in app_log.warning.call_args_list)
+    assert "CreateTasksRequest" in logged  # the pending message is in the log
+
+
+def test_clear_empty_queue_is_quiet_but_still_deletes(monkeypatch, fake_table):
+    monkeypatch.setattr(meta, "snapshot_message_queue", lambda conn: [])
+    app_log = MagicMock()
+    monkeypatch.setattr(lm, "APP_LOGGER", app_log)
+
+    meta.clear_msg_queue(MagicMock())
+
+    app_log.warning.assert_not_called()  # no noise on a clean start
+    app_log.debug.assert_called_once()
+    fake_table.delete_row.assert_called_once()
+
+
+def test_clear_falls_back_to_module_logger_when_app_logger_absent(monkeypatch, fake_table):
+    # Before make_db_logger() runs, APP_LOGGER is None; clearing must still work.
+    monkeypatch.setattr(meta, "snapshot_message_queue", lambda conn: [_row("u1", age=90.0)])
+    monkeypatch.setattr(lm, "APP_LOGGER", None)
+
+    meta.clear_msg_queue(MagicMock())  # must not raise
+
+    fake_table.delete_row.assert_called_once()
+
+
+def test_clear_still_deletes_when_snapshot_fails(monkeypatch, fake_table):
+    # The capture is best-effort; a broken snapshot must not block the clear, and the
+    # connection is rolled back so the delete isn't poisoned by an aborted transaction.
+    monkeypatch.setattr(
+        meta, "snapshot_message_queue",
+        MagicMock(side_effect=RuntimeError("SELECT blew up")),
+    )
+    app_log = MagicMock()
+    monkeypatch.setattr(lm, "APP_LOGGER", app_log)
+    conn = MagicMock()
+
+    meta.clear_msg_queue(conn)  # must not raise
+
+    fake_table.delete_row.assert_called_once()  # essential op still ran
+    conn.rollback.assert_called_once()
+    app_log.exception.assert_called_once()

--- a/tests/pytest/test_log_manager_postgres_handler.py
+++ b/tests/pytest/test_log_manager_postgres_handler.py
@@ -1,0 +1,81 @@
+"""Resilience tests for ``PostgreSQLHandler`` (log_manager).
+
+The handler must not silently drop logs on a DB problem: it should reconnect a
+broken connection and retry, and fall back to a local file when the DB is still
+unreachable. Regression coverage for the all-day logging blackout where a single
+dropped DB connection killed logging for the rest of a process's life and emit
+only ``print()``'d to a hidden console.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+import neurobooth_os.log_manager as lm
+
+
+def _record(msg: str = "boom") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="app", level=logging.ERROR, pathname=__file__, lineno=10,
+        msg=msg, args=(), exc_info=None,
+    )
+
+
+@pytest.fixture
+def handler(monkeypatch, tmp_path):
+    """A ``PostgreSQLHandler`` wired to mock DB connections and a temp log dir."""
+    monkeypatch.setattr(lm.config, "get_server_name_from_env", lambda: "ACQ")
+    monkeypatch.setattr(lm, "_get_log_dir", lambda: str(tmp_path))
+
+    conns = []
+
+    def fake_get_conn():
+        conn = MagicMock(name=f"conn{len(conns)}")
+        conn.cursor.return_value = MagicMock(name="cursor")
+        conns.append(conn)
+        return conn
+
+    monkeypatch.setattr(lm.metadator, "get_database_connection", fake_get_conn)
+    h = lm.PostgreSQLHandler(logging.DEBUG)
+    h._reconnect_interval_sec = 0.0  # don't rate-limit reconnects in tests
+    h._conns = conns
+    return h
+
+
+def test_emit_happy_path_inserts(handler):
+    handler.emit(_record())
+    handler.cursor.execute.assert_called_once()
+
+
+def test_emit_reconnects_on_broken_cursor(handler, tmp_path):
+    handler.cursor.execute.side_effect = Exception("connection closed")
+
+    handler.emit(_record("after-drop"))
+
+    # A fresh connection was built and the row landed on it; nothing lost.
+    assert len(handler._conns) == 2
+    handler._conns[1].cursor.return_value.execute.assert_called_once()
+    assert not (tmp_path / "neurobooth_db_log_fallback.log").exists()
+
+
+def test_emit_falls_back_to_file_when_db_down(handler, monkeypatch, tmp_path):
+    handler.cursor.execute.side_effect = Exception("db down")
+    monkeypatch.setattr(
+        lm.metadator, "get_database_connection",
+        MagicMock(side_effect=Exception("cannot connect")),
+    )
+
+    handler.emit(_record("must-not-be-lost"))
+
+    fallback = tmp_path / "neurobooth_db_log_fallback.log"
+    assert fallback.exists()
+    assert "must-not-be-lost" in fallback.read_text()
+
+
+def test_emit_never_raises(handler, monkeypatch):
+    # Even if building the row blows up, emit must not propagate.
+    monkeypatch.setattr(
+        handler, "_build_args", MagicMock(side_effect=Exception("kaboom")))
+    handler.emit(_record())  # must not raise

--- a/tests/pytest/test_log_manager_postgres_handler.py
+++ b/tests/pytest/test_log_manager_postgres_handler.py
@@ -31,7 +31,7 @@ def handler(monkeypatch, tmp_path):
 
     conns = []
 
-    def fake_get_conn():
+    def fake_get_conn(*args, **kwargs):
         conn = MagicMock(name=f"conn{len(conns)}")
         conn.cursor.return_value = MagicMock(name="cursor")
         conns.append(conn)
@@ -79,3 +79,22 @@ def test_emit_never_raises(handler, monkeypatch):
     monkeypatch.setattr(
         handler, "_build_args", MagicMock(side_effect=Exception("kaboom")))
     handler.emit(_record())  # must not raise
+
+
+def test_connect_uses_bounded_timeout(monkeypatch):
+    # The (re)connect must pass a bounded connect_timeout so a dead DB can't
+    # block the logging thread for the OS default.
+    captured = {}
+
+    def fake(*args, **kwargs):
+        captured.update(kwargs)
+        conn = MagicMock()
+        conn.cursor.return_value = MagicMock()
+        return conn
+
+    monkeypatch.setattr(lm.config, "get_server_name_from_env", lambda: "ACQ")
+    monkeypatch.setattr(lm.metadator, "get_database_connection", fake)
+
+    h = lm.PostgreSQLHandler(logging.DEBUG)
+
+    assert captured.get("connect_timeout") == h._connect_timeout_sec


### PR DESCRIPTION
> **This branch bundles two issues.** The #822 logging fix and a first step for #706 (`message_queue` clear-time logging) landed together — the #706 `metadator` helpers were committed alongside the `connect_timeout` change in 235a323. The sections below are split by issue; if you'd prefer them reviewed separately, the #706 commits can be lifted onto their own branch.

## #822 — PostgreSQLHandler logging blackout

### Problem
`PostgreSQLHandler.emit` caught every `INSERT INTO log_application` failure and only `print()`d to stdout -- the hidden console on the booth machines -- so any log that couldn't reach the DB was silently dropped. And the connection/cursor were built once and never reconnected, so a single dropped connection left the logger dead for the rest of the process's life. One transient DB blip became an all-day logging blackout across every running service (the cause of the unlogged Wang failures on 2026-06-11).

### Change
`emit` now:
- builds the row separately, and on a failed insert attempts a **rate-limited reconnect** and retries;
- if the DB is still unreachable, appends the record to a local **`neurobooth_db_log_fallback.log`** (in `NB_INSTALL`/home) instead of dropping it;
- never raises (logging contract).

### Retry / reconnect semantics
- **At most one retry per log call.** `emit` tries the insert once; on failure it calls `_try_reconnect()`, and the single retry runs **only if that returned a live connection**. If the reconnect fails or is throttled, there is no retry -- the record goes straight to the fallback file. So a log call makes at most 2 DB attempts (1 retry); no loop, no busy-spin.
- The retry uses a **fresh connection**, not a blind re-execute on the same broken cursor -- `_try_reconnect()` rebuilds `connection`/`cursor`.
- The **reconnect is throttled to once per 30s** (`_reconnect_interval_sec`). During a sustained outage, the first failing call per 30s window gets the reconnect+retry; every other failing call in that window writes straight to the file. Across the process it keeps attempting recovery every 30s, so it self-heals once the DB is back.
- Also bounds the reconnect's TCP connect with a `connect_timeout` (235a323) so an unreachable DB can't block inside `logging.emit`.

### Tests
Adds `tests/pytest/test_log_manager_postgres_handler.py`: happy-path insert, reconnect-on-broken-cursor, file-fallback when the DB is down, and emit-never-raises. 4 passing.

Closes #822.

---

## #706 — log message_queue before the session-start clear

`clear_msg_queue` (called at session start in `gui.py`) now snapshots `message_queue` and logs its contents to `log_application` **before** wiping it. A session that *starts* with rows still present means the prior session halted with messages unconsumed -- the forensic gap behind the 2026-04-22 CTR freeze (we couldn't tell whether a `CreateTasksRequest` had been produced and then left unread). Empty queue -> DEBUG, no noise.

New read-only helpers in `metadator.py`: `MessageQueueRow`, `snapshot_message_queue()` (never sets `time_read`), `format_message_queue_rows()`. Closes the long-standing "copy messages to log before clearing" TODO.

The capture is **best-effort**: it runs on the session-start path, so a snapshot/log failure can never block the clear (the essential operation), and a failed SELECT rolls back the connection before the delete.

Tests: `tests/pytest/test_clear_msg_queue_logging.py` (7, DB-free).

**Before release:** the snapshot SQL runs at every session start but is only mock-tested so far -- it needs one validation pass against the production DB.

Addresses #706 (Approach A, the on-startup capture). The on-error / live-hang capture (a per-server background watchdog, Approach B) is deferred to a phase-2 follow-up -- see the issue thread for the pros/cons.
