### PR TITLE
Hard-exit ACQ on terminate to avoid device-finalizer SIGABRT (#710)

### DIFF
--- a/neurobooth_os/server_acq.py
+++ b/neurobooth_os/server_acq.py
@@ -33,6 +33,20 @@ def countdown(period):
         t2 = local_clock()
 
 
+def _flush_and_hard_exit(exit_code: int) -> None:
+    """Flush logging and terminate via ``os._exit`` without running finalizers.
+
+    The acquisition process must not let Python GC-finalize its device objects
+    on the way out. ``DeviceManager.close_streams()`` already frees their native
+    handles; re-running native teardown on freed handles (LSL outlets,
+    MetaWear/warble, camera SDKs) aborts the process (#710). ``os._exit`` skips
+    finalizers and ``atexit`` entirely, so we flush logging explicitly first,
+    then exit, rather than returning and unwinding the frame.
+    """
+    logging.shutdown()
+    os._exit(exit_code)
+
+
 def main():
     acq_index = int(sys.argv[1]) if len(sys.argv) > 1 else 0
     logger = None
@@ -52,8 +66,7 @@ def main():
                         exc_info=sys.exc_info())
         exit_code = 1
     finally:
-        logging.shutdown()
-        os._exit(exit_code)
+        _flush_and_hard_exit(exit_code)
 
 
 def run_acq(logger, acq_index: int = 0):
@@ -207,7 +220,14 @@ def run_acq(logger, acq_index: int = 0):
 
                 if device_manager is not None:
                     device_manager.close_streams()
-                break
+
+                # #710: do not fall through to run_acq's return here. Unwinding
+                # the frame GC-finalizes `device_manager`, whose device objects
+                # re-run native teardown (LSL outlets, MetaWear/warble, camera
+                # SDKs) on handles close_streams() already freed -> SIGABRT before
+                # the process can exit. Hard-exit instead, so no finalizer runs.
+                logger.debug("Stopping ACQ")
+                _flush_and_hard_exit(0)
             else:
                 logger.error(f'Unexpected message received: {message.model_dump_json()}')
     except Exception as argument:


### PR DESCRIPTION
**Draft — do not merge until the WER LocalDump confirms the line‑46 finalizer (see Merge gate).**

## What

On `TerminateServerRequest`, `run_acq` tore down devices via `close_streams()` and then **returned**, letting Python GC-finalize the device objects as the frame unwound. `close_streams()` has already freed their native handles, so the finalizers (LSL outlets, MetaWear/warble, camera SDKs) re-ran native teardown on freed handles and aborted the process with **SIGABRT** before it could exit.

This flushes logging and calls `os._exit()` directly from the terminate handler instead of returning, so no device finalizer runs. The terminate path keeps its clean log trail (`Stopping ACQ` → `Closing app log db connection`).

## Why this is the fix

Production `log_application` correlation (`extras/perf/_investigate_silent_exit.py --audit`, Wang, 2026‑05‑28…06‑11):

- **18 of 22** ACQ_0 faulthandler dumps are this crash: `Fatal Python error: Aborted`, main thread parked at `server_acq.py:46` (run_acq just returned), only the app‑log SSH‑tunnel threads alive (bystanders), **no device threads**.
- Each one's last DB log line is **"Microphone: Exiting LSL Thread"** — the final line of `close_streams()` — i.e. full device teardown completed, *then* abort. Not idle, not mid‑session.
- Clean exits log "Closing app log db connection" (line 55); these never reach it → the abort is at the **line‑46 return/finalization boundary**, before `logging.shutdown()`. The surviving tunnel threads belong to the app‑log handler (torn down later) — bystanders, not the crash site.

Mechanism detail and correction: #710. Full census + falsified alternatives: #824.

## Merge gate (per "falsify before shipping")

- [ ] **WER LocalDump** (full minidump, `DumpType=2`, `python.exe` on ACQ_0) naming the aborting native module at the line‑46 finalization. The fix skips all finalizers so it is robust regardless, but the dump proves we are eliminating the fault, not masking a different one.
- [ ] Post‑deploy field check: ACQ_0 unclean‑exit rate falls toward the STM box's, and "Closing app log db connection" becomes the consistent last line in the shutdown audit.

## Scope / follow‑ups

- Covers the **`TerminateServerRequest`** path (the 18 Family‑A crashes).
- **Not** covered: the exception path (`run_acq` raises → frame unwind → same finalizer abort, `server_acq.py:213‑217`) — separate follow‑up.
- The now‑unreachable `logger.debug("Stopping ACQ")` at `main()` line 47 is left in place to keep the diff minimal; can be removed.

Relates to #710, #824, #759.
