### PR TITLE
Only warn on unconsumed messages when clearing message_queue (#706)

### DIFF
--- a/neurobooth_os/iout/metadator.py
+++ b/neurobooth_os/iout/metadator.py
@@ -275,15 +275,17 @@ def format_message_queue_rows(
 
 
 def clear_msg_queue(conn):
-    """Clear ``message_queue``, capturing its contents to the log first.
+    """Clear ``message_queue``, logging any *unconsumed* messages first.
 
-    Intended for use at the start of a session so unhandled messages from a prior
-    session don't leak into the new one. Before deleting, the current contents are
-    snapshotted and logged: a session that starts with a non-empty queue is a signal
-    that the previous session halted with messages still pending, and we want that
-    evidence preserved rather than silently dropped. Implements the on-startup half of
-    issue #706 (and closes the long-standing "copy messages to log before clearing"
-    TODO).
+    Called at the start of a session so leftovers from the prior session don't leak
+    into the new one. The queue is only wiped here (never mid-session), so a normal
+    prior session leaves its whole accumulated -- and mostly already-read -- history
+    for this clear; that is routine, not a halt. The signal worth surfacing is the
+    **unread** rows: messages the prior session never consumed (e.g. a Start click
+    whose ``CreateTasksRequest`` sat unread). Those are logged at WARNING before the
+    delete so the evidence survives; an all-consumed leftover is logged quietly at
+    DEBUG. Implements the on-startup half of issue #706 (and closes the long-standing
+    "copy messages to log before clearing" TODO).
 
     Args:
         conn: A database connection.
@@ -301,17 +303,25 @@ def clear_msg_queue(conn):
     # back before the delete.
     try:
         rows = snapshot_message_queue(conn)
-        if rows:
-            unread = sum(1 for r in rows if r.unread)
+        unread = [r for r in rows if r.unread]
+        if unread:
+            # The meaningful signal: the prior session left messages unconsumed. Warn,
+            # and dump only the unread rows -- the read ones are normal accumulation.
             app_log.warning(
-                "Clearing message_queue at session start with %d row(s) still present "
-                "(%d unread); prior session may have halted with messages pending.",
+                "Clearing message_queue at session start: %d of %d row(s) were never "
+                "consumed by the prior session.",
+                len(unread),
                 len(rows),
-                unread,
             )
             app_log.warning(
-                "message_queue contents before clear:\n%s",
-                format_message_queue_rows(rows),
+                "Unconsumed message_queue rows before clear:\n%s",
+                format_message_queue_rows(unread),
+            )
+        elif rows:
+            # Normal end-of-session leftovers (all consumed) -- routine, not a halt.
+            app_log.debug(
+                "Clearing %d fully-consumed leftover row(s) from the prior session.",
+                len(rows),
             )
         else:
             app_log.debug("message_queue empty at session start; nothing to clear.")

--- a/tests/pytest/test_clear_msg_queue_logging.py
+++ b/tests/pytest/test_clear_msg_queue_logging.py
@@ -1,10 +1,11 @@
 """Tests for capturing message_queue contents before the GUI clears it (issue #706).
 
-``clear_msg_queue`` wipes the table at the start of each session. A session that starts
-with rows still present means the *prior* session halted with messages pending -- the
-forensic signal we want preserved. These tests confirm the contents are snapshotted and
-logged *before* the delete, with no database (the connection, ``Table``, and the
-snapshot SELECT are stubbed).
+``clear_msg_queue`` wipes the table at the start of each session. Because the queue is
+only cleared here, a normal prior session leaves hundreds of already-read rows behind --
+so the forensic signal is the *unread* rows (messages never consumed), not mere presence.
+These tests confirm unread messages are logged at WARNING (and only the unread ones are
+dumped) before the delete, while all-consumed leftovers stay quiet -- with no database
+(the connection, ``Table``, and the snapshot SELECT are stubbed).
 """
 from __future__ import annotations
 
@@ -135,3 +136,41 @@ def test_clear_still_deletes_when_snapshot_fails(monkeypatch, fake_table):
     fake_table.delete_row.assert_called_once()  # essential op still ran
     conn.rollback.assert_called_once()
     app_log.exception.assert_called_once()
+
+
+def test_clear_all_read_rows_is_quiet_no_halt_warning(monkeypatch, fake_table):
+    # Normal end-of-session leftovers: rows present but all consumed. Must NOT warn --
+    # the calibration bug was crying "may have halted" on every session's read leftovers.
+    monkeypatch.setattr(
+        meta, "snapshot_message_queue",
+        lambda conn: [_row("a", age=300.0, unread=False),
+                      _row("b", age=250.0, unread=False)],
+    )
+    app_log = MagicMock()
+    monkeypatch.setattr(lm, "APP_LOGGER", app_log)
+
+    meta.clear_msg_queue(MagicMock())
+
+    app_log.warning.assert_not_called()   # no false halt/unconsumed warning
+    app_log.debug.assert_called_once()    # logged quietly at DEBUG instead
+    fake_table.delete_row.assert_called_once()
+
+
+def test_clear_warns_and_dumps_only_unread_rows(monkeypatch, fake_table):
+    # When the prior session left messages unconsumed, warn and dump *only* the unread
+    # rows -- the consumed rows are normal accumulation and would just be noise.
+    monkeypatch.setattr(
+        meta, "snapshot_message_queue",
+        lambda conn: [_row("read1", age=300.0, unread=False, msg_type="FramePreviewRequest"),
+                      _row("stuck", age=250.0, unread=True, msg_type="CreateTasksRequest")],
+    )
+    app_log = MagicMock()
+    monkeypatch.setattr(lm, "APP_LOGGER", app_log)
+
+    meta.clear_msg_queue(MagicMock())
+
+    app_log.warning.assert_called()
+    logged = " ".join(str(c) for c in app_log.warning.call_args_list)
+    assert "CreateTasksRequest" in logged       # the unread message is surfaced
+    assert "FramePreviewRequest" not in logged  # the consumed one is not dumped
+    fake_table.delete_row.assert_called_once()


### PR DESCRIPTION
## Problem
`clear_msg_queue` (the #706 on-startup capture shipped in v0.93.4) logs a WARNING — *"prior session may have halted with messages pending"* — whenever **any** rows are present at session start, and dumps all of them. But the queue is only ever wiped here, so a normal prior session leaves its entire accumulated (mostly already-*read*) message history for this clear. The warning therefore fires on essentially **every** session.

Confirmed read-only against prod: of the 6 warnings logged so far, **one fired with 0 unread** (a clean session) and the rest had only 2–3 unread out of hundreds of rows. The alarm keys on the wrong thing — rows *present* — instead of the real signal: **unread** rows (messages the prior session never consumed).

## Change
- WARN only when there are **unread** rows, and dump **only those** (not the hundreds of consumed rows).
- All-consumed leftovers are logged quietly at `DEBUG` ("clearing N fully-consumed leftover rows") — routine, not a halt.
- Dropped the "may have halted" wording; an operator-initiated stop isn't a halt. The message now states "N of M rows were never consumed by the prior session."

## Tests
`tests/pytest/test_clear_msg_queue_logging.py` — adds the all-read quiet path and the unread-only-dump guard; **9 passing**.

Refines the #706 on-startup logging. Does **not** close #706 — the live-hang watchdog (Approach B) remains deferred.
